### PR TITLE
Modify indices on key-value tables to improve query performance

### DIFF
--- a/lib/generators/rails/mobility/templates/create_string_translations.rb
+++ b/lib/generators/rails/mobility/templates/create_string_translations.rb
@@ -10,6 +10,7 @@ class CreateStringTranslations < ActiveRecord::Migration[<%= ActiveRecord::Migra
       t.timestamps
     end
     add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
-    add_index :mobility_string_translations, [:translatable_id, :translatable_type], name: :index_mobility_string_translations_on_translatable
+    add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
+    add_index :mobility_string_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
   end
 end

--- a/lib/generators/rails/mobility/templates/create_text_translations.rb
+++ b/lib/generators/rails/mobility/templates/create_text_translations.rb
@@ -10,6 +10,7 @@ class CreateTextTranslations < ActiveRecord::Migration[<%= ActiveRecord::Migrati
       t.timestamps
     end
     add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
-    add_index :mobility_text_translations, [:translatable_id, :translatable_type], name: :index_mobility_text_translations_on_translatable
+    add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
+    add_index :mobility_text_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_text_translations_on_query_keys
   end
 end

--- a/lib/generators/rails/mobility/templates/create_text_translations.rb
+++ b/lib/generators/rails/mobility/templates/create_text_translations.rb
@@ -11,6 +11,5 @@ class CreateTextTranslations < ActiveRecord::Migration[<%= ActiveRecord::Migrati
     end
     add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
     add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
-    add_index :mobility_text_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_text_translations_on_query_keys
   end
 end

--- a/lib/mobility/backend/active_record/key_value/query_methods.rb
+++ b/lib/mobility/backend/active_record/key_value/query_methods.rb
@@ -4,7 +4,7 @@ module Mobility
       def initialize(attributes, **options)
         super
         association_name, translation_class = options[:association_name], options[:class_name]
-        @association_name    = association_name
+        @association_name = association_name
 
         define_join_method(association_name, translation_class)
         define_query_methods(association_name)

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -65,7 +65,6 @@ module Mobility
           end
           add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
           add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
-          add_index :mobility_text_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_text_translations_on_query_keys
 
           create_table "comments" do |t|
             t.text :content_en

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -53,7 +53,8 @@ module Mobility
             t.string  :translatable_type, null: false
           end
           add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
-          add_index :mobility_string_translations, [:translatable_id, :translatable_type], name: :index_mobility_string_translations_on_translatable
+          add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
+          add_index :mobility_string_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
 
           create_table "mobility_text_translations" do |t|
             t.string  :locale,            null: false
@@ -63,7 +64,8 @@ module Mobility
             t.string  :translatable_type, null: false
           end
           add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
-          add_index :mobility_text_translations, [:translatable_id, :translatable_type], name: :index_mobility_text_translations_on_translatable
+          add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
+          add_index :mobility_text_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_text_translations_on_query_keys
 
           create_table "comments" do |t|
             t.text :content_en

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -64,7 +64,6 @@ module Mobility
             String      :translatable_type, null: false
             index [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
             index [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
-            index [:translatable_type, :key, :value, :locale], name: :index_mobility_text_translations_on_query_keys
           end
 
           DB.create_table? :mobility_string_translations do

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -63,7 +63,8 @@ module Mobility
             Integer     :translatable_id,   null: false
             String      :translatable_type, null: false
             index [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
-            index [:translatable_id, :translatable_type], name: :index_mobility_text_translations_on_translatable
+            index [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
+            index [:translatable_type, :key, :value, :locale], name: :index_mobility_text_translations_on_query_keys
           end
 
           DB.create_table? :mobility_string_translations do
@@ -74,7 +75,8 @@ module Mobility
             Integer     :translatable_id,   null: false
             String      :translatable_type, null: false
             index [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
-            index [:translatable_id, :translatable_type], name: :index_mobility_string_translations_on_translatable
+            index [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
+            index [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
           end
 
           DB.create_table? :comments do

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -102,7 +102,7 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, attri
           expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => nil)).to eq([@post1])
 
           Mobility.with_locale(:ja) do
-            expect(model_class.i18n.where(attribute1 => "foo post")).to eq([@ja_post2, @ja_post3])
+            expect(model_class.i18n.where(attribute1 => "foo post")).to match_array([@ja_post2, @ja_post3])
             expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content")).to eq([@ja_post2])
             expect(model_class.i18n.where(attribute1 => "foo post ja", attribute2 => "foo content ja")).to eq([@ja_post1])
           end
@@ -247,7 +247,7 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
           expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => nil).select_all(table_name).all).to eq([@post1])
 
           Mobility.with_locale(:ja) do
-            expect(model_class.i18n.where(attribute1 => "foo post").select_all(table_name).all).to eq([@ja_post2, @ja_post3])
+            expect(model_class.i18n.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@ja_post2, @ja_post3])
             expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to eq([@ja_post2])
             expect(model_class.i18n.where(attribute1 => "foo post ja", attribute2 => "foo content ja").select_all(table_name).all).to eq([@ja_post1])
           end


### PR DESCRIPTION
I've updated the migrations in the default install generator to use these
indices for text columns:

```ruby
add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
```

The first index is unchanged, but I've modified the second one to also include
the `key` column. This allows the index to be used to get values for all
locales of a given attribute on a given model, which is a likely query; it
should not affect the performance of querying for all attributes together.

For string columns, I made the same change and also added an extra index:

```ruby
add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
add_index :mobility_string_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
```

The last index is for querying on value matches for a given attribute in a
given locale. I could not add this one for text translations since the value in
that case is a text column and a key length is required (for MySQL at least).

In any case, I think these indices should be enough to cover standard
use-cases. Beyond this the developer can add/remove/change whatever suits their
needs.