### PR TITLE
Make generators work with Rails 4.2

### DIFF
--- a/lib/generators/rails/mobility/active_record_migration_compatibility.rb
+++ b/lib/generators/rails/mobility/active_record_migration_compatibility.rb
@@ -1,0 +1,14 @@
+require "rails/generators/active_record"
+require "active_record/migration"
+
+module Mobility
+  module ActiveRecordMigrationCompatibility
+    def activerecord_migration_class
+      if ::ActiveRecord::Migration.respond_to?(:current_version)
+        "ActiveRecord::Migration[#{::ActiveRecord::Migration.current_version}]"
+      else
+        "ActiveRecord::Migration"
+      end
+    end
+  end
+end

--- a/lib/generators/rails/mobility/backend_generators/base.rb
+++ b/lib/generators/rails/mobility/backend_generators/base.rb
@@ -6,6 +6,7 @@ module Mobility
     class Base < ::Rails::Generators::NamedBase
       argument :attributes, type: :array, default: []
       include ::ActiveRecord::Generators::Migration
+      include ::Mobility::ActiveRecordMigrationCompatibility
 
       def create_migration_file
         if self.class.migration_exists?(migration_dir, migration_file)

--- a/lib/generators/rails/mobility/generators.rb
+++ b/lib/generators/rails/mobility/generators.rb
@@ -1,5 +1,6 @@
 require "rails/generators"
 
+require_relative "./active_record_migration_compatibility"
 require_relative "./install_generator"
 require_relative "./translations_generator"
 require_relative "./backend_generators/base"

--- a/lib/generators/rails/mobility/install_generator.rb
+++ b/lib/generators/rails/mobility/install_generator.rb
@@ -4,6 +4,7 @@ require "rails/generators/active_record"
 module Mobility
   class InstallGenerator < ::Rails::Generators::Base
     include ::Rails::Generators::Migration
+    include ::Mobility::ActiveRecordMigrationCompatibility
 
     desc "Generates migrations to add translations tables."
 

--- a/lib/generators/rails/mobility/templates/column_translations.rb
+++ b/lib/generators/rails/mobility/templates/column_translations.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
 <% attributes.each do |attribute| -%>
 <% I18n.available_locales.each do |locale| -%>

--- a/lib/generators/rails/mobility/templates/create_string_translations.rb
+++ b/lib/generators/rails/mobility/templates/create_string_translations.rb
@@ -1,4 +1,4 @@
-class CreateStringTranslations < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class CreateStringTranslations < <%= activerecord_migration_class %>
 
   def change
     create_table :mobility_string_translations do |t|

--- a/lib/generators/rails/mobility/templates/create_text_translations.rb
+++ b/lib/generators/rails/mobility/templates/create_text_translations.rb
@@ -1,4 +1,4 @@
-class CreateTextTranslations < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class CreateTextTranslations < <%= activerecord_migration_class %>
 
   def change
     create_table :mobility_text_translations do |t|

--- a/lib/generators/rails/mobility/templates/table_migration.rb
+++ b/lib/generators/rails/mobility/templates/table_migration.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
 <% attributes.each do |attribute| -%>
   <%- if attribute.reference? -%>

--- a/lib/generators/rails/mobility/templates/table_migration.rb
+++ b/lib/generators/rails/mobility/templates/table_migration.rb
@@ -3,7 +3,7 @@ class <%= migration_class_name %> < <%= activerecord_migration_class %>
 <% attributes.each do |attribute| -%>
   <%- if attribute.reference? -%>
     add_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %>
-  <%- elsif attribute.token? -%>
+  <%- elsif attribute.respond_to?(:token?) && attribute.token? -%>
     add_column :<%= table_name %>, :<%= attribute.name %>, :string<%= attribute.inject_options %>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>, unique: true
   <%- else -%>

--- a/lib/generators/rails/mobility/templates/table_translations.rb
+++ b/lib/generators/rails/mobility/templates/table_translations.rb
@@ -1,10 +1,10 @@
 class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
-    create_table :<%= table_name %><%= primary_key_type %> do |t|
+    create_table :<%= table_name %><%= primary_key_type if respond_to?(:primary_key_type) %> do |t|
 
       # Translated attribute(s)
 <% attributes.each do |attribute| -%>
-<% if attribute.token? -%>
+<% if attribute.respond_to?(:token?) && attribute.token? -%>
       t.string :<%= attribute.name %><%= attribute.inject_options %>
 <% else -%>
       t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>

--- a/lib/generators/rails/mobility/templates/table_translations.rb
+++ b/lib/generators/rails/mobility/templates/table_translations.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
     create_table :<%= table_name %><%= primary_key_type %> do |t|
 

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -34,7 +34,11 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
         directory "db" do
           directory "migrate" do
             migration "create_text_translations" do
-              contains "class CreateTextTranslations < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+              if ENV["RAILS_VERSION"] < "5.0"
+                contains "class CreateTextTranslations < ActiveRecord::Migration"
+              else
+                contains "class CreateTextTranslations < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+              end
               contains "def change"
               contains "create_table :mobility_text_translations"
               contains "t.text    :value"
@@ -52,7 +56,11 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
         directory "db" do
           directory "migrate" do
             migration "create_string_translations" do
-              contains "class CreateStringTranslations < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+              if ENV["RAILS_VERSION"] < "5.0"
+                contains "class CreateStringTranslations < ActiveRecord::Migration"
+              else
+                contains "class CreateStringTranslations < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+              end
               contains "def change"
               contains "create_table :mobility_string_translations"
               contains "t.string  :value"

--- a/spec/generators/rails/mobility/translations_generator_spec.rb
+++ b/spec/generators/rails/mobility/translations_generator_spec.rb
@@ -23,7 +23,11 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
           directory "db" do
             directory "migrate" do
               migration "create_post_title_and_content_translations_for_mobility_table_backend" do
-                contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                if ENV["RAILS_VERSION"] < "5.0"
+                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration"
+                else
+                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                end
                 contains "def change"
                 contains "create_table :post_translations"
                 contains "t.string :title"
@@ -52,7 +56,11 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
           directory "db" do
             directory "migrate" do
               migration "create_post_title_and_content_translations_for_mobility_table_backend" do
-                contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                if ENV["RAILS_VERSION"] < "5.0"
+                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration"
+                else
+                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                end
                 contains "add_column :post_translations, :title, :string"
                 contains "add_index :post_translations, :title"
                 contains "add_column :post_translations, :content, :text"
@@ -89,7 +97,11 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
           directory "db" do
             directory "migrate" do
               migration "create_foo_title_and_content_translations_for_mobility_column_backend" do
-                contains "class CreateFooTitleAndContentTranslationsForMobilityColumnBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                if ENV["RAILS_VERSION"] < "5.0"
+                  contains "class CreateFooTitleAndContentTranslationsForMobilityColumnBackend < ActiveRecord::Migration"
+                else
+                  contains "class CreateFooTitleAndContentTranslationsForMobilityColumnBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                end
                 contains "add_column :foos, :title_en, :string"
                 contains "add_index  :foos, :title_en"
                 contains "add_column :foos, :title_ja, :string"


### PR DESCRIPTION
I looked at which tests where failing on the `active_record_4.2` branch, and thought I'd try to help out where I could.

This should fix the failing generator tests on Rails 4.2.

- [x] Use the older `ActiveRecord::Migration` as base class for migrations
- [x] Don't call `primary_key_type` unless it's defined
  - This [seems to be](https://github.com/rails/rails/blob/v5.1.1/activerecord/lib/rails/generators/active_record/migration.rb#L19-L22) used to add `id: :uuid` and similar
  - AFAIK there's no Rails 4.2 equivalent, so we can just leave it out
- [x] Don't call `token?` unless it's defined
  - I'm guessing this is for the new `has_secure_token` attributes
  - Again, it shouldn't need any 4.2 counterpart

Let me know what you think. :)
