### PR TITLE
Add option to set default value or proc for translated attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,36 @@ fallbacks](http://www.rubydoc.info/gems/mobility/Mobility/Backend/Fallbacks)
 and [this article on I18n
 fallbacks](https://github.com/svenfuchs/i18n/wiki/Fallbacks).
 
+### <a name="default"></a>Default values
+
+Another option is to assign a default value, which will be used if the result of a fetch would otherwise be `nil`:
+
+```ruby
+class Word < ApplicationRecord
+  include Mobility
+  translates :name, type: :string, default: 'foo'
+end
+
+Mobility.locale = :ja
+word = Word.create(name: "モビリティ")
+word.name
+#=> "モビリティ"
+Mobility.locale = :de
+word.name
+#=> "foo"
+```
+
+You can override the default by passing a `default` option to the attribute reader:
+
+```ruby
+word.name
+#=> 'foo'
+word.name(default: nil)
+#=> nil
+word.name(default: 'bar')
+#=> 'bar'
+```
+
 ### <a name="dirty"></a>Dirty Tracking
 
 Dirty tracking (tracking of changed attributes) can be enabled for models which

--- a/README.md
+++ b/README.md
@@ -467,6 +467,9 @@ word.name(default: 'bar')
 #=> 'bar'
 ```
 
+The default can also be a `Proc`, which will be passed the model and attribute
+name as keyword arguments. See the [API docs][docs] for details.
+
 ### <a name="dirty"></a>Dirty Tracking
 
 Dirty tracking (tracking of changed attributes) can be enabled for models which

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -179,7 +179,7 @@ with other backends.
       backend_class.include(Backend::Dirty.for(options[:model_class])) if options[:dirty]
       backend_class.include(Backend::Fallbacks)                        unless options[:fallbacks] == false
       backend_class.include(Backend::Presence)                         unless options[:presence] == false
-      backend_class.include(Backend::Default)                          if options[:default] != nil
+      backend_class.include(Backend::Default)                          if options.has_key?(:default)
     end
 
     def define_backend(attribute)

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -127,6 +127,7 @@ with other backends.
     #   this model backend. Will default to +true+ if +dirty+ option is +true+.
     # @option options_ [Boolean] presence (true) Enable presence filter on
     #   reads and writes
+    # @option options_ [Object] default Enable default value for this model backend
     # @raise [ArgumentError] if method is not reader, writer or accessor
     def initialize(method, *attributes_, **options_)
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)
@@ -178,6 +179,7 @@ with other backends.
       backend_class.include(Backend::Dirty.for(options[:model_class])) if options[:dirty]
       backend_class.include(Backend::Fallbacks)                        unless options[:fallbacks] == false
       backend_class.include(Backend::Presence)                         unless options[:presence] == false
+      backend_class.include(Backend::Default)                          if options[:default] != nil
     end
 
     def define_backend(attribute)

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -53,6 +53,7 @@ On top of this, a backend will normally:
     autoload :ActiveRecord, 'mobility/backend/active_record'
     autoload :Cache,        'mobility/backend/cache'
     autoload :Column,       'mobility/backend/column'
+    autoload :Default,      'mobility/backend/default'
     autoload :Dirty,        'mobility/backend/dirty'
     autoload :Fallbacks,    'mobility/backend/fallbacks'
     autoload :Hstore,       'mobility/backend/hstore'

--- a/lib/mobility/backend/default.rb
+++ b/lib/mobility/backend/default.rb
@@ -34,6 +34,18 @@ otherwise be nil.
 
   post.title(default: nil)
   #=> nil
+
+@example Using Proc as default
+  class Post
+    translates :title, default: lambda { |model:, attribute:| attribute.to_s }
+  end
+
+  post = Post.new(title: nil)
+  post.title
+  #=> "title"
+
+  post.title(default: lambda { |model:| model.class.name.to_s }
+  #=> "Post"
 =end
     module Default
       # @!macro [new] backend_constructor
@@ -50,7 +62,7 @@ otherwise be nil.
       #   this read.
       def read(locale, **options)
         default = options.has_key?(:default) ? options.delete(:default) : @default
-        super || default
+        super || (default.is_a?(Proc) ? default.call(model: model, attribute:attribute) : default)
       end
     end
   end

--- a/lib/mobility/backend/default.rb
+++ b/lib/mobility/backend/default.rb
@@ -1,0 +1,57 @@
+module Mobility
+  module Backend
+=begin
+
+Defines value or proc to fall through to if return value from getter would
+otherwise be nil.
+
+@example With default enabled (falls through to default value)
+  class Post
+    translates :title, default: 'foo'
+  end
+
+  Mobility.locale = :en
+  post = Post.new(title: "English title")
+
+  Mobility.locale = :de
+  post.title
+  #=> 'foo'
+
+@example Overriding default with reader option
+  class Post
+    translates :title, default: 'foo'
+  end
+
+  Mobility.locale = :en
+  post  = Post.new(title: "English title")
+
+  Mobility.locale = :de
+  post.title
+  #=> 'foo'
+
+  post.title(default: 'bar')
+  #=> 'bar'
+
+  post.title(default: nil)
+  #=> nil
+=end
+    module Default
+      # @!macro [new] backend_constructor
+      #   @option backend_options [Object] default Default value
+      def initialize(*args, **backend_options)
+        super
+        @default = backend_options[:default]
+      end
+
+      # @group Backend Accessors
+      # @!macro backend_reader
+      # @param [Boolean] default
+      #   *false* to disable default value, or another value to set default for
+      #   this read.
+      def read(locale, **options)
+        default = options.has_key?(:default) ? options.delete(:default) : @default
+        super || default
+      end
+    end
+  end
+end

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -131,6 +131,13 @@ describe Mobility::Attributes do
       end
     end
 
+    describe "default" do
+      it "includes Backend::Default into backend when options has key :default" do
+        expect(backend_class).to receive(:include).with(Mobility::Backend::Default)
+        Article.include described_class.new(:accessor, "title", clean_options.merge(backend: backend_class, default: nil))
+      end
+    end
+
     describe "defining attribute backend on model" do
       before do
         Article.include described_class.new(:accessor, "title", { backend: backend_class, foo: "bar" })

--- a/spec/mobility/backend/default_spec.rb
+++ b/spec/mobility/backend/default_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
 
 describe Mobility::Backend::Default do
+  let(:default) { 'default foo' }
   let(:backend_double) { double("backend") }
-  let(:backend) { backend_class.new("model", "attribute", default: 'default foo') }
+  let(:backend) { backend_class.new("model", "title", default: default) }
   let(:backend_class) do
     backend_double_ = backend_double
     backend_class = Class.new(Mobility::Backend::Null) do
@@ -41,6 +42,22 @@ describe Mobility::Backend::Default do
     it "returns false if passed default: false as option to reader" do
       expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
       expect(backend.read(:fr, default: false)).to eq(false)
+    end
+
+    context "default is a Proc" do
+      let(:default) { lambda { |model:, attribute:| "#{model} #{attribute}" } }
+
+      it "calls default with model and attribute as args if default is a Proc" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(backend.read(:fr)).to eq('model title')
+      end
+
+      it "calls default with model and attribute as args if default option is a Proc" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(backend.read(:fr, default: lambda do |model:, attribute:|
+          "#{model} #{attribute} from options"
+        end)).to eq('model title from options')
+      end
     end
   end
 end

--- a/spec/mobility/backend/default_spec.rb
+++ b/spec/mobility/backend/default_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe Mobility::Backend::Default do
+  let(:backend_double) { double("backend") }
+  let(:backend) { backend_class.new("model", "attribute", default: 'default foo') }
+  let(:backend_class) do
+    backend_double_ = backend_double
+    backend_class = Class.new(Mobility::Backend::Null) do
+      define_method :read do |*args|
+        backend_double_.read(*args)
+      end
+
+      define_method :write do |*args|
+        backend_double_.write(*args)
+      end
+    end
+    Class.new(backend_class).include(described_class)
+  end
+
+  describe "#read" do
+    it "returns value if not nil" do
+      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("foo")
+      expect(backend.read(:fr)).to eq("foo")
+    end
+
+    it "returns default if backend return value is nil" do
+      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+      expect(backend.read(:fr)).to eq("default foo")
+    end
+
+    it "returns value of default override if passed as option to reader" do
+      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+      expect(backend.read(:fr, default: "default bar")).to eq("default bar")
+    end
+
+    it "returns nil if passed default: nil as option to reader" do
+      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+      expect(backend.read(:fr, default: nil)).to eq(nil)
+    end
+
+    it "returns false if passed default: false as option to reader" do
+      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+      expect(backend.read(:fr, default: false)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This adds an option which can be passed when defining an attribute or when
calling an attribute reader to define a default value which will be returned if
the backend would otherwise return `nil`.

Resolves #48.