### PR TITLE
Handle uniqueness validation for translated attributes and translated scopes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ group :development, :test do
   end
 
   if ENV['ORM'] == 'sequel'
-    gem 'sequel', '>= 4.0.0', '< 5.0'
+    # some interal API changes are breaking specs, limit to 4.45.x for now
+    gem 'sequel', '>= 4.0.0', '< 4.46.0'
   end
 
   platforms :ruby do

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development, :test do
 
   if ENV['ORM'] == 'sequel'
     # some interal API changes are breaking specs, limit to 4.45.x for now
-    gem 'sequel', '>= 4.0.0', '< 4.46.0'
+    gem 'sequel', '>= 4.41.0', '< 4.46.0'
   end
 
   platforms :ruby do

--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -5,11 +5,12 @@ Module loading ActiveRecord-specific classes for Mobility models.
 
 =end
   module ActiveRecord
-    autoload :BackendResetter,   "mobility/active_record/backend_resetter"
-    autoload :ModelTranslation,  "mobility/active_record/model_translation"
-    autoload :StringTranslation, "mobility/active_record/string_translation"
-    autoload :TextTranslation,   "mobility/active_record/text_translation"
-    autoload :Translation,       "mobility/active_record/translation"
+    autoload :BackendResetter,     "mobility/active_record/backend_resetter"
+    autoload :ModelTranslation,    "mobility/active_record/model_translation"
+    autoload :StringTranslation,   "mobility/active_record/string_translation"
+    autoload :TextTranslation,     "mobility/active_record/text_translation"
+    autoload :Translation,         "mobility/active_record/translation"
+    autoload :UniquenessValidator, "mobility/active_record/uniqueness_validator"
 
     def changes_applied
       @previously_changed = changes
@@ -27,6 +28,8 @@ Module loading ActiveRecord-specific classes for Mobility models.
 
     def self.included(model_class)
       model_class.extend(ClassMethods)
+      model_class.const_set(:UniquenessValidator,
+                            Class.new(::Mobility::ActiveRecord::UniquenessValidator))
     end
 
     module ClassMethods

--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -3,14 +3,12 @@ module Mobility
     class UniquenessValidator < ::ActiveRecord::Validations::UniquenessValidator
       def validate_each(record, attribute, value)
         klass = record.class
-        if klass.translated_attribute_names.include?(attribute.to_s) ||
-            (Array(options[:scope]).map(&:to_s) & klass.translated_attribute_names).present?
+
+        if ((Array(options[:scope]) + [attribute]).map(&:to_s) & klass.translated_attribute_names).present?
           return unless value.present?
           relation = klass.send(Mobility.query_method).where(attribute => value)
           relation = relation.where.not(klass.primary_key => record.id) if record.persisted?
-          Array(options[:scope]).each do |scope_item|
-            relation = relation.where(scope_item => record.send(scope_item))
-          end
+          relation = mobility_scope_relation(record, relation)
           relation = relation.merge(options[:conditions]) if options[:conditions]
 
           if relation.exists?
@@ -22,6 +20,15 @@ module Mobility
         else
           super
         end
+      end
+
+      private
+
+      def mobility_scope_relation(record, relation)
+        Array(options[:scope]).each do |scope_item|
+          relation = relation.where(scope_item => record.send(scope_item))
+        end
+        relation
       end
     end
   end

--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -4,7 +4,7 @@ module Mobility
       def validate_each(record, attribute, value)
         klass = record.class
         if klass.translated_attribute_names.include?(attribute.to_s) ||
-            (Array(options[:scope]).map(&:to_s) & klass.translated_attribute_names)
+            (Array(options[:scope]).map(&:to_s) & klass.translated_attribute_names).present?
           return unless value.present?
           relation = klass.send(Mobility.query_method).where(attribute => value)
           relation = relation.where.not(klass.primary_key => record.id) if record.persisted?

--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -6,7 +6,7 @@ module Mobility
         if klass.translated_attribute_names.include?(attribute.to_s) ||
             (Array(options[:scope]).map(&:to_s) & klass.translated_attribute_names)
           return unless value.present?
-          relation = klass.i18n.where(attribute => value)
+          relation = klass.send(Mobility.query_method).where(attribute => value)
           relation = relation.where.not(klass.primary_key => record.id) if record.persisted?
           Array(options[:scope]).each do |scope_item|
             relation = relation.where(scope_item => record.send(scope_item))

--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -1,0 +1,24 @@
+module Mobility
+  module ActiveRecord
+    class UniquenessValidator < ::ActiveRecord::Validations::UniquenessValidator
+      def validate_each(record, attribute, value)
+        klass = record.class
+        if klass.translated_attribute_names.include?(attribute.to_s)
+          return unless value.present?
+          relation = klass.i18n.where(attribute => value)
+          relation = relation.where.not(klass.primary_key => record.id) if record.persisted?
+          relation = relation.merge(options[:conditions]) if options[:conditions]
+
+          if relation.exists?
+            error_options = options.except(:case_sensitive, :scope, :conditions)
+            error_options[:value] = value
+
+            record.errors.add(attribute, :taken, error_options)
+          end
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/mobility/backend/active_record/column_spec.rb
+++ b/spec/mobility/backend/active_record/column_spec.rb
@@ -97,5 +97,6 @@ describe Mobility::Backend::ActiveRecord::Column, orm: :active_record do
 
   describe "mobility scope (.i18n)" do
     include_querying_examples 'Comment', :content, :author
+    include_validation_examples 'Comment', :content, :author
   end
 end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backend/active_record/hstore_spec.rb
+++ b/spec/mobility/backend/active_record/hstore_spec.rb
@@ -15,6 +15,7 @@ describe Mobility::Backend::ActiveRecord::Hstore, orm: :active_record, db: :post
   include_accessor_examples 'HstorePost'
   include_serialization_examples 'HstorePost'
   include_querying_examples 'HstorePost'
+  include_validation_examples 'HstorePost'
 
   describe "non-text values" do
     it "converts non-string types to strings when saving" do

--- a/spec/mobility/backend/active_record/jsonb_spec.rb
+++ b/spec/mobility/backend/active_record/jsonb_spec.rb
@@ -15,6 +15,7 @@ describe Mobility::Backend::ActiveRecord::Jsonb, orm: :active_record, db: :postg
   include_accessor_examples 'JsonbPost'
   include_serialization_examples 'JsonbPost'
   include_querying_examples 'JsonbPost'
+  include_validation_examples 'JsonbPost'
 
   describe "non-text values" do
     it "stores non-string types as-is when saving" do

--- a/spec/mobility/backend/active_record/key_value_spec.rb
+++ b/spec/mobility/backend/active_record/key_value_spec.rb
@@ -305,6 +305,7 @@ describe Mobility::Backend::ActiveRecord::KeyValue, orm: :active_record do
 
   describe "mobility scope (.i18n)" do
     include_querying_examples('Post')
+    include_validation_examples('Post')
 
     describe "joins" do
       it "uses inner join for WHERE queries" do

--- a/spec/mobility/backend/active_record/key_value_spec.rb
+++ b/spec/mobility/backend/active_record/key_value_spec.rb
@@ -304,8 +304,8 @@ describe Mobility::Backend::ActiveRecord::KeyValue, orm: :active_record do
   end
 
   describe "mobility scope (.i18n)" do
-    include_querying_examples('Post')
-    include_validation_examples('Post')
+    include_querying_examples('Article')
+    include_validation_examples('Article')
 
     describe "joins" do
       it "uses inner join for WHERE queries" do

--- a/spec/mobility/backend/active_record/table_spec.rb
+++ b/spec/mobility/backend/active_record/table_spec.rb
@@ -39,7 +39,6 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
   context "attributes defined separately" do
     include_accessor_examples "MultitablePost", :title, :foo
     include_querying_examples "MultitablePost", :title, :foo
-    include_validation_examples 'MultitablePost', :title, :foo
   end
 
   describe "Backend methods" do

--- a/spec/mobility/backend/active_record/table_spec.rb
+++ b/spec/mobility/backend/active_record/table_spec.rb
@@ -39,6 +39,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
   context "attributes defined separately" do
     include_accessor_examples "MultitablePost", :title, :foo
     include_querying_examples "MultitablePost", :title, :foo
+    include_validation_examples 'MultitablePost', :title, :foo
   end
 
   describe "Backend methods" do
@@ -148,6 +149,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
   describe "mobility scope (.i18n)" do
     before { Article.translates :title, :content, backend: :table, cache: false }
     include_querying_examples('Article')
+    include_validation_examples('Article')
 
     describe "joins" do
       it "uses inner join for WHERE queries if query has at least one non-null attribute" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -17,6 +17,10 @@ module Helpers
     def include_serialization_examples *args
       it_behaves_like "AR Model with serialized translations", *args
     end
+
+    def include_validation_examples *args
+      it_behaves_like "AR Model validation", *args
+    end
   end
 
   module Sequel

--- a/spec/support/shared_examples/validation_examples.rb
+++ b/spec/support/shared_examples/validation_examples.rb
@@ -1,27 +1,131 @@
 shared_examples_for "AR Model validation" do |model_class_name, attribute1=:title, attribute2=:content|
-  let(:model_class) do
-    model_class = model_class_name.constantize
-    model_class.class_eval do
-      validates attribute1, uniqueness: true
-    end
-    model_class
-  end
-
   describe "Uniqueness validation" do
-    it "is valid if no other record has same attribute value in same locale" do
-      Mobility.with_locale(:ja) do
+    context "without scope" do
+      let(:model_class) do
+        model_class = model_class_name.constantize
+        model_class.class_eval do
+          validates attribute1, uniqueness: true
+        end
+        model_class
+      end
+
+      it "is valid if no other record has same attribute value in same locale" do
         @instance1 = model_class.create(attribute1 => "foo")
+        Mobility.with_locale(:ja) do
+          @instance2 = model_class.new(attribute1 => "foo")
+        end
+        expect(@instance2).to be_valid
       end
-      Mobility.with_locale(:'pt-BR') do
+
+      it "is invalid if other record has same attribute value in same locale" do
+        @instance1 = model_class.create(attribute1 => "foo")
         @instance2 = model_class.new(attribute1 => "foo")
+        expect(@instance2).not_to be_valid
       end
-      expect(@instance2).to be_valid
     end
 
-    it "is invalid if other record has same attribute value in same locale" do
-      @instance1 = model_class.create(attribute1 => "foo")
-      @instance2 = model_class.new(attribute1 => "foo")
-      expect(@instance2).not_to be_valid
+    context "with untranslated scope on translated attribute" do
+      let(:model_class) do
+        model_class = model_class_name.constantize
+        model_class.class_eval do
+          validates attribute1, uniqueness: { scope: :published }
+        end
+        model_class
+      end
+
+      it "is valid if no other record has same attribute value in same locale, for the same scope" do
+        @instance1 = model_class.create(attribute1 => "foo", published: true)
+        @instance2 = model_class.new(attribute1    => "foo", published: false)
+        expect(@instance2).to be_valid
+      end
+
+      it "is invalid if other record has same attribute value in same locale, for the same scope" do
+        @instance1 = model_class.create(attribute1 => "foo", published: true)
+        @instance2 = model_class.new(attribute1    => "foo", published: true)
+        Mobility.with_locale(:ja) do
+          @instance3 = model_class.new(attribute1  => "foo", published: true)
+        end
+        expect(@instance2).not_to be_valid
+        expect(@instance3).to be_valid
+      end
+    end
+
+    context "with translated scope on translated attribute" do
+      let(:model_class) do
+        model_class = model_class_name.constantize
+        model_class.class_eval do
+          validates attribute1, uniqueness: { scope: attribute2 }
+        end
+        model_class
+      end
+
+      it "is valid if no other record has same attribute value in same locale, for the same scope" do
+        @instance1 = model_class.create(attribute1 => "foo", attribute2 => "bar")
+        @instance2 = model_class.new(attribute1    => "foo", attribute2 => "baz")
+        expect(@instance2).to be_valid
+      end
+
+      it "is invalid if other record has same attribute value in same locale, for the same scope" do
+        @instance1 = model_class.create(attribute1 => "foo", attribute2 => "bar")
+        @instance2 = model_class.new(attribute1    => "foo", attribute2 => "bar")
+        Mobility.with_locale(:ja) do
+          @instance3 = model_class.new(attribute1  => "foo", attribute2 => "bar")
+        end
+        expect(@instance2).not_to be_valid
+        expect(@instance3).to be_valid
+      end
+    end
+
+    context "with translated scope on untranslated attribute" do
+      let(:model_class) do
+        model_class = model_class_name.constantize
+        model_class.class_eval do
+          validates :published, uniqueness: { :scope => attribute1 }
+        end
+        model_class
+      end
+
+      it "is valid if no other record has same attribute value, for the same scope in same locale" do
+        @instance1 = model_class.create(published: true, attribute1 => "foo")
+        @instance2 = model_class.new(published: true,    attribute1 => "baz")
+        expect(@instance2).to be_valid
+      end
+
+      it "is invalid if other record has same attribute value in same locale, for the same scope" do
+        @instance1 = model_class.create(published: true, attribute1 => "foo")
+        @instance2 = model_class.new(published:    true, attribute1 => "foo")
+        Mobility.with_locale(:ja) do
+          @instance3 = model_class.new(published:  true, attribute1 => "foo")
+        end
+        expect(@instance2).not_to be_valid
+        expect(@instance3).to be_valid
+      end
+    end
+
+    context "uniqueness validation on untranslated attribute" do
+      let(:model_class) do
+        model_class = model_class_name.constantize
+        model_class.class_eval do
+          validates :published, uniqueness: true
+        end
+        model_class
+      end
+
+      it "is valid if no other record has same attribute value" do
+        @instance1 = model_class.create(published: true)
+        @instance2 = model_class.new(published: false)
+        expect(@instance2).to be_valid
+      end
+
+      it "is invalid if other record has same attribute value in same locale" do
+        @instance1 = model_class.create(published: true)
+        @instance2 = model_class.new(published: true)
+        Mobility.with_locale(:ja) do
+          @instance3 = model_class.new(published: true)
+        end
+        expect(@instance2).not_to be_valid
+        expect(@instance3).not_to be_valid
+      end
     end
   end
 end

--- a/spec/support/shared_examples/validation_examples.rb
+++ b/spec/support/shared_examples/validation_examples.rb
@@ -1,0 +1,27 @@
+shared_examples_for "AR Model validation" do |model_class_name, attribute1=:title, attribute2=:content|
+  let(:model_class) do
+    model_class = model_class_name.constantize
+    model_class.class_eval do
+      validates attribute1, uniqueness: true
+    end
+    model_class
+  end
+
+  describe "Uniqueness validation" do
+    it "is valid if no other record has same attribute value in same locale" do
+      Mobility.with_locale(:ja) do
+        @instance1 = model_class.create(attribute1 => "foo")
+      end
+      Mobility.with_locale(:'pt-BR') do
+        @instance2 = model_class.new(attribute1 => "foo")
+      end
+      expect(@instance2).to be_valid
+    end
+
+    it "is invalid if other record has same attribute value in same locale" do
+      @instance1 = model_class.create(attribute1 => "foo")
+      @instance2 = model_class.new(attribute1 => "foo")
+      expect(@instance2).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This adds a `Mobility::ActiveRecord::UniquenessValidator` that is defined as a subclass on a model namespace when the model includes `Mobility`. By doing this, the model will use this validator if `validates` is called with `uniqueness: true`, but due to the namespacing the validator will not be used for any other (non-translated) models.

I'm conciously avoiding monkey-patching the original uniqueness validator since that could have strange and unpredictable results. The validator defined here sticks to very simple queries using `where` and `not` in order to be compatible with *any* supported backend.

Fixes #20