### PR TITLE
Make query scope method configurable

### DIFF
--- a/lib/generators/rails/mobility/install_generator.rb
+++ b/lib/generators/rails/mobility/install_generator.rb
@@ -21,10 +21,7 @@ module Mobility
     end
 
     def create_initializer
-      create_file(
-        "config/initializers/mobility.rb",
-        "Mobility.configure do |config|\n  config.default_backend = :key_value\n  config.accessor_method = :translates\n  config.query_method = :i18n\nend"
-      )
+      copy_file "initializer.rb", "config/initializers/mobility.rb"
     end
 
     def self.next_migration_number(dirname)

--- a/lib/generators/rails/mobility/install_generator.rb
+++ b/lib/generators/rails/mobility/install_generator.rb
@@ -23,7 +23,7 @@ module Mobility
     def create_initializer
       create_file(
         "config/initializers/mobility.rb",
-        "Mobility.configure do |config|\n  config.default_backend = :key_value\n  config.accessor_method = :translates\nend"
+        "Mobility.configure do |config|\n  config.default_backend = :key_value\n  config.accessor_method = :translates\n  config.query_method = :i18n\nend"
       )
     end
 

--- a/lib/generators/rails/mobility/templates/initializer.rb
+++ b/lib/generators/rails/mobility/templates/initializer.rb
@@ -1,0 +1,5 @@
+Mobility.configure do |config|
+  config.default_backend = :key_value
+  config.accessor_method = :translates
+  config.query_method    = :i18n
+end

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -162,6 +162,9 @@ module Mobility
 
     # (see Mobility::Configuration#accessor_method)
     # @!method accessor_method
+    #
+    # (see Mobility::Configuration#query_method)
+    # @!method query_method
 
     # (see Mobility::Configuration#default_fallbacks)
     # @!method default_fallbacks
@@ -171,7 +174,7 @@ module Mobility
 
     # (see Mobility::Configuration#default_accessor_locales)
     # @!method default_accessor_locales
-    %w[accessor_method default_backend default_accessor_locales].each do |method_name|
+    %w[accessor_method query_method default_backend default_accessor_locales].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end

--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -31,7 +31,7 @@ Module loading ActiveRecord-specific classes for Mobility models.
 
     module ClassMethods
       # @return [ActiveRecord::Relation] relation extended with Mobility query methods.
-      def i18n
+      define_method ::Mobility.query_method do
         all
       end
     end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -84,8 +84,8 @@ This allows a backend to do things like (for example) define associations on a
 model class required by the backend, as happens in the {Backend::KeyValue} and
 {Backend::Table} backends.
 
-The +setup+ block is also used to extend the +i18n+ scope/dataset with
-backend-specific query method support.
+The +setup+ block is also used to extend the query scope/dataset (+i18n+ by
+default) with backend-specific query method support.
 
 Since setup blocks are evaluated on the model class, it is possible that
 backends can conflict (for example, overwriting previously defined methods).

--- a/lib/mobility/backend/active_record.rb
+++ b/lib/mobility/backend/active_record.rb
@@ -8,6 +8,21 @@ module Mobility
       autoload :Serialized,   'mobility/backend/active_record/serialized'
       autoload :QueryMethods, 'mobility/backend/active_record/query_methods'
       autoload :Table,        'mobility/backend/active_record/table'
+
+      def setup_query_methods(query_methods)
+        setup do |attributes, options|
+          extend(Module.new do
+            define_method ::Mobility.query_method do
+              @mobility_scope ||= super().extending(query_methods.new(attributes, options))
+            end
+          end)
+        end
+      end
+
+      def self.included(backend_class)
+        backend_class.include(Backend)
+        backend_class.extend(self)
+      end
     end
   end
 end

--- a/lib/mobility/backend/active_record/column.rb
+++ b/lib/mobility/backend/active_record/column.rb
@@ -54,7 +54,7 @@ or locales.)
 
       setup do |attributes, options|
         mod = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/active_record/column.rb
+++ b/lib/mobility/backend/active_record/column.rb
@@ -29,10 +29,10 @@ or locales.)
   #=> "foo"
 =end
     class ActiveRecord::Column
-      include Backend
-      include Backend::Column
+      include ActiveRecord
+      include Column
 
-      autoload :QueryMethods, 'mobility/backend/active_record/column/query_methods'
+      require 'mobility/backend/active_record/column/query_methods'
 
       # @!group Backend Accessors
       # @!macro backend_reader
@@ -52,14 +52,7 @@ or locales.)
       end
       # @!endgroup
 
-      setup do |attributes, options|
-        mod = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
-          end
-        end
-        extend mod
-      end
+      setup_query_methods(QueryMethods)
     end
   end
 end

--- a/lib/mobility/backend/active_record/hash_valued.rb
+++ b/lib/mobility/backend/active_record/hash_valued.rb
@@ -6,7 +6,7 @@ Internal class used by ActiveRecord backends that store values as a hash.
 
 =end
     class ActiveRecord::HashValued
-      include Backend
+      include ActiveRecord
 
       # @!group Backend Accessors
       #

--- a/lib/mobility/backend/active_record/hstore.rb
+++ b/lib/mobility/backend/active_record/hstore.rb
@@ -10,7 +10,7 @@ Implements the {Mobility::Backend::Hstore} backend for ActiveRecord models.
 
 =end
     class ActiveRecord::Hstore < ActiveRecord::HashValued
-      autoload :QueryMethods, 'mobility/backend/active_record/hstore/query_methods'
+      require 'mobility/backend/active_record/hstore/query_methods'
 
       # @!group Backend Accessors
       # @!macro backend_reader
@@ -23,14 +23,7 @@ Implements the {Mobility::Backend::Hstore} backend for ActiveRecord models.
       end
       # @!endgroup
 
-      setup do |attributes, options|
-        query_methods = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
-          end
-        end
-        extend query_methods
-      end
+      setup_query_methods(QueryMethods)
     end
   end
 end

--- a/lib/mobility/backend/active_record/hstore.rb
+++ b/lib/mobility/backend/active_record/hstore.rb
@@ -25,7 +25,7 @@ Implements the {Mobility::Backend::Hstore} backend for ActiveRecord models.
 
       setup do |attributes, options|
         query_methods = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/active_record/jsonb.rb
+++ b/lib/mobility/backend/active_record/jsonb.rb
@@ -10,7 +10,7 @@ Implements the {Mobility::Backend::Jsonb} backend for ActiveRecord models.
 
 =end
     class ActiveRecord::Jsonb < ActiveRecord::HashValued
-      autoload :QueryMethods, 'mobility/backend/active_record/jsonb/query_methods'
+      require 'mobility/backend/active_record/jsonb/query_methods'
 
       # @!group Backend Accessors
       #
@@ -30,14 +30,7 @@ Implements the {Mobility::Backend::Jsonb} backend for ActiveRecord models.
       # @return [String,Integer,Boolean] Updated value
       # @!method write(locale, value, **options)
 
-      setup do |attributes, options|
-        query_methods = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
-          end
-        end
-        extend query_methods
-      end
+      setup_query_methods(QueryMethods)
     end
   end
 end

--- a/lib/mobility/backend/active_record/jsonb.rb
+++ b/lib/mobility/backend/active_record/jsonb.rb
@@ -32,7 +32,7 @@ Implements the {Mobility::Backend::Jsonb} backend for ActiveRecord models.
 
       setup do |attributes, options|
         query_methods = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -21,10 +21,10 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
 
 =end
     class ActiveRecord::KeyValue
-      include Backend
-      include Backend::KeyValue
+      include ActiveRecord
+      include KeyValue
 
-      autoload :QueryMethods, 'mobility/backend/active_record/key_value/query_methods'
+      require 'mobility/backend/active_record/key_value/query_methods'
 
       # @return [Symbol] Name of the association
       attr_reader :association_name
@@ -88,13 +88,6 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
         end
         after_destroy :mobility_destroy_key_value_translations
 
-        mod = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
-          end
-        end
-        extend mod
-
         private
 
         # Clean up *all* leftover translations of this model, only once.
@@ -105,6 +98,8 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
           end
         end unless private_instance_methods(false).include?(:mobility_destroy_key_value_translations)
       end
+
+      setup_query_methods(QueryMethods)
 
       # @!group Cache Methods
       # @return [KeyValue::TranslationsCache]

--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -89,7 +89,7 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
         after_destroy :mobility_destroy_key_value_translations
 
         mod = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/active_record/serialized.rb
+++ b/lib/mobility/backend/active_record/serialized.rb
@@ -53,7 +53,7 @@ Implements {Mobility::Backend::Serialized} backend for ActiveRecord models.
         attributes.each { |attribute| serialize attribute, coder }
 
         extension = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/active_record/serialized.rb
+++ b/lib/mobility/backend/active_record/serialized.rb
@@ -21,9 +21,9 @@ Implements {Mobility::Backend::Serialized} backend for ActiveRecord models.
 
 =end
     class ActiveRecord::Serialized
-      include Backend
+      include ActiveRecord
 
-      autoload :QueryMethods, 'mobility/backend/active_record/serialized/query_methods'
+      require 'mobility/backend/active_record/serialized/query_methods'
 
       # @!group Backend Accessors
       #
@@ -51,14 +51,9 @@ Implements {Mobility::Backend::Serialized} backend for ActiveRecord models.
       setup do |attributes, options|
         coder = { yaml: YAMLCoder, json: JSONCoder }[options[:format]]
         attributes.each { |attribute| serialize attribute, coder }
-
-        extension = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
-          end
-        end
-        extend extension
       end
+
+      setup_query_methods(QueryMethods)
 
       # @!group Cache Methods
       # Returns column value as a hash

--- a/lib/mobility/backend/active_record/table.rb
+++ b/lib/mobility/backend/active_record/table.rb
@@ -159,7 +159,7 @@ columns to that table.
           inverse_of:  association_name
 
         query_methods = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/active_record/table.rb
+++ b/lib/mobility/backend/active_record/table.rb
@@ -84,9 +84,9 @@ columns to that table.
   #  title: "bar">
 =end
     class ActiveRecord::Table
-      include Backend
+      include ActiveRecord
 
-      autoload :QueryMethods, 'mobility/backend/active_record/table/query_methods'
+      require 'mobility/backend/active_record/table/query_methods'
 
       # @return [Symbol] name of the association method
       attr_reader :association_name
@@ -157,14 +157,9 @@ columns to that table.
           class_name:  name,
           foreign_key: options[:foreign_key],
           inverse_of:  association_name
-
-        query_methods = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_scope ||= super().extending(QueryMethods.new(attributes, options))
-          end
-        end
-        extend query_methods
       end
+
+      setup_query_methods(QueryMethods)
 
       # @!group Cache Methods
       # @return [Table::TranslationsCache]

--- a/lib/mobility/backend/active_record/table.rb
+++ b/lib/mobility/backend/active_record/table.rb
@@ -131,7 +131,7 @@ columns to that table.
       end
       # @!endgroup
 
-      setup do |attributes, options|
+      setup do |_attributes, options|
         association_name = options[:association_name]
         subclass_name    = options[:subclass_name]
 

--- a/lib/mobility/backend/orm_delegator.rb
+++ b/lib/mobility/backend/orm_delegator.rb
@@ -17,11 +17,11 @@ Adds {#for} method to backend to return ORM-specific backend.
       # @return [Class] Class of backend to use for model
       def for(model_class)
         if Loaded::ActiveRecord && model_class < ::ActiveRecord::Base
-          const_get(name.split("::").insert(-2, "ActiveRecord").join("::"))
+          const_get(name.split("::".freeze).insert(-2, "ActiveRecord".freeze).join("::".freeze))
         elsif Loaded::Sequel && model_class < ::Sequel::Model
-          const_get(name.split("::").insert(-2, "Sequel").join("::"))
+          const_get(name.split("::".freeze).insert(-2, "Sequel".freeze).join("::".freeze))
         else
-          raise ArgumentError, "#{name.split('::').last} backend can only be used by ActiveRecord or Sequel models"
+          raise ArgumentError, "#{name.split('::'.freeze).last} backend can only be used by ActiveRecord or Sequel models".freeze
         end
       end
 

--- a/lib/mobility/backend/sequel.rb
+++ b/lib/mobility/backend/sequel.rb
@@ -9,6 +9,21 @@ module Mobility
       autoload :Serialized,   'mobility/backend/sequel/serialized'
       autoload :Table,        'mobility/backend/sequel/table'
       autoload :QueryMethods, 'mobility/backend/sequel/query_methods'
+
+      def setup_query_methods(query_methods)
+        setup do |attributes, options|
+          extend(Module.new do
+            define_method ::Mobility.query_method do
+              @mobility_dataset ||= super().with_extend(query_methods.new(attributes, options))
+            end
+          end)
+        end
+      end
+
+      def self.included(backend_class)
+        backend_class.include(Backend)
+        backend_class.extend(self)
+      end
     end
   end
 end

--- a/lib/mobility/backend/sequel/column.rb
+++ b/lib/mobility/backend/sequel/column.rb
@@ -36,7 +36,7 @@ Implements the {Mobility::Backend::Column} backend for Sequel models.
       setup do |attributes, options|
         extension = Module.new do
           define_method ::Mobility.query_method do
-            @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
+            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end
         extend extension

--- a/lib/mobility/backend/sequel/column.rb
+++ b/lib/mobility/backend/sequel/column.rb
@@ -8,10 +8,10 @@ Implements the {Mobility::Backend::Column} backend for Sequel models.
   otherwise interfere with column methods.
 =end
     class Sequel::Column
-      include Backend
-      include Backend::Column
+      include Sequel
+      include Column
 
-      autoload :QueryMethods, 'mobility/backend/sequel/column/query_methods'
+      require 'mobility/backend/sequel/column/query_methods'
 
       # @!group Backend Accessors
       # @!macro backend_reader
@@ -33,14 +33,7 @@ Implements the {Mobility::Backend::Column} backend for Sequel models.
       end
       # @!endgroup
 
-      setup do |attributes, options|
-        extension = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
-          end
-        end
-        extend extension
-      end
+      setup_query_methods(QueryMethods)
     end
   end
 end

--- a/lib/mobility/backend/sequel/column.rb
+++ b/lib/mobility/backend/sequel/column.rb
@@ -35,7 +35,7 @@ Implements the {Mobility::Backend::Column} backend for Sequel models.
 
       setup do |attributes, options|
         extension = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/sequel/hash_valued.rb
+++ b/lib/mobility/backend/sequel/hash_valued.rb
@@ -6,7 +6,7 @@ Internal class used by Sequel backends that store values as a hash.
 
 =end
     class Sequel::HashValued
-      include Backend
+      include Sequel
 
       # @!macro backend_reader
       def read(locale, **_)

--- a/lib/mobility/backend/sequel/hstore.rb
+++ b/lib/mobility/backend/sequel/hstore.rb
@@ -26,7 +26,7 @@ Implements the {Mobility::Backend::Hstore} backend for Sequel models.
       setup do |attributes, options|
         extension = Module.new do
           define_method ::Mobility.query_method do
-            @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
+            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end
         extend extension

--- a/lib/mobility/backend/sequel/hstore.rb
+++ b/lib/mobility/backend/sequel/hstore.rb
@@ -25,7 +25,7 @@ Implements the {Mobility::Backend::Hstore} backend for Sequel models.
 
       setup do |attributes, options|
         extension = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/sequel/hstore.rb
+++ b/lib/mobility/backend/sequel/hstore.rb
@@ -10,7 +10,7 @@ Implements the {Mobility::Backend::Hstore} backend for Sequel models.
 
 =end
     class Sequel::Hstore < Sequel::HashValued
-      autoload :QueryMethods, 'mobility/backend/sequel/hstore/query_methods'
+      require 'mobility/backend/sequel/hstore/query_methods'
 
       # @!group Backend Accessors
       # @!macro backend_reader
@@ -23,14 +23,7 @@ Implements the {Mobility::Backend::Hstore} backend for Sequel models.
       end
       # @!endgroup
 
-      setup do |attributes, options|
-        extension = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
-          end
-        end
-        extend extension
-      end
+      setup_query_methods(QueryMethods)
     end
   end
 end

--- a/lib/mobility/backend/sequel/jsonb.rb
+++ b/lib/mobility/backend/sequel/jsonb.rb
@@ -10,7 +10,7 @@ Implements the {Mobility::Backend::Jsonb} backend for Sequel models.
 
 =end
     class Sequel::Jsonb < Sequel::HashValued
-      autoload :QueryMethods, 'mobility/backend/sequel/jsonb/query_methods'
+      require 'mobility/backend/sequel/jsonb/query_methods'
 
       # @!group Backend Accessors
       #
@@ -30,14 +30,7 @@ Implements the {Mobility::Backend::Jsonb} backend for Sequel models.
       # @return [String,Integer,Boolean] Updated value
       # @!method write(locale, value, **options)
 
-      setup do |attributes, options|
-        extension = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
-          end
-        end
-        extend extension
-      end
+      setup_query_methods(QueryMethods)
     end
   end
 end

--- a/lib/mobility/backend/sequel/jsonb.rb
+++ b/lib/mobility/backend/sequel/jsonb.rb
@@ -33,7 +33,7 @@ Implements the {Mobility::Backend::Jsonb} backend for Sequel models.
       setup do |attributes, options|
         extension = Module.new do
           define_method ::Mobility.query_method do
-            @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
+            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end
         extend extension

--- a/lib/mobility/backend/sequel/jsonb.rb
+++ b/lib/mobility/backend/sequel/jsonb.rb
@@ -32,7 +32,7 @@ Implements the {Mobility::Backend::Jsonb} backend for Sequel models.
 
       setup do |attributes, options|
         extension = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/sequel/key_value.rb
+++ b/lib/mobility/backend/sequel/key_value.rb
@@ -12,10 +12,10 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
 
 =end
     class Sequel::KeyValue
-      include Backend
-      include Backend::KeyValue
+      include Sequel
+      include KeyValue
 
-      autoload :QueryMethods, 'mobility/backend/sequel/key_value/query_methods'
+      require 'mobility/backend/sequel/key_value/query_methods'
 
       # @return [Symbol] name of the association
       attr_reader :association_name
@@ -91,13 +91,6 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
         end
         include callback_methods
 
-        extension = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
-          end
-        end
-        extend extension
-
         include Mobility::Sequel::ColumnChanges.new(attributes)
 
         private
@@ -116,6 +109,8 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
         end unless respond_to?(:mobility_key_value_callbacks_module, true)
         include mobility_key_value_callbacks_module
       end
+
+      setup_query_methods(QueryMethods)
 
       # @!group Cache Methods
       # @return [KeyValue::TranslationsCache]

--- a/lib/mobility/backend/sequel/key_value.rb
+++ b/lib/mobility/backend/sequel/key_value.rb
@@ -93,7 +93,7 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
 
         extension = Module.new do
           define_method ::Mobility.query_method do
-            @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
+            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end
         extend extension

--- a/lib/mobility/backend/sequel/key_value.rb
+++ b/lib/mobility/backend/sequel/key_value.rb
@@ -92,7 +92,7 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
         include callback_methods
 
         extension = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/sequel/serialized.rb
+++ b/lib/mobility/backend/sequel/serialized.rb
@@ -28,9 +28,9 @@ Sequel serialization plugin.
 
 =end
     class Sequel::Serialized
-      include Backend
+      include Sequel
 
-      autoload :QueryMethods, 'mobility/backend/sequel/serialized/query_methods'
+      require 'mobility/backend/sequel/serialized/query_methods'
 
       # @!group Backend Accessors
       #
@@ -74,15 +74,10 @@ Sequel serialization plugin.
         end
         include method_overrides
 
-        extension = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
-          end
-        end
-        extend extension
-
         include SerializationModificationDetectionFix
       end
+
+      setup_query_methods(QueryMethods)
 
       # Returns deserialized column value
       # @return [Hash]

--- a/lib/mobility/backend/sequel/serialized.rb
+++ b/lib/mobility/backend/sequel/serialized.rb
@@ -76,7 +76,7 @@ Sequel serialization plugin.
 
         extension = Module.new do
           define_method ::Mobility.query_method do
-            @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
+            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end
         extend extension

--- a/lib/mobility/backend/sequel/serialized.rb
+++ b/lib/mobility/backend/sequel/serialized.rb
@@ -75,7 +75,7 @@ Sequel serialization plugin.
         include method_overrides
 
         extension = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/backend/sequel/table.rb
+++ b/lib/mobility/backend/sequel/table.rb
@@ -6,9 +6,9 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
 
 =end
     class Sequel::Table
-      include Backend
+      include Sequel
 
-      autoload :QueryMethods, 'mobility/backend/sequel/table/query_methods'
+      require 'mobility/backend/sequel/table/query_methods'
 
       # @return [Symbol] name of the association method
       attr_reader :association_name
@@ -95,15 +95,10 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
         end
         include callback_methods
 
-        extension = Module.new do
-          define_method ::Mobility.query_method do
-            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
-          end
-        end
-        extend extension
-
         include Mobility::Sequel::ColumnChanges.new(attributes)
       end
+
+      setup_query_methods(QueryMethods)
 
       # @!group Cache Methods
       # @return [Table::TranslationsCache]

--- a/lib/mobility/backend/sequel/table.rb
+++ b/lib/mobility/backend/sequel/table.rb
@@ -97,7 +97,7 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
 
         extension = Module.new do
           define_method ::Mobility.query_method do
-            @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
+            @mobility_dataset ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end
         extend extension

--- a/lib/mobility/backend/sequel/table.rb
+++ b/lib/mobility/backend/sequel/table.rb
@@ -96,7 +96,7 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
         include callback_methods
 
         extension = Module.new do
-          define_method :i18n do
+          define_method ::Mobility.query_method do
             @mobility_scope ||= super().with_extend(QueryMethods.new(attributes, options))
           end
         end

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -9,6 +9,10 @@ Stores shared Mobility configuration referenced by all backends.
     # @return [Symbol]
     attr_accessor :accessor_method
 
+    # Name of query scope/dataset method (defaults to +i18n+)
+    # @return [Symbol]
+    attr_accessor :query_method
+
     # Default fallbacks instance
     # @return [I18n::Locale::Fallbacks]
     def default_fallbacks(fallbacks = {})
@@ -34,6 +38,7 @@ Stores shared Mobility configuration referenced by all backends.
 
     def initialize
       @accessor_method = :translates
+      @query_method = :i18n
       @default_fallbacks = lambda { |fallbacks| I18n::Locale::Fallbacks.new(fallbacks) }
       @default_accessor_locales = lambda { I18n.available_locales }
     end

--- a/lib/mobility/sequel.rb
+++ b/lib/mobility/sequel.rb
@@ -18,7 +18,7 @@ Module loading Sequel-specific classes for Mobility models.
 
     module ClassMethods
       # @return [Sequel::Dataset] dataset extended with Mobility query methods.
-      def i18n
+      define_method ::Mobility.query_method do
         dataset
       end
     end

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -14,6 +14,21 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
       run_generator
     end
 
+    it "generates initializer" do
+      expect(destination_root).to have_structure {
+        directory "config" do
+          directory "initializers" do
+            file "mobility.rb" do
+              contains "Mobility.configure do |config|"
+              contains "config.default_backend = :key_value"
+              contains "config.accessor_method = :translates"
+              contains "config.query_method = :i18n"
+            end
+          end
+        end
+      }
+    end
+
     it "generates migration for text translations table" do
       expect(destination_root).to have_structure {
         directory "db" do

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -22,7 +22,7 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
               contains "Mobility.configure do |config|"
               contains "config.default_backend = :key_value"
               contains "config.accessor_method = :translates"
-              contains "config.query_method = :i18n"
+              contains "config.query_method    = :i18n"
             end
           end
         end

--- a/spec/mobility/backend/active_record/column_spec.rb
+++ b/spec/mobility/backend/active_record/column_spec.rb
@@ -98,4 +98,4 @@ describe Mobility::Backend::ActiveRecord::Column, orm: :active_record do
   describe "mobility scope (.i18n)" do
     include_querying_examples 'Comment', :content, :author
   end
-end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backend/active_record/hstore_spec.rb
+++ b/spec/mobility/backend/active_record/hstore_spec.rb
@@ -25,4 +25,4 @@ describe Mobility::Backend::ActiveRecord::Hstore, orm: :active_record, db: :post
       expect(post.read_attribute(:title)).to match_hash({ en: "{:foo=>:bar}" })
     end
   end
-end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backend/active_record/jsonb_spec.rb
+++ b/spec/mobility/backend/active_record/jsonb_spec.rb
@@ -34,4 +34,4 @@ describe Mobility::Backend::ActiveRecord::Jsonb, orm: :active_record, db: :postg
       expect(post.title).to eq(1)
     end
   end
-end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backend/active_record/key_value_spec.rb
+++ b/spec/mobility/backend/active_record/key_value_spec.rb
@@ -372,4 +372,4 @@ describe Mobility::Backend::ActiveRecord::KeyValue, orm: :active_record do
       end
     end
   end
-end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backend/active_record/serialized_spec.rb
+++ b/spec/mobility/backend/active_record/serialized_spec.rb
@@ -138,4 +138,4 @@ describe Mobility::Backend::ActiveRecord::Serialized, orm: :active_record do
       end
     end
   end
-end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backend/active_record/table_spec.rb
+++ b/spec/mobility/backend/active_record/table_spec.rb
@@ -190,4 +190,4 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
       end
     end
   end
-end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backend/sequel/column_spec.rb
+++ b/spec/mobility/backend/sequel/column_spec.rb
@@ -101,4 +101,4 @@ describe Mobility::Backend::Sequel::Column, orm: :sequel do
   describe "mobility dataset (.i18n)" do
     include_querying_examples 'Comment', :content, :author
   end
-end
+end if Mobility::Loaded::Sequel

--- a/spec/mobility/backend/sequel/dirty_spec.rb
+++ b/spec/mobility/backend/sequel/dirty_spec.rb
@@ -203,4 +203,4 @@ describe Mobility::Backend::Sequel::Dirty, orm: :sequel do
       end
     end
   end
-end
+end if Mobility::Loaded::Sequel

--- a/spec/mobility/backend/sequel/hstore_spec.rb
+++ b/spec/mobility/backend/sequel/hstore_spec.rb
@@ -26,4 +26,4 @@ describe Mobility::Backend::Sequel::Hstore, orm: :sequel, db: :postgres do
       expect(post.title_before_mobility.to_hash).to eq({ "en" => "{:foo=>:bar}" })
     end
   end
-end
+end if Mobility::Loaded::Sequel

--- a/spec/mobility/backend/sequel/jsonb_spec.rb
+++ b/spec/mobility/backend/sequel/jsonb_spec.rb
@@ -35,4 +35,4 @@ describe Mobility::Backend::Sequel::Jsonb, orm: :sequel, db: :postgres do
       expect(post.title).to eq(1)
     end
   end
-end
+end if Mobility::Loaded::Sequel

--- a/spec/mobility/backend/sequel/key_value_spec.rb
+++ b/spec/mobility/backend/sequel/key_value_spec.rb
@@ -371,4 +371,4 @@ describe Mobility::Backend::Sequel::KeyValue, orm: :sequel do
       end
     end
   end
-end
+end if Mobility::Loaded::Sequel

--- a/spec/mobility/backend/sequel/serialized_spec.rb
+++ b/spec/mobility/backend/sequel/serialized_spec.rb
@@ -109,4 +109,4 @@ describe Mobility::Backend::Sequel::Serialized, orm: :sequel do
       end
     end
   end
-end
+end if Mobility::Loaded::Sequel

--- a/spec/mobility/backend/sequel/table_spec.rb
+++ b/spec/mobility/backend/sequel/table_spec.rb
@@ -123,4 +123,4 @@ describe Mobility::Backend::Sequel::Table, orm: :sequel do
     before { Article.translates :title, :content, backend: :table, cache: true }
     include_querying_examples('Article')
   end
-end
+end if Mobility::Loaded::Sequel

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -195,7 +195,7 @@ describe Mobility do
     end
   end
 
-  %w[accessor_method default_fallbacks default_accessor_locales].each do |delegated_method|
+  %w[accessor_method query_method default_fallbacks default_accessor_locales].each do |delegated_method|
     describe ".#{delegated_method}" do
       it "delegates to config" do
         expect(Mobility.config).to receive(delegated_method).and_return("foo")

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -1,5 +1,6 @@
 shared_examples_for "AR Model with translated scope" do |model_class_name, attribute1=:title, attribute2=:content|
   let(:model_class) { model_class_name.constantize }
+  let(:query_scope) { model_class.i18n }
 
   describe ".where" do
     context "querying on one translated attribute" do
@@ -12,20 +13,20 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, attri
       end
 
       it "returns correct result searching on unique attribute value" do
-        expect(model_class.i18n.where(attribute1 => "bar post")).to eq([@post2])
+        expect(query_scope.where(attribute1 => "bar post")).to eq([@post2])
       end
 
       it "returns correct results when query matches multiple records" do
-        expect(model_class.i18n.where(attribute1 => "foo post")).to match_array([@post1, @post5])
+        expect(query_scope.where(attribute1 => "foo post")).to match_array([@post1, @post5])
       end
 
       it "returns correct result when querying on translated and untranslated attributes" do
-        expect(model_class.i18n.where(attribute1 => "baz post", published: true)).to eq([@post3])
+        expect(query_scope.where(attribute1 => "baz post", published: true)).to eq([@post3])
       end
 
       it "returns correct result when querying on nil values" do
         post = model_class.create(attribute1 => nil)
-        expect(model_class.i18n.where(attribute1 => nil)).to eq([post])
+        expect(query_scope.where(attribute1 => nil)).to eq([post])
       end
 
       context "with content in different locales" do
@@ -37,11 +38,11 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, attri
         end
 
         it "returns correct result when querying on same attribute value in different locale" do
-          expect(model_class.i18n.where(attribute1 => "foo post")).to match_array([@post1, @post5])
+          expect(query_scope.where(attribute1 => "foo post")).to match_array([@post1, @post5])
 
           Mobility.with_locale(:ja) do
-            expect(model_class.i18n.where(attribute1 => "foo post ja")).to eq([@ja_post1])
-            expect(model_class.i18n.where(attribute1 => "foo post")).to eq([@ja_post2])
+            expect(query_scope.where(attribute1 => "foo post ja")).to eq([@ja_post1])
+            expect(query_scope.where(attribute1 => "foo post")).to eq([@ja_post2])
           end
         end
       end
@@ -59,32 +60,32 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, attri
 
       # @note Regression spec
       it "does not modify scope in-place" do
-        model_class.i18n.where(attribute1 => "foo post")
-        expect(model_class.i18n.to_sql).to eq(model_class.all.to_sql)
+        query_scope.where(attribute1 => "foo post")
+        expect(query_scope.to_sql).to eq(model_class.all.to_sql)
       end
 
       it "returns correct results querying on one attribute" do
-        expect(model_class.i18n.where(attribute1 => "foo post")).to match_array([@post1, @post2, @post3])
-        expect(model_class.i18n.where(attribute2 => "foo content")).to match_array([@post2, @post3, @post4])
+        expect(query_scope.where(attribute1 => "foo post")).to match_array([@post1, @post2, @post3])
+        expect(query_scope.where(attribute2 => "foo content")).to match_array([@post2, @post3, @post4])
       end
 
       it "returns correct results querying on two attributes in single where call" do
-        expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content")).to match_array([@post2, @post3])
+        expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content")).to match_array([@post2, @post3])
       end
 
       it "returns correct results querying on two attributes in separate where calls" do
-        expect(model_class.i18n.where(attribute1 => "foo post").where(attribute2 => "foo content")).to match_array([@post2, @post3])
+        expect(query_scope.where(attribute1 => "foo post").where(attribute2 => "foo content")).to match_array([@post2, @post3])
       end
 
       it "returns correct result querying on two translated attributes and untranslated attribute" do
-        expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content", published: false)).to eq([@post3])
+        expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content", published: false)).to eq([@post3])
       end
 
       it "works with nil values" do
-        expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => nil)).to eq([@post1])
-        expect(model_class.i18n.where(attribute1 => "foo post").where(attribute2 => nil)).to eq([@post1])
+        expect(query_scope.where(attribute1 => "foo post", attribute2 => nil)).to eq([@post1])
+        expect(query_scope.where(attribute1 => "foo post").where(attribute2 => nil)).to eq([@post1])
         post = model_class.create
-        expect(model_class.i18n.where(attribute1 => nil, attribute2 => nil)).to eq([post])
+        expect(query_scope.where(attribute1 => nil, attribute2 => nil)).to eq([post])
       end
 
       context "with content in different locales" do
@@ -98,13 +99,13 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, attri
         end
 
         it "returns correct result when querying on same attribute values in different locale" do
-          expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content")).to match_array([@post2, @post3])
-          expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => nil)).to eq([@post1])
+          expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content")).to match_array([@post2, @post3])
+          expect(query_scope.where(attribute1 => "foo post", attribute2 => nil)).to eq([@post1])
 
           Mobility.with_locale(:ja) do
-            expect(model_class.i18n.where(attribute1 => "foo post")).to match_array([@ja_post2, @ja_post3])
-            expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content")).to eq([@ja_post2])
-            expect(model_class.i18n.where(attribute1 => "foo post ja", attribute2 => "foo content ja")).to eq([@ja_post1])
+            expect(query_scope.where(attribute1 => "foo post")).to match_array([@ja_post2, @ja_post3])
+            expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content")).to eq([@ja_post2])
+            expect(query_scope.where(attribute1 => "foo post ja", attribute2 => "foo content ja")).to eq([@ja_post1])
           end
         end
       end
@@ -124,26 +125,26 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, attri
 
     # @note Regression spec
     it "does not modify scope in-place" do
-      model_class.i18n.where.not(attribute1 => nil)
-      expect(model_class.i18n.to_sql).to eq(model_class.all.to_sql)
+      query_scope.where.not(attribute1 => nil)
+      expect(query_scope.to_sql).to eq(model_class.all.to_sql)
     end
 
     it "works with nil values" do
-      expect(model_class.i18n.where.not(attribute1 => nil)).to match_array([@post1, @post2, @post3, @post5, @post6])
-      expect(model_class.i18n.where.not(attribute1 => nil).where.not(attribute2 => nil)).to match_array([@post2, @post3, @post5, @post6])
-      expect(model_class.i18n.where(attribute1 => nil).where.not(attribute2 => nil)).to eq([@post4])
+      expect(query_scope.where.not(attribute1 => nil)).to match_array([@post1, @post2, @post3, @post5, @post6])
+      expect(query_scope.where.not(attribute1 => nil).where.not(attribute2 => nil)).to match_array([@post2, @post3, @post5, @post6])
+      expect(query_scope.where(attribute1 => nil).where.not(attribute2 => nil)).to eq([@post4])
     end
 
     it "returns record without translated attribute value" do
-      expect(model_class.i18n.where.not(attribute1 => "foo post")).to match_array([@post5, @post6])
+      expect(query_scope.where.not(attribute1 => "foo post")).to match_array([@post5, @post6])
     end
 
     it "returns record without set of translated attribute values" do
-      expect(model_class.i18n.where.not(attribute1 => "foo post", attribute2 => "baz content")).to match_array([@post5])
+      expect(query_scope.where.not(attribute1 => "foo post", attribute2 => "baz content")).to match_array([@post5])
     end
 
     it "works in combination with untranslated attributes" do
-      expect(model_class.i18n.where.not(attribute1 => "foo post", published: true)).to eq([@post6])
+      expect(query_scope.where.not(attribute1 => "foo post", published: true)).to eq([@post6])
     end
   end
 end
@@ -151,6 +152,7 @@ end
 shared_examples_for "Sequel Model with translated dataset" do |model_class_name, attribute1=:title, attribute2=:content|
   let(:model_class) { model_class_name.constantize }
   let(:table_name) { model_class.table_name }
+  let(:query_scope) { model_class.i18n }
 
   describe ".where" do
     context "querying on one translated attribute" do
@@ -163,20 +165,20 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
       end
 
       it "returns correct result searching on unique attribute value" do
-        expect(model_class.i18n.where(attribute1 => "bar post").select_all(table_name).all).to eq([@post2])
+        expect(query_scope.where(attribute1 => "bar post").select_all(table_name).all).to eq([@post2])
       end
 
       it "returns correct results when query matches multiple records" do
-        expect(model_class.i18n.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@post1, @post5])
+        expect(query_scope.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@post1, @post5])
       end
 
       it "returns correct result when querying on translated and untranslated attributes" do
-        expect(model_class.i18n.where(attribute1 => "baz post", :published => true).select_all(table_name).all).to eq([@post3])
+        expect(query_scope.where(attribute1 => "baz post", :published => true).select_all(table_name).all).to eq([@post3])
       end
 
       it "returns correct result when querying on nil values" do
         post = model_class.create(attribute1 => nil)
-        expect(model_class.i18n.where(attribute1 => nil).select_all(table_name).all).to eq([post])
+        expect(query_scope.where(attribute1 => nil).select_all(table_name).all).to eq([post])
       end
 
       context "with content in different locales" do
@@ -188,11 +190,11 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
         end
 
         it "returns correct result when querying on same attribute value in different locale" do
-          expect(model_class.i18n.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@post1, @post5])
+          expect(query_scope.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@post1, @post5])
 
           Mobility.with_locale(:ja) do
-            expect(model_class.i18n.where(attribute1 => "foo post ja").select_all(table_name).all).to eq([@ja_post1])
-            expect(model_class.i18n.where(attribute1 => "foo post").select_all(table_name).all).to eq([@ja_post2])
+            expect(query_scope.where(attribute1 => "foo post ja").select_all(table_name).all).to eq([@ja_post1])
+            expect(query_scope.where(attribute1 => "foo post").select_all(table_name).all).to eq([@ja_post2])
           end
         end
       end
@@ -209,27 +211,27 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
       end
 
       it "returns correct results querying on one attribute" do
-        expect(model_class.i18n.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@post1, @post2, @post3])
-        expect(model_class.i18n.where(attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3, @post4])
+        expect(query_scope.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@post1, @post2, @post3])
+        expect(query_scope.where(attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3, @post4])
       end
 
       it "returns correct results querying on two attributes in single where call" do
-        expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
+        expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
       end
 
       it "returns correct results querying on two attributes in separate where calls" do
-        expect(model_class.i18n.where(attribute1 => "foo post").where(attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
+        expect(query_scope.where(attribute1 => "foo post").where(attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
       end
 
       it "returns correct result querying on two translated attributes and untranslated attribute" do
-        expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content", published: false).select_all(table_name).all).to eq([@post3])
+        expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content", published: false).select_all(table_name).all).to eq([@post3])
       end
 
       it "works with nil values" do
-        expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => nil).select_all(table_name).all).to eq([@post1])
-        expect(model_class.i18n.where(attribute1 => "foo post").where(attribute2 => nil).select_all(table_name).all).to eq([@post1])
+        expect(query_scope.where(attribute1 => "foo post", attribute2 => nil).select_all(table_name).all).to eq([@post1])
+        expect(query_scope.where(attribute1 => "foo post").where(attribute2 => nil).select_all(table_name).all).to eq([@post1])
         post = model_class.create
-        expect(model_class.i18n.where(attribute1 => nil, attribute2 => nil).select_all(table_name).all).to eq([post])
+        expect(query_scope.where(attribute1 => nil, attribute2 => nil).select_all(table_name).all).to eq([post])
       end
 
       context "with content in different locales" do
@@ -243,13 +245,13 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
         end
 
         it "returns correct result when querying on same attribute values in different locale" do
-          expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
-          expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => nil).select_all(table_name).all).to eq([@post1])
+          expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
+          expect(query_scope.where(attribute1 => "foo post", attribute2 => nil).select_all(table_name).all).to eq([@post1])
 
           Mobility.with_locale(:ja) do
-            expect(model_class.i18n.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@ja_post2, @ja_post3])
-            expect(model_class.i18n.where(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to eq([@ja_post2])
-            expect(model_class.i18n.where(attribute1 => "foo post ja", attribute2 => "foo content ja").select_all(table_name).all).to eq([@ja_post1])
+            expect(query_scope.where(attribute1 => "foo post").select_all(table_name).all).to match_array([@ja_post2, @ja_post3])
+            expect(query_scope.where(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to eq([@ja_post2])
+            expect(query_scope.where(attribute1 => "foo post ja", attribute2 => "foo content ja").select_all(table_name).all).to eq([@ja_post1])
           end
         end
       end
@@ -264,17 +266,17 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
     end
 
     it "returns record without excluded attribute condition" do
-      expect(model_class.i18n.exclude(attribute1 => "foo post").select_all(table_name).all).to match_array([@post3])
+      expect(query_scope.exclude(attribute1 => "foo post").select_all(table_name).all).to match_array([@post3])
     end
 
     it "returns record without excluded set of attribute conditions" do
-      expect(model_class.i18n.exclude(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
+      expect(query_scope.exclude(attribute1 => "foo post", attribute2 => "foo content").select_all(table_name).all).to match_array([@post2, @post3])
     end
 
     it "works with nil values" do
-      expect(model_class.i18n.exclude(attribute1 => "bar post", attribute2 => nil).select_all(table_name).all).to match_array([@post1, @post2, @post3])
-      expect(model_class.i18n.exclude(attribute1 => "bar post").exclude(attribute2 => nil).select_all(table_name).all).to eq([@post2])
-      expect(model_class.i18n.exclude(attribute1 => nil).exclude(attribute2 => nil).select_all(table_name).all).to match_array([@post2, @post3])
+      expect(query_scope.exclude(attribute1 => "bar post", attribute2 => nil).select_all(table_name).all).to match_array([@post1, @post2, @post3])
+      expect(query_scope.exclude(attribute1 => "bar post").exclude(attribute2 => nil).select_all(table_name).all).to eq([@post2])
+      expect(query_scope.exclude(attribute1 => nil).exclude(attribute2 => nil).select_all(table_name).all).to match_array([@post2, @post3])
     end
   end
 
@@ -287,19 +289,19 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
       Mobility.locale = :en
       post.send(:"#{attribute1}=", "Title")
       post.save
-      match = model_class.i18n.send(finder_method, "Title")
+      match = query_scope.send(finder_method, "Title")
       expect(match).to eq(post)
       Mobility.locale = :ja
-      expect(model_class.i18n.send(finder_method, "タイトル")).to eq(post)
-      expect(model_class.i18n.send(finder_method, "foo")).to be_nil
+      expect(query_scope.send(finder_method, "タイトル")).to eq(post)
+      expect(query_scope.send(finder_method, "foo")).to be_nil
     end
 
     it "returns nil if no matching translation exists in this locale" do
       Mobility.locale = :ja
       model_class.create(attribute1 => "タイトル")
       Mobility.locale = :en
-      expect(model_class.i18n.send(finder_method, "タイトル")).to eq(nil)
-      expect(model_class.i18n.send(finder_method, "foo")).to be_nil
+      expect(query_scope.send(finder_method, "タイトル")).to eq(nil)
+      expect(query_scope.send(finder_method, "foo")).to be_nil
     end
   end
 end


### PR DESCRIPTION
Currently, the query scope method (`i18n`) is fixed. This PR makes it
configurable, defaulting to `i18n`.