### PR TITLE
Fix fallbacks options

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -76,7 +76,7 @@ On top of this, a backend will normally:
     # @!macro [new] backend_constructor
     #   @param model Model on which backend is defined
     #   @param [String] attribute Backend attribute
-    #   @param [Hash] fallbacks Fallbacks hash
+    #   @option options [Hash] fallbacks Fallbacks hash
     def initialize(model, attribute, **options)
       @model = model
       @attribute = attribute

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -70,18 +70,14 @@ On top of this, a backend will normally:
     # @return [Object] Model on which backend is defined
     attr_reader :model
 
-    # @return [Hash] Backend options
-    attr_reader :options
-
     # @!macro [new] backend_constructor
     #   @param model Model on which backend is defined
     #   @param [String] attribute Backend attribute
-    #   @option options [Hash] fallbacks Fallbacks hash
-    def initialize(model, attribute, **options)
+    #   @option backend_options [Hash] fallbacks Fallbacks hash
+    def initialize(model, attribute, **backend_options)
       @model = model
       @attribute = attribute
-      @options = options
-      fallbacks = options[:fallbacks]
+      fallbacks = backend_options[:fallbacks]
       @fallbacks = I18n::Locale::Fallbacks.new(fallbacks) if fallbacks.is_a?(Hash)
     end
 

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -81,14 +81,14 @@ locale was +nil+.
       # @param [Boolean,Symbol,Array] fallback
       #   +false+ to disable fallbacks on lookup, or a locale or array of
       #   locales to set fallback(s) for this lookup.
-      def read(locale, fallback: nil, **_)
+      def read(locale, fallback: nil, **options)
         if !options[:fallbacks].nil?
           warn "You passed an option with key 'fallbacks', which will be
             ignored. Did you mean 'fallback'?"
         end
         return super if fallback == false
         (fallback ? [locale, *fallback] : fallbacks[locale]).detect do |locale|
-          value = super(locale)
+          value = super(locale, **options)
           break value if value.present?
         end
       end

--- a/lib/mobility/backend/sequel/table.rb
+++ b/lib/mobility/backend/sequel/table.rb
@@ -13,11 +13,15 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
       # @return [Symbol] name of the association method
       attr_reader :association_name
 
+      # @return [Symbol] class for translations
+      attr_reader :translation_class
+
       # @!macro backend_constructor
       # @option options [Symbol] association_name Name of association
       def initialize(model, attribute, **options)
         super
-        @association_name = options[:association_name]
+        @association_name  = options[:association_name]
+        @translation_class = options[:model_class].const_get(options[:subclass_name])
       end
 
       # @!group Backend Accessors
@@ -128,10 +132,6 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
 
       def translations
         model.send(association_name)
-      end
-
-      def translation_class
-        @translation_class ||= options[:model_class].const_get(options[:subclass_name])
       end
 
       def model_cache

--- a/spec/mobility/backend/fallbacks_spec.rb
+++ b/spec/mobility/backend/fallbacks_spec.rb
@@ -6,6 +6,7 @@ describe Mobility::Backend::Fallbacks do
     backend_class.include(Mobility::Backend)
     backend_class.class_eval do
       def read(locale, **options)
+        return "bar" if options[:bar]
         {
           "title" => {
             :'de-DE' => "foo",
@@ -50,5 +51,9 @@ describe Mobility::Backend::Fallbacks do
 
   it "uses array of locales passed in as value of fallback options when present" do
     expect(subject.read(:"en-US", fallback: [:es, :'de-DE'])).to eq("foo")
+  end
+
+  it "passes options to getter in fallback locale" do
+    expect(subject.read(:'en-US', bar: true)).to eq("bar")
   end
 end

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -25,10 +25,6 @@ describe Mobility::Backend do
       subject { MyBackend.new(model, attribute, options) }
       let(:options) { { foo: "bar" } }
 
-      it "assigns options" do
-        expect(subject.options).to eq(options)
-      end
-
       context "with fallbacks" do
         let(:options) { { fallbacks: { :'en-US' => 'de-DE' } } }
 

--- a/spec/support/shared_examples/serialization_examples.rb
+++ b/spec/support/shared_examples/serialization_examples.rb
@@ -133,7 +133,7 @@ shared_examples_for "Sequel Model with serialized translations" do |model_class_
   include Helpers
 
   let(:model_class) { model_class_name.constantize }
-  let(:format) { backend.options[:format] }
+  let(:format) { model_class.mobility.modules.first.options[:format] }
   let(:backend) { instance.mobility_backend_for(attribute1) }
 
   def serialize(value)


### PR DESCRIPTION
I noticed that using `options` as an attribute reader in the backend instance
to get backend options is potentially conflicing with the `options` passed in
to the getter method. In 0.1.7, this name conflict is causing bogus warnings about not passing `fallbacks` to the getter, which is wrong.

This PR fixes the issue and also removes `options` as an attribute reader from
the backend instance, to avoid any possible conflict with locale variable naming.