### PR TITLE
Allow passing fallback locale or locales to getter method

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -76,12 +76,11 @@ On top of this, a backend will normally:
     # @!macro [new] backend_constructor
     #   @param model Model on which backend is defined
     #   @param [String] attribute Backend attribute
-    #   @option options [Hash] fallbacks Fallbacks hash
-    def initialize(model, attribute, **options)
+    #   @param [Hash] fallbacks Fallbacks hash
+    def initialize(model, attribute, fallbacks: nil, **options)
       @model = model
       @attribute = attribute
       @options = options
-      fallbacks = options[:fallbacks]
       @fallbacks = I18n::Locale::Fallbacks.new(fallbacks) if fallbacks.is_a?(Hash)
     end
 

--- a/lib/mobility/backend/active_model/dirty.rb
+++ b/lib/mobility/backend/active_model/dirty.rb
@@ -28,7 +28,7 @@ value of the translated attribute if passed to it.
         locale_accessor = Mobility.normalize_locale_accessor(attribute, locale)
         if model.changed_attributes.has_key?(locale_accessor) && model.changed_attributes[locale_accessor] == value
           model.attributes_changed_by_setter.except!(locale_accessor)
-        elsif read(locale, options.merge(fallbacks: false)) != value
+        elsif read(locale, options.merge(fallback: false)) != value
           model.send(:attribute_will_change!, locale_accessor)
         end
         super

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -80,6 +80,10 @@ locale was +nil+.
       # @!macro backend_reader
       # @option options [Boolean] fallbacks +false+ to disable fallbacks on lookup
       def read(locale, fallback: nil, **_)
+        if !options[:fallbacks].nil?
+          warn "You passed an option with key 'fallbacks', which will be
+            ignored. Did you mean 'fallback'?"
+        end
         return super if fallback == false
         (fallback ? [locale, *fallback] : fallbacks[locale]).detect do |locale|
           value = super(locale)

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -78,7 +78,9 @@ locale was +nil+.
     module Fallbacks
       # @!group Backend Accessors
       # @!macro backend_reader
-      # @option options [Boolean] fallbacks +false+ to disable fallbacks on lookup
+      # @param [Boolean,Symbol,Array] fallback
+      #   +false+ to disable fallbacks on lookup, or a locale or array of
+      #   locales to set fallback(s) for this lookup.
       def read(locale, fallback: nil, **_)
         if !options[:fallbacks].nil?
           warn "You passed an option with key 'fallbacks', which will be

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -16,9 +16,11 @@ created for the model with the hash defining additional fallbacks.
 In addition, fallbacks can be disabled when reading by passing <tt>fallback:
 false</tt> to the reader method. This can be useful to determine the actual
 value of the translated attribute, including a possible +nil+ value. You can
-also pass a locale to the +fallback+ option to force a given fallback for that
-read, e.g. <tt>fallback: :fr</tt> would fetch the French translation if the
-value in the current locale was +nil+.
+also pass a locale or array of locales to the +fallback+ option to use that
+locale or locales that read, e.g. <tt>fallback: :fr</tt> would fetch the French
+translation if the value in the current locale was +nil+, whereas <tt>fallback:
+[:fr, :es]</tt> would try French, then Spanish if the value in the current
+locale was +nil+.
 
 @see https://github.com/svenfuchs/i18n/wiki/Fallbacks I18n Fallbacks
 
@@ -79,7 +81,7 @@ value in the current locale was +nil+.
       # @option options [Boolean] fallbacks +false+ to disable fallbacks on lookup
       def read(locale, fallback: nil, **_)
         return super if fallback == false
-        (fallback ? [locale, fallback] : fallbacks[locale]).detect do |locale|
+        (fallback ? [locale, *fallback] : fallbacks[locale]).detect do |locale|
           value = super(locale)
           break value if value.present?
         end

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -13,9 +13,12 @@ defaults to an instance of +I18n::Locale::Fallbacks+, but can be configured
 If a hash is passed to the +fallbacks+ option, a new fallbacks instance will be
 created for the model with the hash defining additional fallbacks. 
 
-In addition, fallbacks can be disabled when reading by passing `fallbacks:
-false` to the reader method. This can be useful to determine the actual value
-of the translated attribute, including a possible +nil+ value.
+In addition, fallbacks can be disabled when reading by passing <tt>fallback:
+false</tt> to the reader method. This can be useful to determine the actual
+value of the translated attribute, including a possible +nil+ value. You can
+also pass a locale to the +fallback+ option to force a given fallback for that
+read, e.g. <tt>fallback: :fr</tt> would fetch the French translation if the
+value in the current locale was +nil+.
 
 @see https://github.com/svenfuchs/i18n/wiki/Fallbacks I18n Fallbacks
 
@@ -52,28 +55,31 @@ of the translated attribute, including a possible +nil+ value.
   post.title
   #=> "bar"
 
-@example Disabling fallbacks when reading value
+@example Passing fallback option when reading value
   class Post
     translates :title, fallbacks: true
   end
 
   I18n.default_locale = :en
   Mobility.locale = :en
-  post = Post.new(title: "foo")
+  post = Post.new(title: "Mobility")
+  Mobility.with_locale(:fr) { post.title = "Mobilité" }
 
   Mobility.locale = :ja
   post.title
-  #=> "foo"
-  post.title(fallbacks: false)
+  #=> "Mobility"
+  post.title(fallback: false)
   #=> nil
+  post.title(fallback: :fr)
+  #=> "Mobilité"
 =end
     module Fallbacks
       # @!group Backend Accessors
       # @!macro backend_reader
       # @option options [Boolean] fallbacks +false+ to disable fallbacks on lookup
-      def read(locale, **options)
-        return super if options[:fallbacks] == false
-        fallbacks[locale].detect do |locale|
+      def read(locale, fallback: nil, **_)
+        return super if fallback == false
+        (fallback ? [locale, fallback] : fallbacks[locale]).detect do |locale|
           value = super(locale)
           break value if value.present?
         end

--- a/lib/mobility/backend/sequel/dirty.rb
+++ b/lib/mobility/backend/sequel/dirty.rb
@@ -16,7 +16,7 @@ Automatically includes dirty plugin in model class when enabled.
         if model.column_changes.has_key?(locale_accessor) && model.initial_values[locale_accessor] == value
           super
           [model.changed_columns, model.initial_values].each { |h| h.delete(locale_accessor) }
-        elsif read(locale, options.merge(fallbacks: false)) != value
+        elsif read(locale, options.merge(fallback: false)) != value
           model.will_change_column(locale_accessor)
           super
         end

--- a/lib/mobility/backend/sequel/dirty.rb
+++ b/lib/mobility/backend/sequel/dirty.rb
@@ -11,6 +11,7 @@ Automatically includes dirty plugin in model class when enabled.
     module Sequel::Dirty
       # @!group Backend Accessors
       # @!macro backend_writer
+      # @param [Hash] options
       def write(locale, value, **options)
         locale_accessor = Mobility.normalize_locale_accessor(attribute, locale).to_sym
         if model.column_changes.has_key?(locale_accessor) && model.initial_values[locale_accessor] == value

--- a/spec/mobility/active_record_compatibility_spec.rb
+++ b/spec/mobility/active_record_compatibility_spec.rb
@@ -84,7 +84,7 @@ describe "ActiveRecord compatibility", orm: :active_record do
 
     it "does not fall through to default locale when fallback: false option passed in" do
       Mobility.locale = :ja
-      expect(post.title(fallbacks: false)).to eq(nil)
+      expect(post.title(fallback: false)).to eq(nil)
     end
   end
 end

--- a/spec/mobility/backend/fallbacks_spec.rb
+++ b/spec/mobility/backend/fallbacks_spec.rb
@@ -41,6 +41,10 @@ describe Mobility::Backend::Fallbacks do
   end
 
   it "returns nil when fallbacks: false option is passed" do
-    expect(subject.read(:"en-US", fallbacks: false)).to eq(nil)
+    expect(subject.read(:"en-US", fallback: false)).to eq(nil)
+  end
+
+  it "uses fallbacks passed in as options when present" do
+    expect(subject.read(:"en-US", fallback: :jp)).to eq("フー")
   end
 end

--- a/spec/mobility/backend/fallbacks_spec.rb
+++ b/spec/mobility/backend/fallbacks_spec.rb
@@ -44,7 +44,11 @@ describe Mobility::Backend::Fallbacks do
     expect(subject.read(:"en-US", fallback: false)).to eq(nil)
   end
 
-  it "uses fallbacks passed in as options when present" do
+  it "uses locale passed in as value of fallback option when present" do
     expect(subject.read(:"en-US", fallback: :jp)).to eq("フー")
+  end
+
+  it "uses array of locales passed in as value of fallback options when present" do
+    expect(subject.read(:"en-US", fallback: [:es, :'de-DE'])).to eq("foo")
   end
 end


### PR DESCRIPTION
See #5.

This is a slight API change, previously `post.title(fallbacks: false)` would disable fallbacks for the fetch, but thinking about this I find `post.title(fallback: false)` (singular `fallback`) makes more sense since the option is specifying *not to fall back*.

In addition, with this PR, the option now accepts one or more locales its value, and when present will use these instead of the default fallbacks or fallbacks defined for the attribute in the model.

So:

```ruby
post.title(fallback: :fr)
```

will fall back to the French locale if the value in the current locale is nil.

```ruby
post.title(fallback: [:fr, :es])
```

will fall back first to French, then (if that is empty) to Spanish, if the value in the current locale is nil.

This can be combined with the `locale` option to specify both locale to fetch and fallbacks, e.g.:

```ruby
post.title(locale: :de, fallback: [:fr, :es])
```

would try first German, then French, then Spanish, *regardless of what locale we are currently in or what fallbacks are defined on the attribute at the model level*.