### PR TITLE
Fix deprecation warnings in Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ rvm:
   - 2.2.5
   - 2.3.1
 env:
-  - DB=postgres ORM=active_record
-  - DB=mysql ORM=active_record
-  - DB=sqlite3 ORM=active_record
+  - DB=postgres ORM=active_record RAILS_VERSION=5.0
+  - DB=mysql ORM=active_record RAILS_VERSION=5.0
+  - DB=sqlite3 ORM=active_record RAILS_VERSION=5.0
+  - DB=postgres ORM=active_record RAILS_VERSION=5.1
+  - DB=mysql ORM=active_record RAILS_VERSION=5.1
+  - DB=sqlite3 ORM=active_record RAILS_VERSION=5.1
   - DB=postgres ORM=sequel
   - DB=mysql ORM=sequel
   - DB=sqlite3 ORM=sequel
@@ -15,11 +18,17 @@ env:
 matrix:
   exclude:
     - rvm: 2.1.10
-      env: DB=postgres ORM=active_record
+      env: DB=postgres ORM=active_record RAILS_VERSION=5.0
     - rvm: 2.1.10
-      env: DB=mysql ORM=active_record
+      env: DB=postgres ORM=active_record RAILS_VERSION=5.1
     - rvm: 2.1.10
-      env: DB=sqlite3 ORM=active_record
+      env: DB=mysql ORM=active_record RAILS_VERSION=5.0
+    - rvm: 2.1.10
+      env: DB=mysql ORM=active_record RAILS_VERSION=5.1
+    - rvm: 2.1.10
+      env: DB=sqlite3 ORM=active_record RAILS_VERSION=5.0
+    - rvm: 2.1.10
+      env: DB=sqlite3 ORM=active_record RAILS_VERSION=5.1
 before_script:
   - bundle exec rake db:create db:up
 before_install: gem install bundler -v 1.12.5

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -102,7 +102,7 @@ module Mobility
 
       if Loaded::ActiveRecord
         model_class.include(ActiveRecord)                   if model_class < ::ActiveRecord::Base
-        model_class.include(ActiveModel::AttributeMethods)  if model_class.ancestors.include?(::ActiveModel::AttributeMethods)
+        model_class.include(ActiveRecord::AttributeMethods) if model_class.ancestors.include?(::ActiveRecord::AttributeMethods)
       end
 
       if Loaded::Sequel

--- a/lib/mobility/active_model.rb
+++ b/lib/mobility/active_model.rb
@@ -1,6 +1,5 @@
 module Mobility
   module ActiveModel
-    autoload :AttributeMethods, "mobility/active_model/attribute_methods"
     autoload :BackendResetter,  "mobility/active_model/backend_resetter"
   end
 end

--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -13,20 +13,6 @@ Module loading ActiveRecord-specific classes for Mobility models.
     autoload :Translation,         "mobility/active_record/translation"
     autoload :UniquenessValidator, "mobility/active_record/uniqueness_validator"
 
-    def changes_applied
-      @previously_changed = changes
-      super
-    end
-
-    def clear_changes_information
-      @previously_changed = ActiveSupport::HashWithIndifferentAccess.new
-      super
-    end
-
-    def previous_changes
-      super.merge(@previously_changed ||= ActiveSupport::HashWithIndifferentAccess.new)
-    end
-
     def self.included(model_class)
       model_class.extend(ClassMethods)
       model_class.const_set(:UniquenessValidator,

--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -5,6 +5,7 @@ Module loading ActiveRecord-specific classes for Mobility models.
 
 =end
   module ActiveRecord
+    autoload :AttributeMethods,    "mobility/active_record/attribute_methods"
     autoload :BackendResetter,     "mobility/active_record/backend_resetter"
     autoload :ModelTranslation,    "mobility/active_record/model_translation"
     autoload :StringTranslation,   "mobility/active_record/string_translation"

--- a/lib/mobility/active_record/attribute_methods.rb
+++ b/lib/mobility/active_record/attribute_methods.rb
@@ -1,8 +1,8 @@
 module Mobility
-  module ActiveModel
+  module ActiveRecord
 =begin
 
-Included into model if model has +ActiveModel::AttributeMethods+ among its
+Included into model if model has +ActiveRecord::AttributeMethods+ among its
 ancestors.
 
 =end

--- a/lib/mobility/backend/active_record.rb
+++ b/lib/mobility/backend/active_record.rb
@@ -2,6 +2,7 @@ module Mobility
   module Backend
     module ActiveRecord
       autoload :Column,       'mobility/backend/active_record/column'
+      autoload :Dirty,        'mobility/backend/active_record/dirty'
       autoload :Hstore,       'mobility/backend/active_record/hstore'
       autoload :Jsonb,        'mobility/backend/active_record/jsonb'
       autoload :KeyValue,     'mobility/backend/active_record/key_value'

--- a/lib/mobility/backend/active_record/dirty.rb
+++ b/lib/mobility/backend/active_record/dirty.rb
@@ -12,13 +12,31 @@ module Mobility
       module ClassMethods
         def setup_model(model_class, attributes, **options)
           super
+
           method_name_regex = /\A(#{attributes.join('|'.freeze)})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
           mod = Module.new do
             define_method :has_attribute? do |attr_name|
               super(attr_name) || !!method_name_regex.match(attr_name)
             end
           end
-          model_class.extend(mod)
+
+          model_class.class_eval do
+            extend mod
+
+            def changes_applied
+              @previously_changed = changes
+              super
+            end
+
+            def clear_changes_information
+              @previously_changed = ActiveSupport::HashWithIndifferentAccess.new
+              super
+            end
+
+            def previous_changes
+              super.merge(@previously_changed ||= ActiveSupport::HashWithIndifferentAccess.new)
+            end
+          end
         end
       end
     end

--- a/lib/mobility/backend/active_record/dirty.rb
+++ b/lib/mobility/backend/active_record/dirty.rb
@@ -31,7 +31,7 @@ module Mobility
             end
 
             def previous_changes
-              super.merge(@previously_changed ||= ActiveSupport::HashWithIndifferentAccess.new)
+              (@previously_changed ||= ActiveSupport::HashWithIndifferentAccess.new).merge(super)
             end
           end
         end

--- a/lib/mobility/backend/active_record/dirty.rb
+++ b/lib/mobility/backend/active_record/dirty.rb
@@ -23,7 +23,11 @@ module Mobility
           model_class.class_eval do
             extend mod
 
-            before_save { @previously_changed = changes }
+            method_name = ::ActiveRecord::VERSION::STRING < '5.1' ? :changes_applied : :changes_internally_applied
+            define_method method_name do
+              @previously_changed = changes
+              super()
+            end
 
             def clear_changes_information
               @previously_changed = ActiveSupport::HashWithIndifferentAccess.new

--- a/lib/mobility/backend/active_record/dirty.rb
+++ b/lib/mobility/backend/active_record/dirty.rb
@@ -1,0 +1,26 @@
+module Mobility
+  module Backend
+    module ActiveRecord::Dirty
+      include ActiveModel::Dirty
+
+      # @param [Class] backend_class Class of backend
+      def self.included(backend_class)
+        backend_class.extend(ActiveModel::Dirty::ClassMethods)
+        backend_class.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def setup_model(model_class, attributes, **options)
+          super
+          method_name_regex = /\A(#{attributes.join('|'.freeze)})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
+          mod = Module.new do
+            define_method :has_attribute? do |attr_name|
+              super(attr_name) || !!method_name_regex.match(attr_name)
+            end
+          end
+          model_class.extend(mod)
+        end
+      end
+    end
+  end
+end

--- a/lib/mobility/backend/active_record/dirty.rb
+++ b/lib/mobility/backend/active_record/dirty.rb
@@ -23,10 +23,7 @@ module Mobility
           model_class.class_eval do
             extend mod
 
-            def changes_applied
-              @previously_changed = changes
-              super
-            end
+            before_save { @previously_changed = changes }
 
             def clear_changes_information
               @previously_changed = ActiveSupport::HashWithIndifferentAccess.new

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -25,7 +25,8 @@ details.
       def self.for(model_class)
         model_class ||= Object
         if Loaded::ActiveRecord && model_class.ancestors.include?(::ActiveModel::Dirty)
-          Backend::ActiveModel::Dirty
+          (model_class < ::ActiveRecord::Base) ?
+            Backend::ActiveRecord::Dirty : Backend::ActiveModel::Dirty
         elsif Loaded::Sequel && model_class < ::Sequel::Model
           Backend::Sequel::Dirty
         else

--- a/spec/mobility/active_record/attribute_methods_spec.rb
+++ b/spec/mobility/active_record/attribute_methods_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
-describe Mobility::ActiveModel::AttributeMethods, orm: :active_record do
+describe Mobility::ActiveRecord::AttributeMethods, orm: :active_record do
   before do
     model = stub_const 'BaseModel', Class.new
     model.class_eval do
       def attributes; { "untranslated" => "bar" }; end
     end
     mobility_model = stub_const 'MobilityModel', Class.new(BaseModel)
-    klass = Mobility::ActiveModel::AttributeMethods
+    klass = Mobility::ActiveRecord::AttributeMethods
     mobility_model.class_eval do
       def self.translated_attribute_names; ["title"]; end
       def title; "foo"; end

--- a/spec/mobility/backend/active_record/dirty_spec.rb
+++ b/spec/mobility/backend/active_record/dirty_spec.rb
@@ -69,6 +69,23 @@ describe Mobility::Backend::ActiveRecord::Dirty, orm: :active_record do
       end
     end
 
+    it "tracks previous changes in one locale in before_save hook" do
+      article = Article.create(title: "foo")
+
+      article.title = "bar"
+      article.save
+
+      article.singleton_class.class_eval do
+        before_save do
+          @actual_previous_changes = previous_changes
+        end
+      end
+
+      article.save
+
+      expect(article.instance_variable_get(:@actual_previous_changes)).to eq({ "title_en" => ["foo", "bar"]})
+    end
+
     it "tracks changes in multiple locales" do
       article = Article.new
 


### PR DESCRIPTION
There are tons of deprecation warnings currently in Rails/AR 5.1. This removes the warnings while still passing specs. However, it introduces some questionable changes to achieve this.

There are two problems:
1. AR::Dirty now requires you to declare all attributes upfront rather than in an open-ended way with `attr_will_change!` (see rails/rails#27963). To get around this, I've overridden `has_attribute?` to make locale accessors (`title_en` etc) act like real attributes. We can't actually define them all since the list of locales is open-ended.
2. You can't call `changes` from within after save callbacks. This conflicts with code used to support `previous_changes` in the Mobility Dirty backend module. This is fixed using a `before_save` hook rather than a `changes_applied` override, but this may fail to work as expected if the model calls `previous_changes` in another `before_save` callback added after this.

The first solution is ok I think for now, the second one may be more problematic but at least is limited to `previous_changes` only.