### PR TITLE
Destroy all translations after model is destroyed (KeyValue backend)

### DIFF
--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 module Mobility
   module Backend
 =begin
@@ -54,7 +56,7 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
       def self.configure!(options)
         super
         type = options[:type]
-        options[:class_name] ||= Mobility::ActiveRecord.const_get("#{type.capitalize}Translation")
+        options[:class_name] ||= Mobility::ActiveRecord.const_get("#{type.capitalize}Translation".freeze)
         options[:class_name] = options[:class_name].constantize if options[:class_name].is_a?(String)
         options[:association_name] ||= options[:class_name].table_name.to_sym
         %i[type association_name].each { |key| options[key] = options[key].to_sym }

--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -85,6 +85,7 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
             send(association_name).destroy(translation)
           end
         end
+        after_destroy :mobility_destroy_key_value_translations
 
         mod = Module.new do
           define_method :i18n do
@@ -92,6 +93,16 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
           end
         end
         extend mod
+
+        private
+
+        # Clean up *all* leftover translations of this model, only once.
+        def mobility_destroy_key_value_translations
+          [:string, :text].freeze.each do |type|
+            Mobility::ActiveRecord.const_get("#{type.capitalize}Translation".freeze).
+              where(translatable: self).destroy_all
+          end
+        end unless private_instance_methods(false).include?(:mobility_destroy_key_value_translations)
       end
 
       # @!group Cache Methods

--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -79,7 +79,6 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
         has_many association_name, ->{ where key: association_attributes },
           as: :translatable,
           class_name: translations_class,
-          dependent:  :destroy,
           inverse_of: :translatable,
           autosave:   true
         before_save do

--- a/lib/mobility/backend/sequel/key_value.rb
+++ b/lib/mobility/backend/sequel/key_value.rb
@@ -79,8 +79,6 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
           clearer:         proc { send(:"#{association_name}_dataset").update(translatable_id: nil, translatable_type: nil) },
           class:           translations_class
 
-        plugin :association_dependencies, association_name => :destroy
-
         callback_methods = Module.new do
           define_method :before_save do
             super()

--- a/lib/mobility/backend/sequel/key_value.rb
+++ b/lib/mobility/backend/sequel/key_value.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 module Mobility
   module Backend
 =begin
@@ -52,7 +54,7 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
         super
         raise CacheRequired, "Cache required for Sequel::KeyValue backend" if options[:cache] == false
         type = options[:type]
-options[:class_name] ||= Mobility::Sequel.const_get("#{type.capitalize}Translation")
+        options[:class_name] ||= Mobility::Sequel.const_get("#{type.capitalize}Translation".freeze)
         options[:class_name] = options[:class_name].constantize if options[:class_name].is_a?(String)
         options[:association_name] ||= options[:class_name].table_name.to_sym
         %i[type association_name].each { |key| options[key] = options[key].to_sym }

--- a/spec/mobility/backend/active_record/key_value_spec.rb
+++ b/spec/mobility/backend/active_record/key_value_spec.rb
@@ -243,16 +243,21 @@ describe Mobility::Backend::ActiveRecord::KeyValue, orm: :active_record do
       article = Article.create(title: "foo title", content: "foo content")
       Mobility.with_locale(:ja) { article.update_attributes(title: "あああ", content: "ばばば") }
       article.save
-      expect(Mobility::ActiveRecord::TextTranslation.count).to eq(4)
+
+      # Create translations on another model, to check they do not get destroyed
+      Post.create(title: "post title", content: "post content")
+
+      expect(Mobility::ActiveRecord::StringTranslation.count).to eq(1)
+      expect(Mobility::ActiveRecord::TextTranslation.count).to eq(5)
 
       Mobility::ActiveRecord::TextTranslation.create!(translatable: article, key: "key1", value: "value1", locale: "de")
       Mobility::ActiveRecord::StringTranslation.create!(translatable: article, key: "key2", value: "value2", locale: "fr")
-      expect(Mobility::ActiveRecord::TextTranslation.count).to eq(5)
-      expect(Mobility::ActiveRecord::StringTranslation.count).to eq(1)
+      expect(Mobility::ActiveRecord::TextTranslation.count).to eq(6)
+      expect(Mobility::ActiveRecord::StringTranslation.count).to eq(2)
 
       article.destroy!
-      expect(Mobility::ActiveRecord::TextTranslation.count).to eq(0)
-      expect(Mobility::ActiveRecord::StringTranslation.count).to eq(0)
+      expect(Mobility::ActiveRecord::TextTranslation.count).to eq(1)
+      expect(Mobility::ActiveRecord::StringTranslation.count).to eq(1)
     end
 
     it "only destroys translations once when cleaning up" do

--- a/spec/mobility/backend/sequel/key_value_spec.rb
+++ b/spec/mobility/backend/sequel/key_value_spec.rb
@@ -279,16 +279,21 @@ describe Mobility::Backend::Sequel::KeyValue, orm: :sequel do
       article = Article.create(title: "foo title", content: "foo content")
       Mobility.with_locale(:ja) { article.update(title: "あああ", content: "ばばば") }
       article.save
-      expect(Mobility::Sequel::TextTranslation.count).to eq(4)
+
+      # Create translations on another model, to check they do not get destroyed
+      Post.create(title: "post title", content: "post content")
+
+      expect(Mobility::Sequel::StringTranslation.count).to eq(1)
+      expect(Mobility::Sequel::TextTranslation.count).to eq(5)
 
       Mobility::Sequel::TextTranslation.create(translatable: article, key: "key1", value: "value1", locale: "de")
       Mobility::Sequel::StringTranslation.create(translatable: article, key: "key2", value: "value2", locale: "fr")
-      expect(Mobility::Sequel::TextTranslation.count).to eq(5)
-      expect(Mobility::Sequel::StringTranslation.count).to eq(1)
+      expect(Mobility::Sequel::TextTranslation.count).to eq(6)
+      expect(Mobility::Sequel::StringTranslation.count).to eq(2)
 
       article.destroy
-      expect(Mobility::Sequel::TextTranslation.count).to eq(0)
-      expect(Mobility::Sequel::StringTranslation.count).to eq(0)
+      expect(Mobility::Sequel::TextTranslation.count).to eq(1)
+      expect(Mobility::Sequel::StringTranslation.count).to eq(1)
     end
 
     it "only destroys translations once when cleaning up" do


### PR DESCRIPTION
This is a small but important change to ensure data integrity. When you translate a model using the KeyValue backend with some attribute, say `title`, then later decide to change the name of the attribute to something else, your earlier translations will disappear. This is natural since they were stored with the key `title`, and Mobility is now looking for a different key on the association.

This means that if you change your attribute name *back*, those earlier translations will again become available, because they were never destroyed (the change of attribute name was made at the code level, not the data level). I consider this a good thing.

However, currently they will also remain in the db even after you *destroy* the model, although translations with keys currently defined on the model will be destroyed. The reason is that there is a `dependent: :destroy` option on the translations association, but the association itself is limited with a `where(key: attributes)` scope. The scope is important for efficiency, to avoid looping through "dead" translations that are no longer used, but it also results in these translations not being seen as dependencies.

To fix this, I've added after destroy callbacks for ActiveRecord and Sequel which destroys *all* translations associated with this model, regardless of their key value. This means that *provided you have at least one KeyValue attribute defined on the model when you destroy it*, all translations will be destroyed as you would expect. I think this is reasonable and the best we can do.