### PR TITLE
Do not mark attribute as changed if value is the same

### DIFF
--- a/lib/mobility/backend/active_model/dirty.rb
+++ b/lib/mobility/backend/active_model/dirty.rb
@@ -27,7 +27,7 @@ value of the translated attribute if passed to it.
         locale_accessor = "#{attribute}_#{locale}"
         if model.changed_attributes.has_key?(locale_accessor) && model.changed_attributes[locale_accessor] == value
           model.attributes_changed_by_setter.except!(locale_accessor)
-        elsif read(locale, **options) != value
+        elsif read(locale, options.merge(fallbacks: false)) != value
           model.send(:attribute_will_change!, "#{attribute}_#{locale}")
         end
         super

--- a/lib/mobility/backend/active_model/dirty.rb
+++ b/lib/mobility/backend/active_model/dirty.rb
@@ -23,11 +23,11 @@ value of the translated attribute if passed to it.
     module ActiveModel::Dirty
       # @!group Backend Accessors
       # @!macro backend_writer
-      def write(locale, value, **)
+      def write(locale, value, **options)
         locale_accessor = "#{attribute}_#{locale}"
         if model.changed_attributes.has_key?(locale_accessor) && model.changed_attributes[locale_accessor] == value
           model.attributes_changed_by_setter.except!(locale_accessor)
-        else
+        elsif read(locale, **options) != value
           model.send(:attribute_will_change!, "#{attribute}_#{locale}")
         end
         super

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -8,6 +8,15 @@ details.
 @see Mobility::Backend::ActiveModel::Dirty
 @see Mobility::Backend::Sequel::Dirty
 
+@note Dirty tracking can have unexpected results when combined with fallbacks.
+  A change in the fallback locale value will not mark an attribute falling
+  through to that locale as changed, even though it may look like it has
+  changed. However, when the value for the current locale is changed from nil
+  or blank to a new value, the change will be recorded as a change from that
+  fallback value, rather than from the nil or blank value. The specs are the
+  most reliable source of information on the interaction between dirty tracking
+  and fallbacks.
+
 =end
     module Dirty
       # @param model_class Class of model this backend is defined on.

--- a/lib/mobility/backend/sequel/dirty.rb
+++ b/lib/mobility/backend/sequel/dirty.rb
@@ -16,7 +16,7 @@ Automatically includes dirty plugin in model class when enabled.
         if model.column_changes.has_key?(locale_accessor) && model.initial_values[locale_accessor] == value
           super
           [model.changed_columns, model.initial_values].each { |h| h.delete(locale_accessor) }
-        elsif read(locale, **options) != value
+        elsif read(locale, options.merge(fallbacks: false)) != value
           model.will_change_column("#{attribute}_#{locale}".to_sym)
           super
         end

--- a/lib/mobility/backend/sequel/dirty.rb
+++ b/lib/mobility/backend/sequel/dirty.rb
@@ -11,12 +11,12 @@ Automatically includes dirty plugin in model class when enabled.
     module Sequel::Dirty
       # @!group Backend Accessors
       # @!macro backend_writer
-      def write(locale, value, **)
+      def write(locale, value, **options)
         locale_accessor = "#{attribute}_#{locale}".to_sym
         if model.column_changes.has_key?(locale_accessor) && model.initial_values[locale_accessor] == value
           super
           [model.changed_columns, model.initial_values].each { |h| h.delete(locale_accessor) }
-        else
+        elsif read(locale, **options) != value
           model.will_change_column("#{attribute}_#{locale}".to_sym)
           super
         end

--- a/spec/mobility/backend/active_model/dirty_spec.rb
+++ b/spec/mobility/backend/active_model/dirty_spec.rb
@@ -36,6 +36,14 @@ describe Mobility::Backend::ActiveModel::Dirty, orm: :active_record do
         expect(article.changes).to eq({})
       end
 
+      aggregate_failures "set same value" do
+        article.title = nil
+        expect(article.title).to eq(nil)
+        expect(article.changed?).to eq(false)
+        expect(article.changed).to eq([])
+        expect(article.changes).to eq({})
+      end
+
       article.title = "foo"
 
       aggregate_failures "after change" do

--- a/spec/mobility/backend/sequel/dirty_spec.rb
+++ b/spec/mobility/backend/sequel/dirty_spec.rb
@@ -38,6 +38,15 @@ describe Mobility::Backend::Sequel::Dirty, orm: :sequel do
         expect(article.column_changes).to eq({})
       end
 
+      aggregate_failures "set same value" do
+        article.title = nil
+        expect(article.title).to eq(nil)
+        expect(article.column_changed?(:title)).to eq(false)
+        expect(article.column_change(:title)).to eq(nil)
+        expect(article.changed_columns).to eq([])
+        expect(article.column_changes).to eq({})
+      end
+
       article.title = "foo"
 
       aggregate_failures "after change" do

--- a/spec/mobility/backend/sequel/dirty_spec.rb
+++ b/spec/mobility/backend/sequel/dirty_spec.rb
@@ -138,4 +138,64 @@ describe Mobility::Backend::Sequel::Dirty, orm: :sequel do
       end
     end
   end
+
+  describe "fallbacks compatiblity" do
+    before do
+      stub_const 'ArticleWithFallbacks', Class.new(Sequel::Model)
+      ArticleWithFallbacks.class_eval do
+        dataset = DB[:articles]
+        include Mobility
+      end
+      ArticleWithFallbacks.translates :title, backend: backend_class, dirty: true, cache: false, fallbacks: { en: 'ja' }
+    end
+
+    it "does not compare with fallback value" do
+      article = ArticleWithFallbacks.new
+
+      aggregate_failures "before change" do
+        expect(article.title).to eq(nil)
+        expect(article.column_changed?(:title)).to eq(false)
+        expect(article.column_change(:title)).to eq(nil)
+        expect(article.changed_columns).to eq([])
+        expect(article.column_changes).to eq({})
+      end
+
+      aggregate_failures "set fallback locale value" do
+        Mobility.with_locale(:ja) { article.title = "あああ" }
+        expect(article.title).to eq("あああ")
+        expect(article.column_changed?(:title)).to eq(false)
+        expect(article.column_change(:title)).to eq(nil)
+        expect(article.changed_columns).to eq([:title_ja])
+        expect(article.column_changes).to eq({ title_ja: [nil, "あああ"]})
+        Mobility.with_locale(:ja) { expect(article.title).to eq("あああ") }
+      end
+
+      aggregate_failures "set value in current locale to same value" do
+        article.title = nil
+        expect(article.title).to eq("あああ")
+        expect(article.column_changed?(:title)).to eq(false)
+        expect(article.column_change(:title)).to eq(nil)
+        expect(article.changed_columns).to eq([:title_ja])
+        expect(article.column_changes).to eq({ title_ja: [nil, "あああ"]})
+      end
+
+      aggregate_failures "set value in fallback locale to different value" do
+        Mobility.with_locale(:ja) { article.title = "ばばば" }
+        expect(article.title).to eq("ばばば")
+        expect(article.column_changed?(:title)).to eq(false)
+        expect(article.column_change(:title)).to eq(nil)
+        expect(article.changed_columns).to eq([:title_ja])
+        expect(article.column_changes).to eq({ title_ja: [nil, "ばばば"]})
+      end
+
+      aggregate_failures "set value in current locale to different value" do
+        article.title = "Title"
+        expect(article.title).to eq("Title")
+        expect(article.column_changed?(:title)).to eq(true)
+        expect(article.column_change(:title)).to eq(["ばばば", "Title"])
+        expect(article.changed_columns).to match_array([:title_ja, :title_en])
+        expect(article.column_changes).to eq({ title_ja: [nil, "ばばば"], title_en: ["ばばば", "Title"]})
+      end
+    end
+  end
 end


### PR DESCRIPTION
(Note: I'm starting to post bug fixes and important changes as pull requests to
make them more visible.)

Currently, for a model post with dirty tracking enabled, this is what happens:

```ruby
post = Post.new
post.title        #=> nil
post.changed?     #=> false
post.changed      #=> []
post.changes      #=> {}
```

So far so good, but if we set the value to `nil`:

```ruby
post.title = nil
post.changed?     #=> true
```

This is a bug, which this PR fixes. After the change:

```ruby
post.title = nil
post.changed?   #=> false
post.title = "foo"
post.changed?   #=> true
```

Note: the change applies to both ActiveModel and Sequel modules.