### PR TITLE
Refactor instance methods

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -37,6 +37,7 @@ module Mobility
   autoload :BackendResetter,      "mobility/backend_resetter"
   autoload :Configuration,        "mobility/configuration"
   autoload :FallthroughAccessors, "mobility/fallthrough_accessors"
+  autoload :LocaleAccessors,      "mobility/locale_accessors"
   autoload :InstanceMethods,      "mobility/instance_methods"
   autoload :Translates,           "mobility/translates"
   autoload :Wrapper,              "mobility/wrapper"

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -139,7 +139,7 @@ with other backends.
       if (options[:dirty] && options[:fallthrough_accessors] != false)
         options[:fallthrough_accessors] = true
       end
-      include FallthroughAccessors.new(attributes) if options[:fallthrough_accessors]
+      include FallthroughAccessors.new(*attributes) if options[:fallthrough_accessors]
 
       @backend_class.configure!(options) if @backend_class.respond_to?(:configure!)
 

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -151,23 +151,8 @@ with other backends.
 
       attributes.each do |attribute|
         define_backend(attribute)
-
-        if %i[accessor reader].include?(method)
-          define_method attribute do |locale: Mobility.locale, **options|
-            Mobility.enforce_available_locales!(locale)
-            mobility_backend_for(attribute).read(locale.to_sym, options)
-          end
-
-          define_method "#{attribute}?" do |locale: Mobility.locale, **options|
-            Mobility.enforce_available_locales!(locale)
-            mobility_backend_for(attribute).read(locale.to_sym, options).present?
-          end
-        end
-
-        define_method "#{attribute}=" do |value, locale: Mobility.locale, **options|
-          Mobility.enforce_available_locales!(locale)
-          mobility_backend_for(attribute).write(locale.to_sym, value, options)
-        end if %i[accessor writer].include?(method)
+        define_reader(attribute) if %i[accessor reader].include?(method)
+        define_writer(attribute) if %i[accessor writer].include?(method)
       end
     end
 
@@ -200,6 +185,25 @@ with other backends.
       define_method Backend.method_name(attribute) do
         @mobility_backends ||= {}
         @mobility_backends[attribute] ||= _backend_class.new(self, attribute, _options)
+      end
+    end
+
+    def define_reader(attribute)
+      define_method attribute do |locale: Mobility.locale, **options|
+        Mobility.enforce_available_locales!(locale)
+        mobility_backend_for(attribute).read(locale.to_sym, options)
+      end
+
+      define_method "#{attribute}?" do |locale: Mobility.locale, **options|
+        Mobility.enforce_available_locales!(locale)
+        mobility_backend_for(attribute).read(locale.to_sym, options).present?
+      end
+    end
+
+    def define_writer(attribute)
+      define_method "#{attribute}=" do |value, locale: Mobility.locale, **options|
+        Mobility.enforce_available_locales!(locale)
+        mobility_backend_for(attribute).write(locale.to_sym, value, options)
       end
     end
 

--- a/lib/mobility/fallthrough_accessors.rb
+++ b/lib/mobility/fallthrough_accessors.rb
@@ -34,7 +34,7 @@ model class is generated.
 
 =end
   class FallthroughAccessors < Module
-    # @param [Array<String>] Array of attributes
+    # @param [String] One or more attributes
     def initialize(*attributes)
       method_name_regex = /\A(#{attributes.join('|'.freeze)})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
 

--- a/lib/mobility/instance_methods.rb
+++ b/lib/mobility/instance_methods.rb
@@ -11,21 +11,5 @@ Instance methods attached to all model classes when model includes or extends
     def mobility_backend_for(attribute)
       send(Backend.method_name(attribute))
     end
-
-    private
-
-    def mobility_get(attribute, locale: Mobility.locale, **options)
-      Mobility.enforce_available_locales!(locale)
-      mobility_backend_for(attribute).read(locale.to_sym, options)
-    end
-
-    def mobility_present?(*args)
-      mobility_get(*args).present?
-    end
-
-    def mobility_set(attribute, value, locale: Mobility.locale, **options)
-      Mobility.enforce_available_locales!(locale)
-      mobility_backend_for(attribute).write(locale.to_sym, value, **options)
-    end
   end
 end

--- a/lib/mobility/locale_accessors.rb
+++ b/lib/mobility/locale_accessors.rb
@@ -1,0 +1,55 @@
+# frozen-string-literal: true
+
+module Mobility
+=begin
+
+Defines methods for a set of locales to access translated attributes in those
+locales directly with a method call, using a suffix including the locale:
+
+  article.title_pt_br
+
+If no locales are passed as an option to the initializer,
++I18n.available_locales+ will be used by default.
+
+@example
+  class Post
+    def title
+      "title in #{Mobility.locale}"
+    end
+    include Mobility::LocaleAccessors.new("title", locales: [:en, :fr])
+  end
+
+  Mobility.locale = :en
+  post = Post.new
+  post.title
+  #=> "title in en"
+  post.title_fr
+  #=> "title in fr"
+
+=end
+  class LocaleAccessors < Module
+    # @param [String] One or more attributes
+    # @param [Array<Symbol>] Locales
+    def initialize(*attributes, locales: I18n.available_locales)
+      warning_message = "locale passed as option to locale accessor will be ignored".freeze
+
+      attributes.each do |attribute|
+        locales.each do |locale|
+          normalized_locale = Mobility.normalize_locale(locale)
+          define_method "#{attribute}_#{normalized_locale}" do |**options|
+            warn warning_message if options.delete(:locale)
+            Mobility.with_locale(locale) { send(attribute, options) }
+          end
+          define_method "#{attribute}_#{normalized_locale}?" do |**options|
+            warn warning_message if options.delete(:locale)
+            Mobility.with_locale(locale) { send("#{attribute}?", options) }
+          end
+          define_method "#{attribute}_#{normalized_locale}=" do |value, **options|
+            warn warning_message if options.delete(:locale)
+            Mobility.with_locale(locale) { send("#{attribute}=", value, options) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mobility/sequel/column_changes.rb
+++ b/lib/mobility/sequel/column_changes.rb
@@ -11,18 +11,18 @@ is called.
       def initialize(attributes)
         @attributes = attributes
 
-        define_method :mobility_set do |attribute, value, locale: Mobility.locale|
-          if attributes.include?(attribute)
-            column = attribute.to_sym
-            column_with_locale = :"#{attribute}_#{Mobility.normalize_locale(locale)}"
-            if mobility_get(attribute) != value
+        attributes.each do |attribute|
+          define_method "#{attribute}=" do |value, **options|
+            if send(attribute) != value
+              locale = options[:locale] || Mobility.locale
+              column = attribute.to_sym
+              column_with_locale = :"#{attribute}_#{Mobility.normalize_locale(locale)}"
               @changed_columns << column_with_locale if !changed_columns.include?(column_with_locale)
               @changed_columns << column             if !changed_columns.include?(column)
             end
+            super(value, **options)
           end
-          super(attribute, value, locale: locale)
         end
-        private :mobility_set
       end
     end
   end

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -319,6 +319,24 @@ describe Mobility::Attributes do
           expect(article.title_pt_br?).to eq(true)
         end
       end
+
+      context "locale accessor called with locale option" do
+        let(:options) { clean_options.merge(locale_accessors: true) }
+        let(:warning_message) { /locale passed as option to locale accessor will be ignored/ }
+
+        it "warns locale will be ignored" do
+          aggregate_failures do
+            expect(backend).to receive(:read).with(:de, {}).and_return("foo")
+            expect { expect(article.title_de(locale: :en)).to eq("foo") }.to output(warning_message).to_stderr
+
+            expect(backend).to receive(:read).with(:de, {}).and_return("foo")
+            expect { expect(article.title_de?(locale: :en)).to eq(true) }.to output(warning_message).to_stderr
+
+            expect(backend).to receive(:write).with(:de, "foo", {}).and_return("foo")
+            expect { expect(article.send(:title_de=, "foo", locale: :en)).to eq("foo") }.to output(warning_message).to_stderr
+          end
+        end
+      end
     end
 
     describe "fallthrough accessors" do

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -110,12 +110,10 @@ describe Mobility::Attributes do
 
         it "does not include Backend::Sequel::Dirty into backend when options[:dirty] is falsey" do
           expect(backend_class).not_to receive(:include).with(Mobility::Backend::Sequel::Dirty)
-          Article.include described_class.new(:accessor, "title", {
+          Article.include described_class.new(:accessor, "title", clean_options.merge(
             backend: backend_class,
-            cache: false,
-            fallbacks: false,
             model_class: Article
-          })
+          ))
         end
       end
     end


### PR DESCRIPTION
This removes the private `mobility_get`, `mobility_set` and `mobility_present?` instance methods, which are not needed anymore now that the presence filtering has been extracted into its own module (in 7d6547).

Instead of overriding `mobility_set`, the `Mobility::Sequel::ColumnChanges` module now overrides setter methods directly, which is cleaner anyway.