### PR TITLE
Add FallthroughAccessors module for use in dirty tracking and on its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The options hash is used to generate the backend, and has several reserved keys:
   Enable [fallbacks](#fallbacks), and optionally configure them.
 - **`dirty`** (Boolean)<br>
   Whether to enable [dirty tracking](#dirty).
-- **`accessor_locales`** (Boolean or Array)<br>
+- **`locale_accessors`** (Boolean or Array)<br>
   Enable [locale accessors](#locale_accessors) and optionally configure them.
 
 In addition to these, each backend may have specific configuration options. For

--- a/README.md
+++ b/README.md
@@ -384,6 +384,14 @@ post.title
 Alternatively, just using `locale_accessors: true` will enable all locales in
 `I18n.available_locales`.
 
+An alternative to using the `locale_accessors` option is to use the
+`fallthrough_accessors` option (defined in {Mobility::FallthroughAccessors})
+with `fallthrough_accessors: true`. This uses +method_missing+ to implicitly
+define the same methods as above, but supporting any locale without any method
+definitions. [Dirty tracking](#dirty) enables fallthrough locales for tracking
+attribute changes. (Both locale accessors and fallthrough locales can be used
+together without conflict.)
+
 For more details, see: {Mobility::Attributes} (specifically, the private method
 `define_locale_accessors`).
 

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -32,13 +32,14 @@ in backends to define gem-dependent behavior.
 
 =end
 module Mobility
-  autoload :Attributes,       "mobility/attributes"
-  autoload :Backend,          "mobility/backend"
-  autoload :BackendResetter,  "mobility/backend_resetter"
-  autoload :Configuration,    "mobility/configuration"
-  autoload :InstanceMethods,  "mobility/instance_methods"
-  autoload :Translates,       "mobility/translates"
-  autoload :Wrapper,          "mobility/wrapper"
+  autoload :Attributes,           "mobility/attributes"
+  autoload :Backend,              "mobility/backend"
+  autoload :BackendResetter,      "mobility/backend_resetter"
+  autoload :Configuration,        "mobility/configuration"
+  autoload :FallthroughAccessors, "mobility/fallthrough_accessors"
+  autoload :InstanceMethods,      "mobility/instance_methods"
+  autoload :Translates,           "mobility/translates"
+  autoload :Wrapper,              "mobility/wrapper"
 
   require "mobility/orm"
 

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -140,12 +140,10 @@ with other backends.
 
       @backend_class.configure!(options) if @backend_class.respond_to?(:configure!)
 
-      @backend_class.include Backend::Cache unless options[:cache] == false
-      @backend_class.include Backend::Dirty.for(model_class) if options[:dirty]
-      @backend_class.include Backend::Fallbacks if options[:fallbacks]
-      @backend_class.include FallthroughAccessors.new(attributes) if options[:fallthrough_accessors]
+      include_backend_modules(@backend_class, options)
+
       @accessor_locales = options[:locale_accessors]
-      @accessor_locales = Mobility.config.default_accessor_locales if options[:locale_accessors] == true
+      @accessor_locales = Mobility.config.default_accessor_locales if @accessor_locales == true
 
       attributes.each do |attribute|
         define_backend(attribute)
@@ -166,6 +164,13 @@ with other backends.
 
         define_locale_accessors(attribute, @accessor_locales) if @accessor_locales
       end
+    end
+
+    def include_backend_modules(backend_class, options)
+      backend_class.include(Backend::Cache)                            unless options[:cache] == false
+      backend_class.include(Backend::Dirty.for(options[:model_class])) if options[:dirty]
+      backend_class.include(Backend::Fallbacks)                        if options[:fallbacks]
+      backend_class.include(FallthroughAccessors.new(attributes))      if options[:fallthrough_accessors]
     end
 
     # Add this attributes module to shared {Mobility::Wrapper} and setup model

--- a/lib/mobility/backend/active_model/dirty.rb
+++ b/lib/mobility/backend/active_model/dirty.rb
@@ -78,6 +78,8 @@ value of the translated attribute if passed to it.
             private :restore_attribute!
           end
           model_class.include restore_methods
+
+          model_class.include(FallthroughAccessors.new(*attributes))
         end
       end
     end

--- a/lib/mobility/backend/active_record/column.rb
+++ b/lib/mobility/backend/active_record/column.rb
@@ -4,7 +4,7 @@ module Mobility
 
 Implements the {Mobility::Backend::Column} backend for ActiveRecord models.
 
-@note This backend disables the +accessor_locales+ option, which would
+@note This backend disables the +locale_accessors+ option, which would
   otherwise interfere with column methods.
 
 @example

--- a/lib/mobility/backend/sequel/column.rb
+++ b/lib/mobility/backend/sequel/column.rb
@@ -4,7 +4,7 @@ module Mobility
 
 Implements the {Mobility::Backend::Column} backend for Sequel models.
 
-@note This backend disables the +accessor_locales+ option, which would
+@note This backend disables the +locale_accessors+ option, which would
   otherwise interfere with column methods.
 =end
     class Sequel::Column

--- a/lib/mobility/backend/sequel/dirty.rb
+++ b/lib/mobility/backend/sequel/dirty.rb
@@ -49,6 +49,8 @@ Automatically includes dirty plugin in model class when enabled.
             end
             include mod
           end
+
+          model_class.include(FallthroughAccessors.new(*attributes))
         end
       end
     end

--- a/lib/mobility/fallthrough_accessors.rb
+++ b/lib/mobility/fallthrough_accessors.rb
@@ -1,0 +1,57 @@
+# frozen-string-literal: true
+
+module Mobility
+=begin
+
+Defines +method_missing+ and +respond_to_missing?+ methods for a set of
+attributes such that a method call using a locale accessor, like:
+
+  article.title_pt_br
+
+will return the value of +article.title+ with the locale set to +pt-BR+ around
+the method call. The class is called "FallthroughAccessors" because when
+included in a model class, locale-specific methods will be available even if
+not explicitly defined with the +locale_accessors+ option.
+
+This is a less efficient (but more open-ended) implementation of locale
+accessors, for use in cases where the locales to be used are not known when the
+model class is generated.
+
+@example Using fallthrough locales on a plain old ruby class
+  class Post
+    def title
+      "title in #{Mobility.locale}"
+    end
+    include Mobility::FallthroughAccessors.new("title")
+  end
+
+  Mobility.locale = :en
+  post = Post.new
+  post.title
+  #=> "title in en"
+  post.title_fr
+  #=> "title in fr"
+
+=end
+  class FallthroughAccessors < Module
+    # @param [Array<String>] Array of attributes
+    def initialize(*attributes)
+      method_name_regex = /\A(#{attributes.join('|'.freeze)})_([a-z]{2}(_[a-z]{2})?)(=?)\z/.freeze
+
+      define_method :method_missing do |method_name, *arguments, &block|
+        if method_name =~ method_name_regex
+          attribute = $1.to_sym
+          locale, suffix = $2.split('_'.freeze)
+          locale = "#{locale}-#{suffix.upcase}".freeze if suffix
+          Mobility.with_locale(locale) { public_send("#{attribute}#{$4}".freeze, *arguments) }
+        else
+          super(method_name, *arguments, &block)
+        end
+      end
+
+      define_method :respond_to_missing? do |method_name, include_private = false|
+        (method_name =~ method_name_regex) || super(method_name, include_private)
+      end
+    end
+  end
+end

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -59,7 +59,13 @@ describe Mobility::Attributes do
         it "includes Backend::ActiveModel::Dirty into backend when options[:dirty] is truthy and model class includes ActiveModel::Dirty" do
           expect(backend_klass).to receive(:include).with(Mobility::Backend::ActiveModel::Dirty)
           Article.include ::ActiveModel::Dirty
-          Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, dirty: true, model_class: Article })
+          Article.include described_class.new(:accessor, "title", {
+            backend: backend_klass,
+            cache: false,
+            dirty: true,
+            fallthrough_accessors: false,
+            model_class: Article
+          })
         end
 
         it "does not include Backend::Model::Dirty into backend when options[:dirty] is falsey" do
@@ -76,7 +82,13 @@ describe Mobility::Attributes do
 
         it "includes Backend::Sequel::Dirty into backend when options[:dirty] is truthy and model class is a ::Sequel::Model" do
           expect(backend_klass).to receive(:include).with(Mobility::Backend::Sequel::Dirty)
-          Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, dirty: true, model_class: Article })
+          Article.include described_class.new(:accessor, "title", {
+            backend: backend_klass,
+            cache: false,
+            dirty: true,
+            fallthrough_accessors: false,
+            model_class: Article
+          })
         end
 
         it "does not include Backend::Sequel::Dirty into backend when options[:dirty] is falsey" do

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -231,7 +231,7 @@ describe Mobility::Attributes do
         Article.include described_class.new(:accessor, "title", options.merge(backend: backend_klass))
       end
 
-      context "with accessor_locales unset" do
+      context "with locale_accessors unset" do
         let(:options) { {} }
 
         it "does not define locale accessors" do
@@ -242,7 +242,7 @@ describe Mobility::Attributes do
         end
       end
 
-      context "with accessor_locales = true" do
+      context "with locale_accessors = true" do
         let(:options) { { locale_accessors: true } }
 
         it "defines accessors for locales in I18n.available_locales" do
@@ -261,7 +261,7 @@ describe Mobility::Attributes do
         end
       end
 
-      context "with accessor_locales a hash" do
+      context "with locale_accessors a hash" do
         let(:options) { { locale_accessors: [:en, :pt] } }
 
         it "defines accessors for locales in locale_accessors hash" do

--- a/spec/mobility/backend/sequel/dirty_spec.rb
+++ b/spec/mobility/backend/sequel/dirty_spec.rb
@@ -97,7 +97,11 @@ describe Mobility::Backend::Sequel::Dirty, orm: :sequel do
     end
 
     it "tracks previous changes in multiple locales" do
-      article = Article.create(title_en: "English title 1", title_fr: "Titre en Francais 1")
+      article = Article.new
+      article.title_en = "English title 1"
+      article.title_fr = "Titre en Francais 1"
+      article.save
+
       article.title = "English title 2"
       Mobility.locale = :fr
       article.title = "Titre en Francais 2"


### PR DESCRIPTION
Currently, enabling dirty tracking for a set of translated attributes also by default enables `locale_accessors`, which defines methods for each attribute, for each locale passed in (or taken from `I18n.available_locales`.

Rather than couple dirty tracking to locale accessors in this way (which may define many methods depending on the number of locales), the alternative in this PR is to define a different class, `FallthroughAcccessors`, which can be instantiated for a set of attributes and included into a model. Doing so adds a hook in `method_missing` to catch any method of the form `<attribute>_<locale>` and interpret that as:

```ruby
Mobility.with_locale(locale) { model.attribute }
```

This is the same as locale accessors, except that: a) it does not require defining locale accessor methods on the model, and b) it will potentially work for any locale. In this sense, it is more open-ended and flexible, however `method_missing` is slower than a method so there are obvious disadvantages as well.

This new "fallthrough accessors" option is turned on by default for dirty tracking so that changes can be tracked per locale, i.e. a change of title in English would be tracked on the method `title_en`. However, the option can also be enabled independently of dirty tracking, with `fallthrough_accessors: true` when calling `translates` on the model. It can be used in combination with normal locale accessors; for instance, if some locales are used often but others not so much, you could define locale accessors for the commonly-used locales and enable fallthrough accessors to catch any other locales.