### PR TITLE
Drop its

### DIFF
--- a/mobility.gemspec
+++ b/mobility.gemspec
@@ -28,6 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "database_cleaner", '~> 1.5.3'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-its", "~> 1.2.0"
   spec.add_development_dependency 'yard', '~> 0.9.0'
 end

--- a/spec/mobility/active_model/attribute_methods_spec.rb
+++ b/spec/mobility/active_model/attribute_methods_spec.rb
@@ -18,7 +18,9 @@ describe Mobility::ActiveModel::AttributeMethods, orm: :active_record do
   subject { MobilityModel.new }
 
   describe "#translated_attribute_names" do
-    its(:translated_attribute_names) { should == ["title"] }
+    it 'returns a title' do
+      expect(subject.translated_attribute_names).to include('title')
+    end
   end
 
   describe "#translated_attributes" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ db = ENV['DB'] || 'none'
 require 'pry-byebug'
 require 'i18n'
 require 'rspec'
-require 'rspec/its'
 require 'json'
 
 require 'mobility'


### PR DESCRIPTION
Dropped its. If mobility once uses, I think `its` is needless.