### PR TITLE
Fix deprecation in has_many associations

### DIFF
--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -78,7 +78,7 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
 
         has_many association_name, ->{ where key: association_attributes },
           as: :translatable,
-          class_name: translations_class,
+          class_name: translations_class.to_s,
           inverse_of: :translatable,
           autosave:   true
         before_save do


### PR DESCRIPTION
`DEPRECATION WARNING: Passing a class to the class_name is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: has_many :mobility_text_translations, class_name: 'Mobility::ActiveRecord::TextTranslation'`