### PR TITLE
Include fallbacks module by default but do not actually use it

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -165,10 +165,14 @@ module Mobility
 
     # (see Mobility::Configuration#default_accessor_locales)
     # @!method default_accessor_locales
-    %w[accessor_method default_fallbacks default_backend default_accessor_locales].each do |method_name|
+    %w[accessor_method default_backend default_accessor_locales].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end
+    end
+
+    define_method :default_fallbacks do |*args|
+      config.public_send(:default_fallbacks, *args)
     end
 
     # Configure Mobility

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -166,13 +166,6 @@ with other backends.
       end
     end
 
-    def include_backend_modules(backend_class, options)
-      backend_class.include(Backend::Cache)                            unless options[:cache] == false
-      backend_class.include(Backend::Dirty.for(options[:model_class])) if options[:dirty]
-      backend_class.include(Backend::Fallbacks)                        if options[:fallbacks]
-      backend_class.include(FallthroughAccessors.new(attributes))      if options[:fallthrough_accessors]
-    end
-
     # Add this attributes module to shared {Mobility::Wrapper} and setup model
     # with backend setup block (see {Mobility::Backend::Setup#setup_model}).
     # @param model_class [Class] Class of model
@@ -188,6 +181,14 @@ with other backends.
     end
 
     private
+
+    # Include backend modules depending on value of options.
+    def include_backend_modules(backend_class, options)
+      backend_class.include(Backend::Cache)                            unless options[:cache] == false
+      backend_class.include(Backend::Dirty.for(options[:model_class])) if options[:dirty]
+      backend_class.include(Backend::Fallbacks)                        unless options[:fallbacks] == false
+      backend_class.include(FallthroughAccessors.new(attributes))      if options[:fallthrough_accessors]
+    end
 
     def define_backend(attribute)
       _backend_class, _options = backend_class, options

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -73,12 +73,9 @@ On top of this, a backend will normally:
     # @!macro [new] backend_constructor
     #   @param model Model on which backend is defined
     #   @param [String] attribute Backend attribute
-    #   @option backend_options [Hash] fallbacks Fallbacks hash
-    def initialize(model, attribute, **backend_options)
+    def initialize(model, attribute, **_)
       @model = model
       @attribute = attribute
-      fallbacks = backend_options[:fallbacks]
-      @fallbacks = I18n::Locale::Fallbacks.new(fallbacks) if fallbacks.is_a?(Hash)
     end
 
     # @!macro [new] backend_reader

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -84,7 +84,7 @@ locale was +nil+.
         super
         @fallbacks =
           if (fallbacks = backend_options[:fallbacks]).is_a?(Hash)
-            I18n::Locale::Fallbacks.new(fallbacks)
+            Mobility.default_fallbacks(fallbacks)
           elsif fallbacks == true
             Mobility.default_fallbacks
           end

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -11,7 +11,10 @@ Stores shared Mobility configuration referenced by all backends.
 
     # Default fallbacks instance
     # @return [I18n::Locale::Fallbacks]
-    attr_accessor :default_fallbacks
+    def default_fallbacks(fallbacks = {})
+      @default_fallbacks.call(fallbacks)
+    end
+    attr_writer :default_fallbacks
 
     # Default backend to use (can be symbol or actual backend class)
     # @return [Symbol,Class]
@@ -31,7 +34,7 @@ Stores shared Mobility configuration referenced by all backends.
 
     def initialize
       @accessor_method = :translates
-      @default_fallbacks = I18n::Locale::Fallbacks.new
+      @default_fallbacks = lambda { |fallbacks| I18n::Locale::Fallbacks.new(fallbacks) }
       @default_accessor_locales = lambda { I18n.available_locales }
     end
   end

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -45,12 +45,12 @@ describe Mobility::Attributes do
     describe "cache" do
       it "includes Backend::Cache into backend when options[:cache] is not false" do
         expect(backend_klass).to receive(:include).with(Mobility::Backend::Cache)
-        Article.include described_class.new(:accessor, "title", { backend: backend_klass })
+        Article.include described_class.new(:accessor, "title", { backend: backend_klass, fallbacks: false })
       end
 
       it "does not include Backend::Cache into backend when options[:cache] is false" do
         expect(backend_klass).not_to receive(:include).with(Mobility::Backend::Cache)
-        Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false })
+        Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, fallbacks: false })
       end
     end
 
@@ -62,6 +62,7 @@ describe Mobility::Attributes do
           Article.include described_class.new(:accessor, "title", {
             backend: backend_klass,
             cache: false,
+            fallbacks: false,
             dirty: true,
             fallthrough_accessors: false,
             model_class: Article
@@ -70,7 +71,7 @@ describe Mobility::Attributes do
 
         it "does not include Backend::Model::Dirty into backend when options[:dirty] is falsey" do
           expect(backend_klass).not_to receive(:include).with(Mobility::Backend::ActiveModel::Dirty)
-          Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, model_class: Article })
+          Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, fallbacks: false, model_class: Article })
         end
       end
 
@@ -85,6 +86,7 @@ describe Mobility::Attributes do
           Article.include described_class.new(:accessor, "title", {
             backend: backend_klass,
             cache: false,
+            fallbacks: false,
             dirty: true,
             fallthrough_accessors: false,
             model_class: Article
@@ -93,20 +95,20 @@ describe Mobility::Attributes do
 
         it "does not include Backend::Sequel::Dirty into backend when options[:dirty] is falsey" do
           expect(backend_klass).not_to receive(:include).with(Mobility::Backend::Sequel::Dirty)
-          Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, model_class: Article })
+          Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, fallbacks: false, model_class: Article })
         end
       end
     end
 
     describe "fallbacks" do
-      it "includes Backend::Fallbacks into backend when options[:fallbacks] is truthy" do
+      it "includes Backend::Fallbacks into backend when options[:fallbacks] is not false" do
         expect(backend_klass).to receive(:include).with(Mobility::Backend::Fallbacks)
-        Article.include described_class.new(:accessor, "title", { backend: backend_klass, fallbacks: true, cache: false })
+        Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false })
       end
 
-      it "does not include Backend::Fallbacks into backend when options[:fallbacks] is falsey" do
+      it "does not include Backend::Fallbacks into backend when options[:fallbacks] is false" do
         expect(backend_klass).not_to receive(:include).with(Mobility::Backend::Fallbacks)
-        Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false })
+        Article.include described_class.new(:accessor, "title", { backend: backend_klass, cache: false, fallbacks: false })
       end
     end
 

--- a/spec/mobility/backend/fallbacks_spec.rb
+++ b/spec/mobility/backend/fallbacks_spec.rb
@@ -10,7 +10,7 @@ describe Mobility::Backend::Fallbacks do
         {
           "title" => {
             :'de-DE' => "foo",
-            :'jp' => "フー",
+            :ja => "フー",
             :'pt' => ""
           }
         }[attribute][locale]
@@ -21,39 +21,65 @@ describe Mobility::Backend::Fallbacks do
   end
   let(:object) { (stub_const 'MobilityModel', Class.new).include(Mobility).new }
 
-  subject do
-    backend_class.new(object, "title", fallbacks: { :'en-US' => 'de-DE', :pt => 'de-DE' })
+  context "fallbacks is a hash" do
+    subject do
+      backend_class.new(object, "title", fallbacks: { :'en-US' => 'de-DE', :pt => 'de-DE' })
+    end
+
+    it "returns value when value is not nil" do
+      expect(subject.read(:ja)).to eq("フー")
+    end
+
+    it "falls through to fallback locale when value is nil" do
+      expect(subject.read(:"en-US")).to eq("foo")
+    end
+
+    it "falls through to fallback locale when value is blank" do
+      expect(subject.read(:pt)).to eq("foo")
+    end
+
+    it "returns nil when no fallback is found" do
+      expect(subject.read(:"fr")).to eq(nil)
+    end
+
+    it "returns nil when fallbacks: false option is passed" do
+      expect(subject.read(:"en-US", fallback: false)).to eq(nil)
+    end
+
+    it "uses locale passed in as value of fallback option when present" do
+      expect(subject.read(:"en-US", fallback: :ja)).to eq("フー")
+    end
+
+    it "uses array of locales passed in as value of fallback options when present" do
+      expect(subject.read(:"en-US", fallback: [:es, :'de-DE'])).to eq("foo")
+    end
+
+    it "passes options to getter in fallback locale" do
+      expect(subject.read(:'en-US', bar: true)).to eq("bar")
+    end
   end
 
-  it "returns value when value is not nil" do
-    expect(subject.read(:"jp")).to eq("フー")
+  context "fallbacks is true" do
+    subject do
+      backend_class.new(object, "title", fallbacks: true)
+    end
+
+    it "uses default fallbacks" do
+      original_default_locale = I18n.default_locale
+      I18n.default_locale = :ja
+      expect(subject.read(:"en-US")).to eq("フー")
+      I18n.default_locale = original_default_locale
+    end
   end
 
-  it "falls through to fallback locale when value is nil" do
-    expect(subject.read(:"en-US")).to eq("foo")
-  end
+  context "fallbacks is falsey" do
+    subject { backend_class.new(object, "title") }
 
-  it "falls through to fallback locale when value is blank" do
-    expect(subject.read(:pt)).to eq("foo")
-  end
-
-  it "returns nil when no fallback is found" do
-    expect(subject.read(:"fr")).to eq(nil)
-  end
-
-  it "returns nil when fallbacks: false option is passed" do
-    expect(subject.read(:"en-US", fallback: false)).to eq(nil)
-  end
-
-  it "uses locale passed in as value of fallback option when present" do
-    expect(subject.read(:"en-US", fallback: :jp)).to eq("フー")
-  end
-
-  it "uses array of locales passed in as value of fallback options when present" do
-    expect(subject.read(:"en-US", fallback: [:es, :'de-DE'])).to eq("foo")
-  end
-
-  it "passes options to getter in fallback locale" do
-    expect(subject.read(:'en-US', bar: true)).to eq("bar")
+    it "does not use fallbacks" do
+      original_default_locale = I18n.default_locale
+      I18n.default_locale = :ja
+      expect(subject.read(:"en-US")).to eq(nil)
+      I18n.default_locale = original_default_locale
+    end
   end
 end

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -21,19 +21,6 @@ describe Mobility::Backend do
       end
     end
 
-    context "with options" do
-      subject { MyBackend.new(model, attribute, options) }
-      let(:options) { { foo: "bar" } }
-
-      context "with fallbacks" do
-        let(:options) { { fallbacks: { :'en-US' => 'de-DE' } } }
-
-        it "sets @fallbacks variable" do
-          expect(subject.instance_variable_get(:'@fallbacks')).to eq(I18n::Locale::Fallbacks.new(:'en-US' => 'de-DE'))
-        end
-      end
-    end
-
     describe ".setup" do
       before do
         MyBackend.class_eval do


### PR DESCRIPTION
It is now possible to set fallbacks through options on the translated attribute getter method (`post.title(fallback: :de)`), but if the fallbacks module is not included then this will not work. Currently, by default `Mobility::Backend::Fallbacks` is not included by default.

This changes the setup so that we include the module by default, but if the value in the backend options hash is `nil`, then we do not use it except in the case above. This should be more intuitive.