### PR TITLE
Reorganize module options

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -170,9 +170,12 @@ module Mobility
     # (see Mobility::Configuration#default_options)
     # @!method default_options
     #
+    # (see Mobility::Configuration#option_modules)
+    # @!method option_modules
+    #
     # (see Mobility::Configuration#default_accessor_locales)
     # @!method default_accessor_locales
-    %w[accessor_method query_method default_backend default_options default_accessor_locales].each do |method_name|
+    %w[accessor_method query_method default_backend default_options option_modules default_accessor_locales].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -167,9 +167,12 @@ module Mobility
     # (see Mobility::Configuration#default_backend)
     # @!method default_backend
 
+    # (see Mobility::Configuration#default_options)
+    # @!method default_options
+    #
     # (see Mobility::Configuration#default_accessor_locales)
     # @!method default_accessor_locales
-    %w[accessor_method query_method default_backend default_accessor_locales].each do |method_name|
+    %w[accessor_method query_method default_backend default_options default_accessor_locales].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -175,11 +175,11 @@ with other backends.
 
     # Include backend modules depending on value of options.
     def include_backend_modules(backend_class, options)
-      backend_class.include(Backend::Cache)                            unless options[:cache] == false
-      backend_class.include(Backend::Dirty.for(options[:model_class])) if options[:dirty]
-      backend_class.include(Backend::Fallbacks)                        unless options[:fallbacks] == false
-      backend_class.include(Backend::Presence)                         unless options[:presence] == false
-      backend_class.include(Backend::Default)                          if options.has_key?(:default)
+      Backend::Cache.apply(backend_class, options[:cache], options)
+      Backend::Dirty.apply(backend_class, options[:dirty], options)
+      Backend::Fallbacks.apply(backend_class, options[:fallbacks], options)
+      Backend::Presence.apply(backend_class, options[:presence], options)
+      Backend::Default.apply(backend_class, options[:default], options)
     end
 
     def define_backend(attribute)

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -142,7 +142,7 @@ with other backends.
 
       @options = Mobility.default_options.merge(options)
       Mobility.option_modules.each do |key, klass|
-        klass.apply(self, options[key], options)
+        klass.apply(self, options[key])
       end
 
       names.each do |name|

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -112,27 +112,27 @@ with other backends.
     attr_reader :backend_name
 
     # @param [Symbol] method One of: [reader, writer, accessor]
-    # @param [Array<String>] names_ Names of attributes to define backend for
-    # @param [Hash] options_ Backend options hash
-    # @option options_ [Class] model_class Class of model
-    # @option options_ [Boolean] cache (true) Enable cache for this model backend
-    # @option options_ [Boolean] dirty Enable dirty tracking for this model
+    # @param [Array<String>] attribute_names Names of attributes to define backend for
+    # @param [Hash] backend_options Backend options hash
+    # @option backend_options [Class] model_class Class of model
+    # @option backend_options [Boolean] cache (true) Enable cache for this model backend
+    # @option backend_options [Boolean] dirty Enable dirty tracking for this model
     #   backend
-    # @option options_ [Boolean, Hash] fallbacks Enable fallbacks or specify
+    # @option backend_options [Boolean, Hash] fallbacks Enable fallbacks or specify
     #   fallbacks for this model backend
-    # @option options_ [Boolean] fallthrough_accessors Enable fallthrough
+    # @option backend_options [Boolean] fallthrough_accessors Enable fallthrough
     #   locale accessors for this model backend
-    # @option options_ [Boolean, Array<Symbol>] locale_accessors Enable locale
+    # @option backend_options [Boolean, Array<Symbol>] locale_accessors Enable locale
     #   accessors or specify locales for which accessors should be defined on
     #   this model backend. Will default to +true+ if +dirty+ option is +true+.
-    # @option options_ [Boolean] presence (true) Enable presence filter on
+    # @option backend_options [Boolean] presence (true) Enable presence filter on
     #   reads and writes
-    # @option options_ [Object] default Enable default value for this model backend
+    # @option backend_options [Object] default Enable default value for this model backend
     # @raise [ArgumentError] if method is not reader, writer or accessor
-    def initialize(method, *names_, **options_)
+    def initialize(method, *attribute_names, **backend_options)
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)
-      @options = options_
-      @names = names_.map(&:to_s)
+      @options = backend_options
+      @names = attribute_names.map(&:to_s)
       model_class = options[:model_class]
       @backend_name = options.delete(:backend) || Mobility.config.default_backend
       @backend_class = Class.new(get_backend_class(backend:     @backend_name,

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -133,10 +133,9 @@ with other backends.
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)
       @options = Mobility.default_options.merge(backend_options)
       @names = attribute_names.map(&:to_s)
-      model_class = options[:model_class]
       @backend_name = options.delete(:backend) || Mobility.config.default_backend
       @backend_class = Class.new(get_backend_class(backend:     @backend_name,
-                                                   model_class: model_class))
+                                                   model_class: options[:model_class]))
 
       @backend_class.configure(options) if @backend_class.respond_to?(:configure)
 

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -172,7 +172,7 @@ with other backends.
 
     # Include backend modules depending on value of options.
     def include_backend_modules(backend_class, options)
-      module_options = options.reject { |k, v| !module_option_keys.include?(k.to_s) }
+      module_options = options.reject { |k, _| !module_option_keys.include?(k.to_s) }
       Mobility.default_options.merge(module_options).each do |name, value|
         Backend.const_get(name.to_s.camelize).apply(backend_class, value, options)
       end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -131,7 +131,7 @@ with other backends.
     # @raise [ArgumentError] if method is not reader, writer or accessor
     def initialize(method, *attribute_names, **backend_options)
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)
-      @options = backend_options
+      @options = Mobility.default_options.merge(backend_options)
       @names = attribute_names.map(&:to_s)
       model_class = options[:model_class]
       @backend_name = options.delete(:backend) || Mobility.config.default_backend
@@ -140,7 +140,6 @@ with other backends.
 
       @backend_class.configure(options) if @backend_class.respond_to?(:configure)
 
-      @options = Mobility.default_options.merge(options)
       Mobility.option_modules.each do |key, klass|
         klass.apply(self, options[key])
       end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -175,11 +175,9 @@ with other backends.
 
     # Include backend modules depending on value of options.
     def include_backend_modules(backend_class, options)
-      Backend::Cache.apply(backend_class, options[:cache], options)
-      Backend::Dirty.apply(backend_class, options[:dirty], options)
-      Backend::Fallbacks.apply(backend_class, options[:fallbacks], options)
-      Backend::Presence.apply(backend_class, options[:presence], options)
-      Backend::Default.apply(backend_class, options[:default], options)
+      %w[cache dirty fallbacks presence default].each do |name|
+        Backend.const_get(name.camelize).apply(backend_class, options[name.to_sym], options)
+      end
     end
 
     def define_backend(attribute)

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -137,14 +137,11 @@ with other backends.
       @backend_name = options.delete(:backend) || Mobility.config.default_backend
       @backend_class = Class.new(get_backend_class(backend:     @backend_name,
                                                    model_class: model_class))
-      if (options[:dirty] && options[:fallthrough_accessors] != false)
-        options[:fallthrough_accessors] = true
-      end
-      include FallthroughAccessors.new(*attributes) if options[:fallthrough_accessors]
-
       @backend_class.configure(options) if @backend_class.respond_to?(:configure)
 
       include_backend_modules(@backend_class, options)
+
+      include FallthroughAccessors.new(*attributes) if options[:fallthrough_accessors]
 
       @accessor_locales = options[:locale_accessors]
       @accessor_locales = Mobility.config.default_accessor_locales if @accessor_locales == true

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -115,19 +115,6 @@ with other backends.
     # @param [Array<String>] attribute_names Names of attributes to define backend for
     # @param [Hash] backend_options Backend options hash
     # @option backend_options [Class] model_class Class of model
-    # @option backend_options [Boolean] cache (true) Enable cache for this model backend
-    # @option backend_options [Boolean] dirty Enable dirty tracking for this model
-    #   backend
-    # @option backend_options [Boolean, Hash] fallbacks Enable fallbacks or specify
-    #   fallbacks for this model backend
-    # @option backend_options [Boolean] fallthrough_accessors Enable fallthrough
-    #   locale accessors for this model backend
-    # @option backend_options [Boolean, Array<Symbol>] locale_accessors Enable locale
-    #   accessors or specify locales for which accessors should be defined on
-    #   this model backend. Will default to +true+ if +dirty+ option is +true+.
-    # @option backend_options [Boolean] presence (true) Enable presence filter on
-    #   reads and writes
-    # @option backend_options [Object] default Enable default value for this model backend
     # @raise [ArgumentError] if method is not reader, writer or accessor
     def initialize(method, *attribute_names, **backend_options)
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -95,9 +95,9 @@ with other backends.
 
 =end
   class Attributes < Module
-    # Attributes for which accessors will be defined
-    # @return [Array<String>] Array of attributes
-    attr_reader :attributes
+    # Attribute names for which accessors will be defined
+    # @return [Array<String>] Array of names
+    attr_reader :names
 
     # Backend options
     # @return [Hash] Backend options
@@ -112,7 +112,7 @@ with other backends.
     attr_reader :backend_name
 
     # @param [Symbol] method One of: [reader, writer, accessor]
-    # @param [Array<String>] attributes_ Attributes to define backend for
+    # @param [Array<String>] names_ Names of attributes to define backend for
     # @param [Hash] options_ Backend options hash
     # @option options_ [Class] model_class Class of model
     # @option options_ [Boolean] cache (true) Enable cache for this model backend
@@ -129,10 +129,10 @@ with other backends.
     #   reads and writes
     # @option options_ [Object] default Enable default value for this model backend
     # @raise [ArgumentError] if method is not reader, writer or accessor
-    def initialize(method, *attributes_, **options_)
+    def initialize(method, *names_, **options_)
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)
       @options = options_
-      @attributes = attributes_.map(&:to_s)
+      @names = names_.map(&:to_s)
       model_class = options[:model_class]
       @backend_name = options.delete(:backend) || Mobility.config.default_backend
       @backend_class = Class.new(get_backend_class(backend:     @backend_name,
@@ -145,10 +145,10 @@ with other backends.
         klass.apply(self, options[key], options)
       end
 
-      attributes.each do |attribute|
-        define_backend(attribute)
-        define_reader(attribute) if %i[accessor reader].include?(method)
-        define_writer(attribute) if %i[accessor writer].include?(method)
+      names.each do |name|
+        define_backend(name)
+        define_reader(name) if %i[accessor reader].include?(method)
+        define_writer(name) if %i[accessor writer].include?(method)
       end
     end
 
@@ -157,13 +157,13 @@ with other backends.
     # @param model_class [Class] Class of model
     def included(model_class)
       model_class.mobility << self
-      backend_class.setup_model(model_class, attributes, options)
+      backend_class.setup_model(model_class, names, options)
     end
 
-    # Yield each attribute to block
+    # Yield each attribute name to block
     # @yield [String] Attribute
     def each &block
-      attributes.each(&block)
+      names.each(&block)
     end
 
     private

--- a/lib/mobility/backend/cache.rb
+++ b/lib/mobility/backend/cache.rb
@@ -33,11 +33,10 @@ this).
 
 =end
     module Cache
-      # @param [Class] backend_class
+      # @param [Attributes] attributes
       # @param [Boolean] option_value
-      # @param [Hash] _options
-      def self.apply(backend_class, option_value, **_options)
-        backend_class.include(self) if option_value
+      def self.apply(attributes, option_value, **_)
+        attributes.backend_class.include(self) if option_value
       end
 
       # @group Backend Accessors

--- a/lib/mobility/backend/cache.rb
+++ b/lib/mobility/backend/cache.rb
@@ -33,6 +33,7 @@ this).
 
 =end
     module Cache
+      # Applies cache option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
       def self.apply(attributes, option_value, **_)
@@ -41,8 +42,7 @@ this).
 
       # @group Backend Accessors
       # @!macro backend_reader
-      # @param [Hash] options
-      # @param [Boolean] cache
+      # @option options [Boolean] cache
       #   *false* to disable cache.
       def read(locale, **options)
         return super if options.delete(:cache) == false
@@ -54,8 +54,7 @@ this).
       end
 
       # @!macro backend_writer
-      # @param [Hash] options
-      # @param [Boolean] cache
+      # @option options [Boolean] cache
       #   *false* to disable cache.
       def write(locale, value, **options)
         return super if options.delete(:cache) == false

--- a/lib/mobility/backend/cache.rb
+++ b/lib/mobility/backend/cache.rb
@@ -33,6 +33,13 @@ this).
 
 =end
     module Cache
+      # @param [Class] backend_class
+      # @param [Boolean] value
+      # @param [Hash] _options
+      def self.apply(backend_class, value, **_options)
+        backend_class.include(self) unless value == false
+      end
+
       # @group Backend Accessors
       # @!macro backend_reader
       # @param [Hash] options

--- a/lib/mobility/backend/cache.rb
+++ b/lib/mobility/backend/cache.rb
@@ -36,7 +36,7 @@ this).
       # Applies cache option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
-      def self.apply(attributes, option_value, **_)
+      def self.apply(attributes, option_value)
         attributes.backend_class.include(self) if option_value
       end
 

--- a/lib/mobility/backend/cache.rb
+++ b/lib/mobility/backend/cache.rb
@@ -34,10 +34,10 @@ this).
 =end
     module Cache
       # @param [Class] backend_class
-      # @param [Boolean] value
+      # @param [Boolean] option_value
       # @param [Hash] _options
-      def self.apply(backend_class, value, **_options)
-        backend_class.include(self) unless value == false
+      def self.apply(backend_class, option_value, **_options)
+        backend_class.include(self) if option_value
       end
 
       # @group Backend Accessors

--- a/lib/mobility/backend/default.rb
+++ b/lib/mobility/backend/default.rb
@@ -7,6 +7,7 @@ otherwise be nil.
 
 @example With default enabled (falls through to default value)
   class Post
+    include Mobility
     translates :title, default: 'foo'
   end
 
@@ -19,6 +20,7 @@ otherwise be nil.
 
 @example Overriding default with reader option
   class Post
+    include Mobility
     translates :title, default: 'foo'
   end
 
@@ -37,6 +39,7 @@ otherwise be nil.
 
 @example Using Proc as default
   class Post
+    include Mobility
     translates :title, default: lambda { |model:, attribute:| attribute.to_s }
   end
 
@@ -44,19 +47,20 @@ otherwise be nil.
   post.title
   #=> "title"
 
-  post.title(default: lambda { |model:| model.class.name.to_s }
+  post.title(default: lambda { |model:| model.class.name.to_s })
   #=> "Post"
 =end
     module Default
+      # Applies default option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] _option_value
-      # @param [Hash] options
+      # @option options [Object] default Default value
       def self.apply(attributes, _option_value, **options)
         attributes.backend_class.include(self) if options.has_key?(:default)
       end
 
       # @!macro [new] backend_constructor
-      #   @option backend_options [Object] default Default value
+      # @option backend_options [Object] default Default value
       def initialize(*args, **backend_options)
         super
         @default = backend_options[:default]

--- a/lib/mobility/backend/default.rb
+++ b/lib/mobility/backend/default.rb
@@ -53,10 +53,9 @@ otherwise be nil.
     module Default
       # Applies default option module to attributes.
       # @param [Attributes] attributes
-      # @param [Boolean] _option_value
       # @option options [Object] default Default value
-      def self.apply(attributes, _option_value, **options)
-        attributes.backend_class.include(self) if options.has_key?(:default)
+      def self.apply(attributes, _)
+        attributes.backend_class.include(self) if attributes.options.has_key?(:default)
       end
 
       # @!macro [new] backend_constructor

--- a/lib/mobility/backend/default.rb
+++ b/lib/mobility/backend/default.rb
@@ -48,6 +48,13 @@ otherwise be nil.
   #=> "Post"
 =end
     module Default
+      # @param [Class] backend_class
+      # @param [Boolean] _value
+      # @param [Hash] options
+      def self.apply(backend_class, _value, **options)
+        backend_class.include(self) if options.has_key?(:default)
+      end
+
       # @!macro [new] backend_constructor
       #   @option backend_options [Object] default Default value
       def initialize(*args, **backend_options)

--- a/lib/mobility/backend/default.rb
+++ b/lib/mobility/backend/default.rb
@@ -55,7 +55,7 @@ otherwise be nil.
       # @param [Attributes] attributes
       # @option options [Object] default Default value
       def self.apply(attributes, _)
-        attributes.backend_class.include(self) if attributes.options.has_key?(:default)
+        attributes.backend_class.include(self)
       end
 
       # @!macro [new] backend_constructor

--- a/lib/mobility/backend/default.rb
+++ b/lib/mobility/backend/default.rb
@@ -48,11 +48,11 @@ otherwise be nil.
   #=> "Post"
 =end
     module Default
-      # @param [Class] backend_class
-      # @param [Boolean] _value
+      # @param [Attributes] attributes
+      # @param [Boolean] _option_value
       # @param [Hash] options
-      def self.apply(backend_class, _value, **options)
-        backend_class.include(self) if options.has_key?(:default)
+      def self.apply(attributes, _option_value, **options)
+        attributes.backend_class.include(self) if options.has_key?(:default)
       end
 
       # @!macro [new] backend_constructor

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -19,6 +19,14 @@ details.
 
 =end
     module Dirty
+      # @param [Class] backend_class
+      # @param [Boolean] value
+      # @param [Hash] options
+      # @option [Class] model_class
+      def self.apply(backend_class, value, **options)
+        backend_class.include(self.for(options[:model_class])) if value
+      end
+
       # @param model_class Class of model this backend is defined on.
       # @return [Backend]
       # @raise [ArgumentError] if model class does not support dirty tracking

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -24,8 +24,9 @@ details.
       # @param [Boolean] option_value
       # @option options [Class] model_class
       # @option options [Boolean] fallthrough_accessors
-      def self.apply(attributes, option_value, options)
+      def self.apply(attributes, option_value)
         if option_value
+          options = attributes.options
           options[:fallthrough_accessors] = true if options[:fallthrough_accessors] != false
           attributes.backend_class.include(self.for(options[:model_class]))
         end

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -19,10 +19,11 @@ details.
 
 =end
     module Dirty
+      # Applies dirty option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
-      # @param [Hash] options
-      # @option [Class] model_class
+      # @option options [Class] model_class
+      # @option options [Boolean] fallthrough_accessors
       def self.apply(attributes, option_value, options)
         if option_value
           options[:fallthrough_accessors] = true if options[:fallthrough_accessors] != false

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -22,8 +22,6 @@ details.
       # Applies dirty option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option
-      # @option options [Class] model_class
-      # @option options [Boolean] fallthrough_accessors
       def self.apply(attributes, option)
         if option
           FallthroughAccessors.apply(attributes, true)

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -21,11 +21,11 @@ details.
     module Dirty
       # Applies dirty option module to attributes.
       # @param [Attributes] attributes
-      # @param [Boolean] option_value
+      # @param [Boolean] option
       # @option options [Class] model_class
       # @option options [Boolean] fallthrough_accessors
-      def self.apply(attributes, option_value)
-        if option_value
+      def self.apply(attributes, option)
+        if option
           FallthroughAccessors.apply(attributes, true)
           attributes.backend_class.include(self.for(attributes.options[:model_class]))
         end

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -20,11 +20,11 @@ details.
 =end
     module Dirty
       # @param [Class] backend_class
-      # @param [Boolean] value
+      # @param [Boolean] option_value
       # @param [Hash] options
       # @option [Class] model_class
-      def self.apply(backend_class, value, model_class: nil, **_options)
-        if value
+      def self.apply(backend_class, option_value, model_class: nil, **_options)
+        if option_value
           options[:fallthrough_accessors] = true if options[:fallthrough_accessors] != false
           backend_class.include(self.for(model_class))
         end

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -23,10 +23,10 @@ details.
       # @param [Boolean] option_value
       # @param [Hash] options
       # @option [Class] model_class
-      def self.apply(backend_class, option_value, model_class: nil, **_options)
+      def self.apply(backend_class, option_value, options)
         if option_value
           options[:fallthrough_accessors] = true if options[:fallthrough_accessors] != false
-          backend_class.include(self.for(model_class))
+          backend_class.include(self.for(options[:model_class]))
         end
       end
 

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -19,14 +19,14 @@ details.
 
 =end
     module Dirty
-      # @param [Class] backend_class
+      # @param [Attributes] attributes
       # @param [Boolean] option_value
       # @param [Hash] options
       # @option [Class] model_class
-      def self.apply(backend_class, option_value, options)
+      def self.apply(attributes, option_value, options)
         if option_value
           options[:fallthrough_accessors] = true if options[:fallthrough_accessors] != false
-          backend_class.include(self.for(options[:model_class]))
+          attributes.backend_class.include(self.for(options[:model_class]))
         end
       end
 

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -23,8 +23,11 @@ details.
       # @param [Boolean] value
       # @param [Hash] options
       # @option [Class] model_class
-      def self.apply(backend_class, value, **options)
-        backend_class.include(self.for(options[:model_class])) if value
+      def self.apply(backend_class, value, model_class: nil, **_options)
+        if value
+          options[:fallthrough_accessors] = true if options[:fallthrough_accessors] != false
+          backend_class.include(self.for(model_class))
+        end
       end
 
       # @param model_class Class of model this backend is defined on.

--- a/lib/mobility/backend/dirty.rb
+++ b/lib/mobility/backend/dirty.rb
@@ -26,9 +26,8 @@ details.
       # @option options [Boolean] fallthrough_accessors
       def self.apply(attributes, option_value)
         if option_value
-          options = attributes.options
-          options[:fallthrough_accessors] = true if options[:fallthrough_accessors] != false
-          attributes.backend_class.include(self.for(options[:model_class]))
+          FallthroughAccessors.apply(attributes, true)
+          attributes.backend_class.include(self.for(attributes.options[:model_class]))
         end
       end
 

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -76,6 +76,13 @@ locale was +nil+.
   #=> "Mobilité"
 =end
     module Fallbacks
+      # @param [Class] backend_class
+      # @param [Boolean] value
+      # @param [Hash] _options
+      def self.apply(backend_class, value, **_options)
+        backend_class.include(self) unless value == false
+      end
+
       # @!macro [new] backend_constructor
       #   @param model Model on which backend is defined
       #   @param [String] attribute Backend attribute

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -84,23 +84,28 @@ locale was +nil+.
       end
 
       def initialize(fallbacks_option)
-        fallbacks = convert_option_to_fallbacks(fallbacks_option)
+        define_read(convert_option_to_fallbacks(fallbacks_option))
+      end
 
+      private
+
+      def define_read(fallbacks)
         define_method :read do |locale, **options|
           if !options[:fallbacks].nil?
             warn "You passed an option with key 'fallbacks', which will be ignored. Did you mean 'fallback'?"
           end
           fallback = options.delete(:fallback)
-          return super(locale, **options) if fallback == false || (fallback.nil? && fallbacks.nil?)
 
-          (fallback ? [locale, *fallback] : fallbacks[locale]).detect do |fallback_locale|
-            value = super(fallback_locale, **options)
-            break value if value.present?
+          if fallback == false || (fallback.nil? && fallbacks.nil?)
+            super(locale, **options)
+          else
+            (fallback ? [locale, *fallback] : fallbacks[locale]).detect do |fallback_locale|
+              value = super(fallback_locale, **options)
+              break value if value.present?
+            end
           end
         end
       end
-
-      private
 
       def convert_option_to_fallbacks(option)
         if option.is_a?(Hash)

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -91,9 +91,6 @@ locale was +nil+.
 
       def define_read(fallbacks)
         define_method :read do |locale, **options|
-          if !options[:fallbacks].nil?
-            warn "You passed an option with key 'fallbacks', which will be ignored. Did you mean 'fallback'?"
-          end
           fallback = options.delete(:fallback)
 
           if fallback == false || (fallback.nil? && fallbacks.nil?)

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -77,10 +77,10 @@ locale was +nil+.
 =end
     module Fallbacks
       # @param [Class] backend_class
-      # @param [Boolean] value
+      # @param [Boolean] option_value
       # @param [Hash] _options
-      def self.apply(backend_class, value, **_options)
-        backend_class.include(self) unless value == false
+      def self.apply(backend_class, option_value, **_options)
+        backend_class.include(self) unless option_value == false
       end
 
       # @!macro [new] backend_constructor

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -76,10 +76,10 @@ locale was +nil+.
   #=> "Mobilité"
 =end
     module Fallbacks
+      # Applies fallbacks option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
-      # @param [Hash] _options
-      def self.apply(attributes, option_value, **_options)
+      def self.apply(attributes, option_value, **_)
         attributes.backend_class.include(self) unless option_value == false
       end
 
@@ -99,7 +99,8 @@ locale was +nil+.
 
       # @!group Backend Accessors
       # @!macro backend_reader
-      # @param [Boolean,Symbol,Array] fallback
+      # @param [Hash] options
+      # @option options [Boolean,Symbol,Array] fallback
       #   +false+ to disable fallbacks on lookup, or a locale or array of
       #   locales to set fallback(s) for this lookup.
       def read(locale, **options)

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -79,7 +79,7 @@ locale was +nil+.
       # Applies fallbacks option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
-      def self.apply(attributes, option_value, **_)
+      def self.apply(attributes, option_value)
         attributes.backend_class.include(self) unless option_value == false
       end
 

--- a/lib/mobility/backend/fallbacks.rb
+++ b/lib/mobility/backend/fallbacks.rb
@@ -76,11 +76,11 @@ locale was +nil+.
   #=> "Mobilité"
 =end
     module Fallbacks
-      # @param [Class] backend_class
+      # @param [Attributes] attributes
       # @param [Boolean] option_value
       # @param [Hash] _options
-      def self.apply(backend_class, option_value, **_options)
-        backend_class.include(self) unless option_value == false
+      def self.apply(attributes, option_value, **_options)
+        attributes.backend_class.include(self) unless option_value == false
       end
 
       # @!macro [new] backend_constructor

--- a/lib/mobility/backend/presence.rb
+++ b/lib/mobility/backend/presence.rb
@@ -7,11 +7,10 @@ backend. Included by default, but can be disabled with presence: false option.
 
 =end
     module Presence
-      # @param [Class] backend_class
+      # @param [Attributes] attributes
       # @param [Boolean] option_value
-      # @param [Hash] _options
-      def self.apply(backend_class, option_value, **_options)
-        backend_class.include(self) if option_value
+      def self.apply(attributes, option_value, **_)
+        attributes.backend_class.include(self) if option_value
       end
 
       # @group Backend Accessors

--- a/lib/mobility/backend/presence.rb
+++ b/lib/mobility/backend/presence.rb
@@ -10,7 +10,7 @@ backend. Included by default, but can be disabled with +presence: false+ option.
       # Applies presence option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
-      def self.apply(attributes, option_value, **_)
+      def self.apply(attributes, option_value)
         attributes.backend_class.include(self) if option_value
       end
 

--- a/lib/mobility/backend/presence.rb
+++ b/lib/mobility/backend/presence.rb
@@ -9,9 +9,9 @@ backend. Included by default, but can be disabled with +presence: false+ option.
     module Presence
       # Applies presence option module to attributes.
       # @param [Attributes] attributes
-      # @param [Boolean] option_value
-      def self.apply(attributes, option_value)
-        attributes.backend_class.include(self) if option_value
+      # @param [Boolean] option
+      def self.apply(attributes, option)
+        attributes.backend_class.include(self) if option
       end
 
       # @group Backend Accessors

--- a/lib/mobility/backend/presence.rb
+++ b/lib/mobility/backend/presence.rb
@@ -3,10 +3,11 @@ module Mobility
 =begin
 
 Applies presence filter to values fetched from backend and to values set on
-backend. Included by default, but can be disabled with presence: false option.
+backend. Included by default, but can be disabled with +presence: false+ option.
 
 =end
     module Presence
+      # Applies presence option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
       def self.apply(attributes, option_value, **_)
@@ -15,7 +16,7 @@ backend. Included by default, but can be disabled with presence: false option.
 
       # @group Backend Accessors
       # @!macro backend_reader
-      # @param [Boolean] presence
+      # @option options [Boolean] presence
       #   *false* to disable presence filter.
       def read(locale, **options)
         return super if options.delete(:presence) == false
@@ -25,7 +26,7 @@ backend. Included by default, but can be disabled with presence: false option.
 
       # @group Backend Accessors
       # @!macro backend_writer
-      # @param [Boolean] presence
+      # @option options [Boolean] presence
       #   *false* to disable presence filter.
       def write(locale, value, **options)
         return super if options.delete(:presence) == false

--- a/lib/mobility/backend/presence.rb
+++ b/lib/mobility/backend/presence.rb
@@ -8,10 +8,10 @@ backend. Included by default, but can be disabled with presence: false option.
 =end
     module Presence
       # @param [Class] backend_class
-      # @param [Boolean] value
+      # @param [Boolean] option_value
       # @param [Hash] _options
-      def self.apply(backend_class, value, **_options)
-        backend_class.include(self) unless value == false
+      def self.apply(backend_class, option_value, **_options)
+        backend_class.include(self) if option_value
       end
 
       # @group Backend Accessors

--- a/lib/mobility/backend/presence.rb
+++ b/lib/mobility/backend/presence.rb
@@ -7,6 +7,13 @@ backend. Included by default, but can be disabled with presence: false option.
 
 =end
     module Presence
+      # @param [Class] backend_class
+      # @param [Boolean] value
+      # @param [Hash] _options
+      def self.apply(backend_class, value, **_options)
+        backend_class.include(self) unless value == false
+      end
+
       # @group Backend Accessors
       # @!macro backend_reader
       # @param [Boolean] presence

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -5,6 +5,8 @@ Stores shared Mobility configuration referenced by all backends.
 
 =end
   class Configuration
+    RESERVED_OPTION_KEYS = %i[backend model_class].freeze
+
     # Alias for mobility_accessor (defaults to +translates+)
     # @return [Symbol]
     attr_accessor :accessor_method
@@ -14,9 +16,18 @@ Stores shared Mobility configuration referenced by all backends.
     attr_accessor :query_method
 
     # Default set of options. These will be merged with any backend options
-    # when defining translated attributes (with +translates+).
+    # when defining translated attributes (with +translates+). Default options
+    # may not include the keys 'backend' or 'model_class'.
     # @return [Hash]
-    attr_accessor :default_options
+    attr_reader :default_options
+    def default_options=(options)
+      if (keys = options.keys & RESERVED_OPTION_KEYS).present?
+        raise ReservedOptionKey,
+          "Default options may not contain the following reserved keys: #{keys.join(', ')}"
+      else
+        @default_options = options
+      end
+    end
 
     # Option modules to apply. Defines which module to apply for each option
     # key. Order of hash keys/values is important, as this becomes the order in
@@ -70,5 +81,7 @@ Stores shared Mobility configuration referenced by all backends.
         locale_accessors:      LocaleAccessors
       }
     end
+
+    class ReservedOptionKey < Exception; end
   end
 end

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -17,6 +17,10 @@ Stores shared Mobility configuration referenced by all backends.
     # @return [Hash]
     attr_accessor :default_options
 
+    # Option modules to apply
+    # @return [Hash]
+    attr_accessor :option_modules
+
     # Default fallbacks instance
     # @return [I18n::Locale::Fallbacks]
     def default_fallbacks(fallbacks = {})
@@ -49,7 +53,17 @@ Stores shared Mobility configuration referenced by all backends.
         cache: true,
         dirty: false,
         fallbacks: nil,
-        presence: true
+        presence: true,
+        default: nil
+      }
+      @option_modules = {
+        cache:                 Backend::Cache,
+        dirty:                 Backend::Dirty,
+        fallbacks:             Backend::Fallbacks,
+        presence:              Backend::Presence,
+        default:               Backend::Default,
+        fallthrough_accessors: FallthroughAccessors,
+        locale_accessors:      LocaleAccessors
       }
     end
   end

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -13,11 +13,15 @@ Stores shared Mobility configuration referenced by all backends.
     # @return [Symbol]
     attr_accessor :query_method
 
-    # Default set of options
+    # Default set of options. These will be merged with any backend options
+    # when defining translated attributes (with +translates+).
     # @return [Hash]
     attr_accessor :default_options
 
-    # Option modules to apply
+    # Option modules to apply. Defines which module to apply for each option
+    # key. Order of hash keys/values is important, as this becomes the order in
+    # which modules are applied and included into the backend class or
+    # attributes instance.
     # @return [Hash]
     attr_accessor :option_modules
 

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -13,6 +13,10 @@ Stores shared Mobility configuration referenced by all backends.
     # @return [Symbol]
     attr_accessor :query_method
 
+    # Default set of options
+    # @return [Hash]
+    attr_accessor :default_options
+
     # Default fallbacks instance
     # @return [I18n::Locale::Fallbacks]
     def default_fallbacks(fallbacks = {})
@@ -41,6 +45,12 @@ Stores shared Mobility configuration referenced by all backends.
       @query_method = :i18n
       @default_fallbacks = lambda { |fallbacks| I18n::Locale::Fallbacks.new(fallbacks) }
       @default_accessor_locales = lambda { I18n.available_locales }
+      @default_options = {
+        cache: true,
+        dirty: false,
+        fallbacks: nil,
+        presence: true
+      }
     end
   end
 end

--- a/lib/mobility/fallthrough_accessors.rb
+++ b/lib/mobility/fallthrough_accessors.rb
@@ -37,7 +37,7 @@ model class is generated.
     # @param [Attributes] attributes
     # @param [Boolean] option_value
     def self.apply(attributes, option_value, **_)
-      attributes.include new(*attributes.attributes) if option_value
+      attributes.include new(*attributes.names) if option_value
     end
 
     # @param [String] One or more attributes

--- a/lib/mobility/fallthrough_accessors.rb
+++ b/lib/mobility/fallthrough_accessors.rb
@@ -36,9 +36,9 @@ model class is generated.
   class FallthroughAccessors < Module
     # Apply fallthrough accessors option module to attributes.
     # @param [Attributes] attributes
-    # @param [Boolean] option_value
-    def self.apply(attributes, option_value)
-      attributes.include new(*attributes.names) if option_value
+    # @param [Boolean] option
+    def self.apply(attributes, option)
+      attributes.include new(*attributes.names) if option
     end
 
     # @param [String] One or more attributes

--- a/lib/mobility/fallthrough_accessors.rb
+++ b/lib/mobility/fallthrough_accessors.rb
@@ -34,6 +34,12 @@ model class is generated.
 
 =end
   class FallthroughAccessors < Module
+    # @param [Attributes] attributes
+    # @param [Boolean] option_value
+    def self.apply(attributes, option_value, **_)
+      attributes.include new(*attributes.attributes) if option_value
+    end
+
     # @param [String] One or more attributes
     def initialize(*attributes)
       method_name_regex = /\A(#{attributes.join('|'.freeze)})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze

--- a/lib/mobility/fallthrough_accessors.rb
+++ b/lib/mobility/fallthrough_accessors.rb
@@ -34,6 +34,7 @@ model class is generated.
 
 =end
   class FallthroughAccessors < Module
+    # Apply fallthrough accessors option module to attributes.
     # @param [Attributes] attributes
     # @param [Boolean] option_value
     def self.apply(attributes, option_value, **_)

--- a/lib/mobility/fallthrough_accessors.rb
+++ b/lib/mobility/fallthrough_accessors.rb
@@ -37,7 +37,7 @@ model class is generated.
     # Apply fallthrough accessors option module to attributes.
     # @param [Attributes] attributes
     # @param [Boolean] option_value
-    def self.apply(attributes, option_value, **_)
+    def self.apply(attributes, option_value)
       attributes.include new(*attributes.names) if option_value
     end
 

--- a/lib/mobility/locale_accessors.rb
+++ b/lib/mobility/locale_accessors.rb
@@ -30,8 +30,7 @@ If no locales are passed as an option to the initializer,
   class LocaleAccessors < Module
     # @param [Attributes] attributes
     # @param [Boolean] option_value
-    # @param [Hash] options
-    def self.apply(attributes, option_value, **options)
+    def self.apply(attributes, option_value, **_)
       if accessor_locales = option_value
         accessor_locales = Mobility.config.default_accessor_locales if accessor_locales == true
         attributes.include new(*attributes.names, locales: accessor_locales)

--- a/lib/mobility/locale_accessors.rb
+++ b/lib/mobility/locale_accessors.rb
@@ -30,9 +30,9 @@ If no locales are passed as an option to the initializer,
   class LocaleAccessors < Module
     # Apply locale accessors option module to attributes.
     # @param [Attributes] attributes
-    # @param [Boolean] option_value
-    def self.apply(attributes, option_value)
-      if accessor_locales = option_value
+    # @param [Boolean] option
+    def self.apply(attributes, option)
+      if accessor_locales = option
         accessor_locales = Mobility.config.default_accessor_locales if accessor_locales == true
         attributes.include new(*attributes.names, locales: accessor_locales)
       end

--- a/lib/mobility/locale_accessors.rb
+++ b/lib/mobility/locale_accessors.rb
@@ -28,6 +28,16 @@ If no locales are passed as an option to the initializer,
 
 =end
   class LocaleAccessors < Module
+    # @param [Attributes] attributes
+    # @param [Boolean] option_value
+    # @param [Hash] options
+    def self.apply(attributes, option_value, **options)
+      if accessor_locales = option_value
+        accessor_locales = Mobility.config.default_accessor_locales if accessor_locales == true
+        attributes.include new(*attributes.attributes, locales: accessor_locales)
+      end
+    end
+
     # @param [String] One or more attributes
     # @param [Array<Symbol>] Locales
     def initialize(*attributes, locales: I18n.available_locales)

--- a/lib/mobility/locale_accessors.rb
+++ b/lib/mobility/locale_accessors.rb
@@ -31,7 +31,7 @@ If no locales are passed as an option to the initializer,
     # Apply locale accessors option module to attributes.
     # @param [Attributes] attributes
     # @param [Boolean] option_value
-    def self.apply(attributes, option_value, **_)
+    def self.apply(attributes, option_value)
       if accessor_locales = option_value
         accessor_locales = Mobility.config.default_accessor_locales if accessor_locales == true
         attributes.include new(*attributes.names, locales: accessor_locales)

--- a/lib/mobility/locale_accessors.rb
+++ b/lib/mobility/locale_accessors.rb
@@ -34,7 +34,7 @@ If no locales are passed as an option to the initializer,
     def self.apply(attributes, option_value, **options)
       if accessor_locales = option_value
         accessor_locales = Mobility.config.default_accessor_locales if accessor_locales == true
-        attributes.include new(*attributes.attributes, locales: accessor_locales)
+        attributes.include new(*attributes.names, locales: accessor_locales)
       end
     end
 

--- a/lib/mobility/locale_accessors.rb
+++ b/lib/mobility/locale_accessors.rb
@@ -28,6 +28,7 @@ If no locales are passed as an option to the initializer,
 
 =end
   class LocaleAccessors < Module
+    # Apply locale accessors option module to attributes.
     # @param [Attributes] attributes
     # @param [Boolean] option_value
     def self.apply(attributes, option_value, **_)

--- a/lib/mobility/wrapper.rb
+++ b/lib/mobility/wrapper.rb
@@ -19,7 +19,7 @@ simple delegator, so any missing method will be delegated to the model class.
 
     # @return [Array<String>] Translated attributes defined on model
     def translated_attribute_names
-      modules.map(&:attributes).flatten
+      modules.map(&:names).flatten
     end
 
     # Appends backend module to +modules+ array for later reference.

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -132,9 +132,9 @@ describe Mobility::Attributes do
     end
 
     describe "default" do
-      it "includes Backend::Default into backend when options has key :default" do
+      it "includes Backend::Default into backend" do
         expect(backend_class).to receive(:include).with(Mobility::Backend::Default)
-        described_class.new(:accessor, "title", clean_options.merge(backend: backend_class, default: nil))
+        described_class.new(:accessor, "title", clean_options.merge(backend: backend_class))
       end
     end
 

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -78,13 +78,13 @@ describe Mobility::Attributes do
     describe "dirty" do
       context "ActiveModel", orm: :active_record do
         it "includes Backend::ActiveModel::Dirty into backend when options[:dirty] is truthy and model class includes ActiveModel::Dirty" do
-          expect(backend_class).to receive(:include).with(Mobility::Backend::ActiveModel::Dirty)
           Article.include ::ActiveModel::Dirty
-          described_class.new(:accessor, "title", clean_options.merge(
+          attributes = described_class.new(:accessor, "title", clean_options.merge(
             backend: backend_class,
             dirty: true,
             model_class: Article
           ))
+          expect(attributes.backend_class.ancestors).to include(Mobility::Backend::ActiveModel::Dirty)
         end
 
         it "does not include Backend::Model::Dirty into backend when options[:dirty] is falsey" do
@@ -100,12 +100,12 @@ describe Mobility::Attributes do
         end
 
         it "includes Backend::Sequel::Dirty into backend when options[:dirty] is truthy and model class is a ::Sequel::Model" do
-          expect(backend_class).to receive(:include).with(Mobility::Backend::Sequel::Dirty)
-          described_class.new(:accessor, "title", clean_options.merge(
+          attributes = described_class.new(:accessor, "title", clean_options.merge(
             backend: backend_class,
             dirty: true,
             model_class: Article
           ))
+          expect(attributes.backend_class.ancestors).to include(Mobility::Backend::Sequel::Dirty)
         end
 
         it "does not include Backend::Sequel::Dirty into backend when options[:dirty] is falsey" do

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -47,7 +47,7 @@ describe Mobility::Attributes do
 
   describe "including Attributes in a model" do
     it "calls configure on backend class with options" do
-      expect(backend_class).to receive(:configure).with({ foo: "bar" })
+      expect(backend_class).to receive(:configure).with(Mobility.default_options.merge(foo: "bar"))
       described_class.new(:accessor, "title", { backend: backend_class, foo: "bar" })
     end
 

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -46,12 +46,12 @@ describe Mobility::Attributes do
   end
 
   describe "including Attributes in a model" do
-    it "calls configure on backend class with options" do
+    it "calls configure on backend class with options merged with default options" do
       expect(backend_class).to receive(:configure).with(Mobility.default_options.merge(foo: "bar"))
       described_class.new(:accessor, "title", { backend: backend_class, foo: "bar" })
     end
 
-    it "calls setup_model on backend class with model_class, attributes, and options" do
+    it "calls setup_model on backend class with model_class, attributes, and options merged with default options" do
       expect(backend_class).to receive(:setup_model).with(Article, ["title"], Mobility.default_options)
       Article.include described_class.new(:accessor, "title", { backend: backend_class })
     end
@@ -72,69 +72,6 @@ describe Mobility::Attributes do
       it "does not include Backend::Cache into backend when options[:cache] is false" do
         attributes = described_class.new(:accessor, "title", clean_options.merge(backend: backend_class))
         expect(attributes.backend_class.ancestors).not_to include(Mobility::Backend::Cache)
-      end
-    end
-
-    describe "dirty" do
-      context "ActiveModel", orm: :active_record do
-        it "includes Backend::ActiveModel::Dirty into backend when options[:dirty] is truthy and model class includes ActiveModel::Dirty" do
-          Article.include ::ActiveModel::Dirty
-          attributes = described_class.new(:accessor, "title", clean_options.merge(
-            backend: backend_class,
-            dirty: true,
-            model_class: Article
-          ))
-          expect(attributes.backend_class.ancestors).to include(Mobility::Backend::ActiveModel::Dirty)
-        end
-
-        it "does not include Backend::Model::Dirty into backend when options[:dirty] is falsey" do
-          expect(backend_class).not_to receive(:include).with(Mobility::Backend::ActiveModel::Dirty)
-          described_class.new(:accessor, "title", clean_options.merge(backend: backend_class, model_class: Article))
-        end
-      end
-
-      context "Sequel", orm: :sequel do
-        before do
-          stub_const 'Article', Class.new(::Sequel::Model)
-          Article.include Mobility
-        end
-
-        it "includes Backend::Sequel::Dirty into backend when options[:dirty] is truthy and model class is a ::Sequel::Model" do
-          attributes = described_class.new(:accessor, "title", clean_options.merge(
-            backend: backend_class,
-            dirty: true,
-            model_class: Article
-          ))
-          expect(attributes.backend_class.ancestors).to include(Mobility::Backend::Sequel::Dirty)
-        end
-
-        it "does not include Backend::Sequel::Dirty into backend when options[:dirty] is falsey" do
-          expect(backend_class).not_to receive(:include).with(Mobility::Backend::Sequel::Dirty)
-          Article.include described_class.new(:accessor, "title", clean_options.merge(
-            backend: backend_class,
-            model_class: Article
-          ))
-        end
-      end
-    end
-
-    describe "fallbacks" do
-      it "includes Backend::Fallbacks into backend when options[:fallbacks] is not false" do
-        clean_options.delete(:fallbacks)
-        attributes = described_class.new(:accessor, "title", clean_options.merge(backend: backend_class))
-        expect(attributes.backend_class.ancestors).to include(Mobility::Backend::Fallbacks)
-      end
-
-      it "does not include Backend::Fallbacks into backend when options[:fallbacks] is false" do
-        expect(backend_class).not_to receive(:include).with(Mobility::Backend::Fallbacks)
-        described_class.new(:accessor, "title", clean_options.merge(backend: backend_class))
-      end
-    end
-
-    describe "default" do
-      it "includes Backend::Default into backend" do
-        expect(backend_class).to receive(:include).with(Mobility::Backend::Default)
-        described_class.new(:accessor, "title", clean_options.merge(backend: backend_class))
       end
     end
 

--- a/spec/mobility/backend/cache_spec.rb
+++ b/spec/mobility/backend/cache_spec.rb
@@ -1,201 +1,225 @@
 require "spec_helper"
 
 describe Mobility::Backend::Cache do
-  let(:backend_class) do
-    Class.new(Mobility::Backend::Null) do
-      def read(*args)
-        backend_double.read(*args)
+  describe "when included into a class" do
+    let(:backend_class) do
+      Class.new(Mobility::Backend::Null) do
+        def read(*args)
+          backend_double.read(*args)
+        end
+
+        def write(*args)
+          backend_double.write(*args)
+        end
+
+        def backend_double
+          @backend_double ||= RSpec::Mocks::Double.new("backend")
+        end
+      end
+    end
+    let(:cached_backend_class) { Class.new(backend_class).include(described_class) }
+    let(:options) { { these: "options" } }
+    let(:locale) { :cz }
+
+    describe "#read" do
+      it "caches reads" do
+        backend = cached_backend_class.new("model", "attribute")
+        expect(backend.backend_double).to receive(:read).once.with(locale, options).and_return("foo")
+        2.times { expect(backend.read(locale, options)).to eq("foo") }
       end
 
-      def write(*args)
-        backend_double.write(*args)
+      it "does not cache reads with cache: false option" do
+        backend = cached_backend_class.new("model", "attribute")
+        expect(backend.backend_double).to receive(:read).twice.with(locale, options).and_return("foo")
+        2.times { expect(backend.read(locale, options.merge(cache: false))).to eq("foo") }
       end
 
-      def backend_double
-        @backend_double ||= RSpec::Mocks::Double.new("backend")
+      it "always returns from cache if backend defines write_to_cache? to return true" do
+        cache = double("cache")
+        backend_class.class_eval do
+          def write_to_cache?
+            true
+          end
+
+          define_method :new_cache do
+            cache
+          end
+        end
+        backend = cached_backend_class.new("model", "attribute")
+        expect(backend.backend_double).not_to receive(:read)
+        expect(cache).to receive(:[]).twice.with(locale).and_return("foo")
+        2.times { expect(backend.read(locale, options)).to eq("foo") }
+      end
+    end
+
+    describe "#write" do
+      it "returns value fetched from backend" do
+        backend = cached_backend_class.new("model", "attribute")
+        expect(backend.backend_double).to receive(:write).twice.with(locale, "foo", options).and_return("bar")
+        2.times { expect(backend.write(locale, "foo", options)).to eq("bar") }
+      end
+
+      it "stores value fetched from backend in cache" do
+        cache = double("cache")
+        backend_class.class_eval do
+          def write_to_cache?
+            true
+          end
+
+          define_method :new_cache do
+            cache
+          end
+        end
+        backend = cached_backend_class.new("model", "attribute")
+        expect(backend.backend_double).not_to receive(:write)
+        expect(cache).to receive(:[]=).twice.with(locale, "foo")
+        2.times { expect(backend.write(locale, "foo", options)).to eq("foo") }
+      end
+
+      it "does not store value in cache with cache: false option" do
+        cache = double("cache")
+        backend_class.class_eval do
+          define_method :new_cache do
+            cache
+          end
+        end
+        backend = cached_backend_class.new("model", "attribute")
+        expect(backend.backend_double).to receive(:write).once.with(locale, "foo", options).and_return("bar")
+        expect(backend).not_to receive(:write_to_cache?)
+        expect(backend.write(locale, "foo", options.merge(cache: false))).to eq("bar")
+      end
+    end
+
+    describe "#clear_cache" do
+      it "reads from backend after cache cleared" do
+        backend = cached_backend_class.new("model", "attribute")
+        expect(backend.backend_double).to receive(:read).twice.with(locale, options).and_return("foo")
+        2.times { expect(backend.read(locale, options)).to eq("foo") }
+        backend.clear_cache
+        expect(backend.read(locale, options)).to eq("foo")
+      end
+    end
+
+    describe "resetting cache on actions" do
+      shared_examples_for "cache that resets on model action" do |action, options = nil|
+        it "updates backend cache on #{action}" do
+          backend = @article.mobility_backend_for("title")
+
+          aggregate_failures "reading and writing" do
+            expect(backend.backend_double).to receive(:write).with(:en, "foo", {}).and_return("foo set")
+            backend.write(:en, "foo")
+            expect(backend.read(:en)).to eq("foo set")
+          end
+
+          aggregate_failures "resetting model" do
+            options ? @article.send(action, options) : @article.send(action)
+            expect(backend.backend_double).to receive(:read).with(:en, {}).and_return("from backend")
+            expect(backend.read(:en)).to eq("from backend")
+          end
+        end
+      end
+
+      shared_examples_for "cache that resets on model action with multiple backends" do |action, options = nil|
+        it "updates cache on both backends on #{action}" do
+          title_backend = @article.mobility_backend_for("title")
+          content_backend = @article.mobility_backend_for("content")
+
+          aggregate_failures "reading and writing" do
+            expect(title_backend.backend_double).to receive(:write).with(:en, "foo", {}).and_return("foo set")
+            expect(content_backend.backend_double).to receive(:write).with(:en, "bar", {}).and_return("bar set")
+            title_backend.write(:en, "foo")
+            content_backend.write(:en, "bar")
+            expect(title_backend.read(:en)).to eq("foo set")
+            expect(content_backend.read(:en)).to eq("bar set")
+          end
+
+          aggregate_failures "resetting model" do
+            options ? @article.send(action, options) : @article.send(action)
+            expect(title_backend.backend_double).to receive(:read).with(:en, {}).and_return("from title backend")
+            expect(title_backend.read(:en)).to eq("from title backend")
+            expect(content_backend.backend_double).to receive(:read).with(:en, {}).and_return("from content backend")
+            expect(content_backend.read(:en)).to eq("from content backend")
+          end
+        end
+      end
+
+      context "ActiveRecord model", orm: :active_record do
+        before do
+          stub_const 'Article', Class.new(ActiveRecord::Base)
+          Article.include Mobility
+        end
+
+        context "with one backend" do
+          before do
+            Article.translates :title, backend: backend_class, cache: true
+            @article = Article.create
+          end
+
+          it_behaves_like "cache that resets on model action", :reload
+          it_behaves_like "cache that resets on model action", :reload, { readonly: true, lock: true }
+          it_behaves_like "cache that resets on model action", :save
+        end
+
+        context "with multiple backends" do
+          before do
+            other_backend = Class.new(backend_class)
+            Article.translates :title,   backend: backend_class, cache: true
+            Article.translates :content, backend: other_backend, cache: true
+            @article = Article.create
+          end
+          it_behaves_like "cache that resets on model action with multiple backends", :reload
+          it_behaves_like "cache that resets on model action with multiple backends", :reload, { readonly: true, lock: true }
+          it_behaves_like "cache that resets on model action with multiple backends", :save
+        end
+      end
+
+      context "Sequel model", orm: :sequel do
+        before do
+          stub_const 'Article', Class.new(Sequel::Model)
+          Article.dataset = DB[:articles]
+          Article.include Mobility
+        end
+
+        context "with one backend" do
+          before do
+            Article.translates :title, backend: backend_class, cache: true
+            @article = Article.create
+          end
+
+          it_behaves_like "cache that resets on model action", :refresh
+        end
+
+        context "with multiple backends" do
+          before do
+            other_backend = Class.new(backend_class)
+            Article.translates :title,   backend: backend_class, cache: true
+            Article.translates :content, backend: other_backend, cache: true
+            @article = Article.create
+          end
+          it_behaves_like "cache that resets on model action with multiple backends", :refresh
+        end
       end
     end
   end
-  let(:cached_backend_class) { Class.new(backend_class).include(described_class) }
-  let(:options) { { these: "options" } }
-  let(:locale) { :cz }
 
-  describe "#read" do
-    it "caches reads" do
-      backend = cached_backend_class.new("model", "attribute")
-      expect(backend.backend_double).to receive(:read).once.with(locale, options).and_return("foo")
-      2.times { expect(backend.read(locale, options)).to eq("foo") }
-    end
-
-    it "does not cache reads with cache: false option" do
-      backend = cached_backend_class.new("model", "attribute")
-      expect(backend.backend_double).to receive(:read).twice.with(locale, options).and_return("foo")
-      2.times { expect(backend.read(locale, options.merge(cache: false))).to eq("foo") }
-    end
-
-    it "always returns from cache if backend defines write_to_cache? to return true" do
-      cache = double("cache")
-      backend_class.class_eval do
-        def write_to_cache?
-          true
-        end
-
-        define_method :new_cache do
-          cache
-        end
-      end
-      backend = cached_backend_class.new("model", "attribute")
-      expect(backend.backend_double).not_to receive(:read)
-      expect(cache).to receive(:[]).twice.with(locale).and_return("foo")
-      2.times { expect(backend.read(locale, options)).to eq("foo") }
-    end
-  end
-
-  describe "#write" do
-    it "returns value fetched from backend" do
-      backend = cached_backend_class.new("model", "attribute")
-      expect(backend.backend_double).to receive(:write).twice.with(locale, "foo", options).and_return("bar")
-      2.times { expect(backend.write(locale, "foo", options)).to eq("bar") }
-    end
-
-    it "stores value fetched from backend in cache" do
-      cache = double("cache")
-      backend_class.class_eval do
-        def write_to_cache?
-          true
-        end
-
-        define_method :new_cache do
-          cache
-        end
-      end
-      backend = cached_backend_class.new("model", "attribute")
-      expect(backend.backend_double).not_to receive(:write)
-      expect(cache).to receive(:[]=).twice.with(locale, "foo")
-      2.times { expect(backend.write(locale, "foo", options)).to eq("foo") }
-    end
-
-    it "does not store value in cache with cache: false option" do
-      cache = double("cache")
-      backend_class.class_eval do
-        define_method :new_cache do
-          cache
-        end
-      end
-      backend = cached_backend_class.new("model", "attribute")
-      expect(backend.backend_double).to receive(:write).once.with(locale, "foo", options).and_return("bar")
-      expect(backend).not_to receive(:write_to_cache?)
-      expect(backend.write(locale, "foo", options.merge(cache: false))).to eq("bar")
-    end
-  end
-
-  describe "#clear_cache" do
-    it "reads from backend after cache cleared" do
-      backend = cached_backend_class.new("model", "attribute")
-      expect(backend.backend_double).to receive(:read).twice.with(locale, options).and_return("foo")
-      2.times { expect(backend.read(locale, options)).to eq("foo") }
-      backend.clear_cache
-      expect(backend.read(locale, options)).to eq("foo")
-    end
-  end
-
-  describe "resetting cache on actions" do
-    shared_examples_for "cache that resets on model action" do |action, options = nil|
-      it "updates backend cache on #{action}" do
-        backend = @article.mobility_backend_for("title")
-
-        aggregate_failures "reading and writing" do
-          expect(backend.backend_double).to receive(:write).with(:en, "foo", {}).and_return("foo set")
-          backend.write(:en, "foo")
-          expect(backend.read(:en)).to eq("foo set")
-        end
-
-        aggregate_failures "resetting model" do
-          options ? @article.send(action, options) : @article.send(action)
-          expect(backend.backend_double).to receive(:read).with(:en, {}).and_return("from backend")
-          expect(backend.read(:en)).to eq("from backend")
-        end
+  # this is identical to apply specs for Presence, and can probably be refactored
+  describe ".apply" do
+    context "option value is truthy" do
+      it "includes Cache into backend class" do
+        backend_class = double("backend class")
+        attributes = instance_double(Mobility::Attributes, backend_class: backend_class)
+        expect(backend_class).to receive(:include).twice.with(described_class)
+        described_class.apply(attributes, true)
+        described_class.apply(attributes, [])
       end
     end
 
-    shared_examples_for "cache that resets on model action with multiple backends" do |action, options = nil|
-      it "updates cache on both backends on #{action}" do
-        title_backend = @article.mobility_backend_for("title")
-        content_backend = @article.mobility_backend_for("content")
-
-        aggregate_failures "reading and writing" do
-          expect(title_backend.backend_double).to receive(:write).with(:en, "foo", {}).and_return("foo set")
-          expect(content_backend.backend_double).to receive(:write).with(:en, "bar", {}).and_return("bar set")
-          title_backend.write(:en, "foo")
-          content_backend.write(:en, "bar")
-          expect(title_backend.read(:en)).to eq("foo set")
-          expect(content_backend.read(:en)).to eq("bar set")
-        end
-
-        aggregate_failures "resetting model" do
-          options ? @article.send(action, options) : @article.send(action)
-          expect(title_backend.backend_double).to receive(:read).with(:en, {}).and_return("from title backend")
-          expect(title_backend.read(:en)).to eq("from title backend")
-          expect(content_backend.backend_double).to receive(:read).with(:en, {}).and_return("from content backend")
-          expect(content_backend.read(:en)).to eq("from content backend")
-        end
-      end
-    end
-
-    context "ActiveRecord model", orm: :active_record do
-      before do
-        stub_const 'Article', Class.new(ActiveRecord::Base)
-        Article.include Mobility
-      end
-
-      context "with one backend" do
-        before do
-          Article.translates :title, backend: backend_class, cache: true
-          @article = Article.create
-        end
-
-        it_behaves_like "cache that resets on model action", :reload
-        it_behaves_like "cache that resets on model action", :reload, { readonly: true, lock: true }
-        it_behaves_like "cache that resets on model action", :save
-      end
-
-      context "with multiple backends" do
-        before do
-          other_backend = Class.new(backend_class)
-          Article.translates :title,   backend: backend_class, cache: true
-          Article.translates :content, backend: other_backend, cache: true
-          @article = Article.create
-        end
-        it_behaves_like "cache that resets on model action with multiple backends", :reload
-        it_behaves_like "cache that resets on model action with multiple backends", :reload, { readonly: true, lock: true }
-        it_behaves_like "cache that resets on model action with multiple backends", :save
-      end
-    end
-
-    context "Sequel model", orm: :sequel do
-      before do
-        stub_const 'Article', Class.new(Sequel::Model)
-        Article.dataset = DB[:articles]
-        Article.include Mobility
-      end
-
-      context "with one backend" do
-        before do
-          Article.translates :title, backend: backend_class, cache: true
-          @article = Article.create
-        end
-
-        it_behaves_like "cache that resets on model action", :refresh
-      end
-
-      context "with multiple backends" do
-        before do
-          other_backend = Class.new(backend_class)
-          Article.translates :title,   backend: backend_class, cache: true
-          Article.translates :content, backend: other_backend, cache: true
-          @article = Article.create
-        end
-        it_behaves_like "cache that resets on model action with multiple backends", :refresh
+    context "option value is falsey" do
+      it "does not include Cache into backend class" do
+        attributes = instance_double(Mobility::Attributes)
+        expect(attributes).not_to receive(:backend_class)
+        described_class.apply(attributes, false)
+        described_class.apply(attributes, nil)
       end
     end
   end

--- a/spec/mobility/backend/default_spec.rb
+++ b/spec/mobility/backend/default_spec.rb
@@ -1,68 +1,82 @@
 require "spec_helper"
 
 describe Mobility::Backend::Default do
-  let(:default) { 'default foo' }
-  let(:backend_double) { double("backend") }
-  let(:backend) { backend_class.new("model", "title", default: default) }
-  let(:backend_class) do
-    backend_double_ = backend_double
-    backend_class = Class.new(Mobility::Backend::Null) do
-      define_method :read do |*args|
-        backend_double_.read(*args)
+  describe "when included into a class" do
+    let(:default) { 'default foo' }
+    let(:backend_double) { double("backend") }
+    let(:backend) { backend_class.new("model", "title", default: default) }
+    let(:backend_class) do
+      backend_double_ = backend_double
+      backend_class = Class.new(Mobility::Backend::Null) do
+        define_method :read do |*args|
+          backend_double_.read(*args)
+        end
+
+        define_method :write do |*args|
+          backend_double_.write(*args)
+        end
+      end
+      Class.new(backend_class).include(described_class.new(default))
+    end
+
+    describe "#read" do
+      it "returns value if not nil" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("foo")
+        expect(backend.read(:fr)).to eq("foo")
       end
 
-      define_method :write do |*args|
-        backend_double_.write(*args)
+      it "returns value if value is false" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(false)
+        expect(backend.read(:fr)).to eq(false)
+      end
+
+      it "returns default if backend return value is nil" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(backend.read(:fr)).to eq("default foo")
+      end
+
+      it "returns value of default override if passed as option to reader" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(backend.read(:fr, default: "default bar")).to eq("default bar")
+      end
+
+      it "returns nil if passed default: nil as option to reader" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(backend.read(:fr, default: nil)).to eq(nil)
+      end
+
+      it "returns false if passed default: false as option to reader" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(backend.read(:fr, default: false)).to eq(false)
+      end
+
+      context "default is a Proc" do
+        let(:default) { lambda { |model:, attribute:| "#{model} #{attribute}" } }
+
+        it "calls default with model and attribute as args if default is a Proc" do
+          expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+          expect(backend.read(:fr)).to eq('model title')
+        end
+
+        it "calls default with model and attribute as args if default option is a Proc" do
+          expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+          expect(backend.read(:fr, default: lambda do |model:, attribute:|
+            "#{model} #{attribute} from options"
+          end)).to eq('model title from options')
+        end
       end
     end
-    Class.new(backend_class).include(described_class.new(default))
   end
 
-  describe "#read" do
-    it "returns value if not nil" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("foo")
-      expect(backend.read(:fr)).to eq("foo")
-    end
+  describe ".apply" do
+    it "includes instance of default into backend class" do
+      backend_class = double("backend class")
+      attributes = instance_double(Mobility::Attributes, backend_class: backend_class)
+      default = instance_double(described_class)
 
-    it "returns value if value is false" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(false)
-      expect(backend.read(:fr)).to eq(false)
-    end
-
-    it "returns default if backend return value is nil" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
-      expect(backend.read(:fr)).to eq("default foo")
-    end
-
-    it "returns value of default override if passed as option to reader" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
-      expect(backend.read(:fr, default: "default bar")).to eq("default bar")
-    end
-
-    it "returns nil if passed default: nil as option to reader" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
-      expect(backend.read(:fr, default: nil)).to eq(nil)
-    end
-
-    it "returns false if passed default: false as option to reader" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
-      expect(backend.read(:fr, default: false)).to eq(false)
-    end
-
-    context "default is a Proc" do
-      let(:default) { lambda { |model:, attribute:| "#{model} #{attribute}" } }
-
-      it "calls default with model and attribute as args if default is a Proc" do
-        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
-        expect(backend.read(:fr)).to eq('model title')
-      end
-
-      it "calls default with model and attribute as args if default option is a Proc" do
-        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
-        expect(backend.read(:fr, default: lambda do |model:, attribute:|
-          "#{model} #{attribute} from options"
-        end)).to eq('model title from options')
-      end
+      expect(described_class).to receive(:new).with("default").and_return(default)
+      expect(backend_class).to receive(:include).with(default)
+      described_class.apply(attributes, "default")
     end
   end
 end

--- a/spec/mobility/backend/default_spec.rb
+++ b/spec/mobility/backend/default_spec.rb
@@ -15,7 +15,7 @@ describe Mobility::Backend::Default do
         backend_double_.write(*args)
       end
     end
-    Class.new(backend_class).include(described_class)
+    Class.new(backend_class).include(described_class.new(default))
   end
 
   describe "#read" do

--- a/spec/mobility/backend/dirty_spec.rb
+++ b/spec/mobility/backend/dirty_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+describe Mobility::Backend::Dirty do
+  describe ".apply" do
+    context "option value is truthy" do
+      let(:attributes) do
+        instance_double(Mobility::Attributes, backend_class: backend_class, options: options)
+      end
+      let(:backend_class) { double("backend class") }
+      let(:options) { { model_class: model_class } }
+      before do
+        expect(Mobility::FallthroughAccessors).to receive(:apply).with(attributes, true)
+      end
+
+      context "options[:model_class] includes ActiveModel::Dirty", orm: :active_record do
+        context "options[:model_class] is an ActiveRecord::Base" do
+          let(:model_class) { Class.new(ActiveRecord::Base) }
+
+          it "includes Backend::ActiveRecord::Dirty into backend class" do
+            expect(backend_class).to receive(:include).with(Mobility::Backend::ActiveRecord::Dirty)
+            described_class.apply(attributes, true)
+          end
+        end
+
+        context "options[:model_class] is not an ActiveRecord::Base" do
+          let(:model_class) do
+            klass = Class.new
+            klass.include(ActiveModel::Dirty)
+            klass
+          end
+
+          it "includes Backend::ActiveModel::Dirty into backend class" do
+            expect(backend_class).to receive(:include).with(Mobility::Backend::ActiveModel::Dirty)
+            described_class.apply(attributes, true)
+          end
+        end
+      end
+
+      context "options[:model_class] is a Sequel::Model", orm: :sequel do
+        let(:model_class) { Class.new(Sequel::Model) }
+
+        it "includes Backend::ActiveRecord::Sequel into backend class" do
+          expect(backend_class).to receive(:include).with(Mobility::Backend::Sequel::Dirty)
+          described_class.apply(attributes, true)
+        end
+      end
+    end
+
+    context "optoin value is falsey" do
+      let(:attributes) { instance_double(Mobility::Attributes) }
+
+      it "does not include Mobility::FallthroughAccessors" do
+        expect(Mobility::FallthroughAccessors).not_to receive(:apply)
+        described_class.apply(attributes, false)
+      end
+
+      it "does not include anything into backend class" do
+        expect(attributes).not_to receive(:backend_class)
+        described_class.apply(attributes, false)
+      end
+    end
+  end
+end

--- a/spec/mobility/backend/fallbacks_spec.rb
+++ b/spec/mobility/backend/fallbacks_spec.rb
@@ -16,14 +16,15 @@ describe Mobility::Backend::Fallbacks do
         }[attribute][locale]
       end
     end
-    backend_class = Class.new(backend_class).include(described_class)
+    backend_class = Class.new(backend_class).include(described_class.new(fallbacks))
     backend_class
   end
   let(:object) { (stub_const 'MobilityModel', Class.new).include(Mobility).new }
 
   context "fallbacks is a hash" do
+    let(:fallbacks) { { :'en-US' => 'de-DE', :pt => 'de-DE' } }
     subject do
-      backend_class.new(object, "title", fallbacks: { :'en-US' => 'de-DE', :pt => 'de-DE' })
+      backend_class.new(object, "title", fallbacks: fallbacks)
     end
 
     it "returns value when value is not nil" do
@@ -60,8 +61,9 @@ describe Mobility::Backend::Fallbacks do
   end
 
   context "fallbacks is true" do
+    let(:fallbacks) { true }
     subject do
-      backend_class.new(object, "title", fallbacks: true)
+      backend_class.new(object, "title", fallbacks: fallbacks)
     end
 
     it "uses default fallbacks" do
@@ -73,7 +75,8 @@ describe Mobility::Backend::Fallbacks do
   end
 
   context "fallbacks is falsey" do
-    subject { backend_class.new(object, "title") }
+    let(:fallbacks) { nil }
+    subject { backend_class.new(object, "title", fallbacks: fallbacks) }
 
     it "does not use fallbacks when fallback option is false or nil" do
       original_default_locale = I18n.default_locale

--- a/spec/mobility/backend/fallbacks_spec.rb
+++ b/spec/mobility/backend/fallbacks_spec.rb
@@ -1,94 +1,117 @@
 require "spec_helper"
 
 describe Mobility::Backend::Fallbacks do
-  let(:backend_class) do
-    backend_class = stub_const 'MyBackend', Class.new
-    backend_class.include(Mobility::Backend)
-    backend_class.class_eval do
-      def read(locale, **options)
-        return "bar" if options[:bar]
-        {
-          "title" => {
-            :'de-DE' => "foo",
-            :ja => "フー",
-            :'pt' => ""
-          }
-        }[attribute][locale]
+  describe "when included into a class" do
+    let(:backend_class) do
+      backend_class = stub_const 'MyBackend', Class.new
+      backend_class.include(Mobility::Backend)
+      backend_class.class_eval do
+        def read(locale, **options)
+          return "bar" if options[:bar]
+          {
+            "title" => {
+              :'de-DE' => "foo",
+              :ja => "フー",
+              :'pt' => ""
+            }
+          }[attribute][locale]
+        end
+      end
+      backend_class = Class.new(backend_class).include(described_class.new(fallbacks))
+      backend_class
+    end
+    let(:object) { (stub_const 'MobilityModel', Class.new).include(Mobility).new }
+
+    context "fallbacks is a hash" do
+      let(:fallbacks) { { :'en-US' => 'de-DE', :pt => 'de-DE' } }
+      subject do
+        backend_class.new(object, "title", fallbacks: fallbacks)
+      end
+
+      it "returns value when value is not nil" do
+        expect(subject.read(:ja)).to eq("フー")
+      end
+
+      it "falls through to fallback locale when value is nil" do
+        expect(subject.read(:"en-US")).to eq("foo")
+      end
+
+      it "falls through to fallback locale when value is blank" do
+        expect(subject.read(:pt)).to eq("foo")
+      end
+
+      it "returns nil when no fallback is found" do
+        expect(subject.read(:"fr")).to eq(nil)
+      end
+
+      it "returns nil when fallback: false option is passed" do
+        expect(subject.read(:"en-US", fallback: false)).to eq(nil)
+      end
+
+      it "uses locale passed in as value of fallback option when present" do
+        expect(subject.read(:"en-US", fallback: :ja)).to eq("フー")
+      end
+
+      it "uses array of locales passed in as value of fallback options when present" do
+        expect(subject.read(:"en-US", fallback: [:es, :'de-DE'])).to eq("foo")
+      end
+
+      it "passes options to getter in fallback locale" do
+        expect(subject.read(:'en-US', bar: true)).to eq("bar")
       end
     end
-    backend_class = Class.new(backend_class).include(described_class.new(fallbacks))
-    backend_class
-  end
-  let(:object) { (stub_const 'MobilityModel', Class.new).include(Mobility).new }
 
-  context "fallbacks is a hash" do
-    let(:fallbacks) { { :'en-US' => 'de-DE', :pt => 'de-DE' } }
-    subject do
-      backend_class.new(object, "title", fallbacks: fallbacks)
+    context "fallbacks is true" do
+      let(:fallbacks) { true }
+      subject do
+        backend_class.new(object, "title", fallbacks: fallbacks)
+      end
+
+      it "uses default fallbacks" do
+        original_default_locale = I18n.default_locale
+        I18n.default_locale = :ja
+        expect(subject.read(:"en-US")).to eq("フー")
+        I18n.default_locale = original_default_locale
+      end
     end
 
-    it "returns value when value is not nil" do
-      expect(subject.read(:ja)).to eq("フー")
-    end
+    context "fallbacks is falsey" do
+      let(:fallbacks) { nil }
+      subject { backend_class.new(object, "title", fallbacks: fallbacks) }
 
-    it "falls through to fallback locale when value is nil" do
-      expect(subject.read(:"en-US")).to eq("foo")
-    end
+      it "does not use fallbacks when fallback option is false or nil" do
+        original_default_locale = I18n.default_locale
+        I18n.default_locale = :ja
+        expect(subject.read(:"en-US")).to eq(nil)
+        I18n.default_locale = original_default_locale
+        expect(subject.read(:"en-US", fallback: false)).to eq(nil)
+        I18n.default_locale = original_default_locale
+      end
 
-    it "falls through to fallback locale when value is blank" do
-      expect(subject.read(:pt)).to eq("foo")
-    end
-
-    it "returns nil when no fallback is found" do
-      expect(subject.read(:"fr")).to eq(nil)
-    end
-
-    it "returns nil when fallback: false option is passed" do
-      expect(subject.read(:"en-US", fallback: false)).to eq(nil)
-    end
-
-    it "uses locale passed in as value of fallback option when present" do
-      expect(subject.read(:"en-US", fallback: :ja)).to eq("フー")
-    end
-
-    it "uses array of locales passed in as value of fallback options when present" do
-      expect(subject.read(:"en-US", fallback: [:es, :'de-DE'])).to eq("foo")
-    end
-
-    it "passes options to getter in fallback locale" do
-      expect(subject.read(:'en-US', bar: true)).to eq("bar")
+      it "uses locale passed in as value of fallback option when present" do
+        expect(subject.read(:"en-US", fallback: :ja)).to eq("フー")
+      end
     end
   end
 
-  context "fallbacks is true" do
-    let(:fallbacks) { true }
-    subject do
-      backend_class.new(object, "title", fallbacks: fallbacks)
+  describe ".apply" do
+    let(:attributes) { instance_double(Mobility::Attributes, backend_class: backend_class) }
+    let(:backend_class) { double("backend class") }
+    let(:fallbacks) { instance_double(described_class) }
+
+    context "option value is not false" do
+      it "includes instance of fallbacks into backend class" do
+        expect(described_class).to receive(:new).with("option").and_return(fallbacks)
+        expect(backend_class).to receive(:include).with(fallbacks)
+        described_class.apply(attributes, "option")
+      end
     end
 
-    it "uses default fallbacks" do
-      original_default_locale = I18n.default_locale
-      I18n.default_locale = :ja
-      expect(subject.read(:"en-US")).to eq("フー")
-      I18n.default_locale = original_default_locale
-    end
-  end
-
-  context "fallbacks is falsey" do
-    let(:fallbacks) { nil }
-    subject { backend_class.new(object, "title", fallbacks: fallbacks) }
-
-    it "does not use fallbacks when fallback option is false or nil" do
-      original_default_locale = I18n.default_locale
-      I18n.default_locale = :ja
-      expect(subject.read(:"en-US")).to eq(nil)
-      I18n.default_locale = original_default_locale
-      expect(subject.read(:"en-US", fallback: false)).to eq(nil)
-      I18n.default_locale = original_default_locale
-    end
-
-    it "uses locale passed in as value of fallback option when present" do
-      expect(subject.read(:"en-US", fallback: :ja)).to eq("フー")
+    context "optoin value is false" do
+      it "does nothing" do
+        expect(attributes).not_to receive(:backend_class)
+        described_class.apply(attributes, false)
+      end
     end
   end
 end

--- a/spec/mobility/backend/presence_spec.rb
+++ b/spec/mobility/backend/presence_spec.rb
@@ -1,73 +1,97 @@
 require "spec_helper"
 
 describe Mobility::Backend::Presence do
-  let(:backend_double) { double("backend") }
-  let(:backend) { backend_class.new("model", "attribute") }
-  let(:backend_class) do
-    backend_double_  = backend_double
-    backend_class = Class.new(Mobility::Backend::Null) do
-      define_method :read do |*args|
-        backend_double_.read(*args)
+  describe "when included into a class" do
+    let(:backend_double) { double("backend") }
+    let(:backend) { backend_class.new("model", "attribute") }
+    let(:backend_class) do
+      backend_double_  = backend_double
+      backend_class = Class.new(Mobility::Backend::Null) do
+        define_method :read do |*args|
+          backend_double_.read(*args)
+        end
+
+        define_method :write do |*args|
+          backend_double_.write(*args)
+        end
+      end
+      Class.new(backend_class).include(described_class)
+    end
+
+    describe "#read" do
+      it "passes through present values unchanged" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("foo")
+        expect(backend.read(:fr)).to eq("foo")
       end
 
-      define_method :write do |*args|
-        backend_double_.write(*args)
+      it "converts blank strings to nil" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("")
+        expect(backend.read(:fr)).to eq(nil)
+      end
+
+      it "passes through nil values unchanged" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(backend.read(:fr)).to eq(nil)
+      end
+
+      it "passes through false values unchanged" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(false)
+        expect(backend.read(:fr)).to eq(false)
+      end
+
+      it "does not convert blank string to nil if presence: false passed as option" do
+        expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("")
+        expect(backend.read(:fr, presence: false)).to eq("")
       end
     end
-    Class.new(backend_class).include(described_class)
+
+    describe "#write" do
+      it "passes through present values unchanged" do
+        expect(backend_double).to receive(:write).once.with(:fr, "foo", {}).and_return("foo")
+        expect(backend.write(:fr, "foo")).to eq("foo")
+      end
+
+      it "converts blank strings to nil" do
+        expect(backend_double).to receive(:write).once.with(:fr, nil, {}).and_return(nil)
+        expect(backend.write(:fr, "")).to eq(nil)
+      end
+
+      it "passes through nil values unchanged" do
+        expect(backend_double).to receive(:write).once.with(:fr, nil, {}).and_return(nil)
+        expect(backend.write(:fr, nil)).to eq(nil)
+      end
+
+      it "passes through false values unchanged" do
+        expect(backend_double).to receive(:write).once.with(:fr, false, {}).and_return(false)
+        expect(backend.write(:fr, false)).to eq(false)
+      end
+
+      it "does not convert blank string to nil if presence: false passed as option" do
+        expect(backend_double).to receive(:write).once.with(:fr, "", {}).and_return("")
+        expect(backend.write(:fr, "", presence: false)).to eq("")
+      end
+    end
   end
 
-  describe "#read" do
-    it "passes through present values unchanged" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("foo")
-      expect(backend.read(:fr)).to eq("foo")
+  # this is identical to apply specs for Cache, and can probably be refactored
+  describe ".apply" do
+    context "option value is truthy" do
+      it "includes Presence into backend class" do
+        backend_class = double("backend class")
+        attributes = instance_double(Mobility::Attributes, backend_class: backend_class)
+        expect(backend_class).to receive(:include).twice.with(described_class)
+        described_class.apply(attributes, true)
+        described_class.apply(attributes, [])
+      end
     end
 
-    it "converts blank strings to nil" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("")
-      expect(backend.read(:fr)).to eq(nil)
-    end
-
-    it "passes through nil values unchanged" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(nil)
-      expect(backend.read(:fr)).to eq(nil)
-    end
-
-    it "passes through false values unchanged" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return(false)
-      expect(backend.read(:fr)).to eq(false)
-    end
-
-    it "does not convert blank string to nil if presence: false passed as option" do
-      expect(backend_double).to receive(:read).once.with(:fr, {}).and_return("")
-      expect(backend.read(:fr, presence: false)).to eq("")
-    end
-  end
-
-  describe "#write" do
-    it "passes through present values unchanged" do
-      expect(backend_double).to receive(:write).once.with(:fr, "foo", {}).and_return("foo")
-      expect(backend.write(:fr, "foo")).to eq("foo")
-    end
-
-    it "converts blank strings to nil" do
-      expect(backend_double).to receive(:write).once.with(:fr, nil, {}).and_return(nil)
-      expect(backend.write(:fr, "")).to eq(nil)
-    end
-
-    it "passes through nil values unchanged" do
-      expect(backend_double).to receive(:write).once.with(:fr, nil, {}).and_return(nil)
-      expect(backend.write(:fr, nil)).to eq(nil)
-    end
-
-    it "passes through false values unchanged" do
-      expect(backend_double).to receive(:write).once.with(:fr, false, {}).and_return(false)
-      expect(backend.write(:fr, false)).to eq(false)
-    end
-
-    it "does not convert blank string to nil if presence: false passed as option" do
-      expect(backend_double).to receive(:write).once.with(:fr, "", {}).and_return("")
-      expect(backend.write(:fr, "", presence: false)).to eq("")
+    context "option value is falsey" do
+      it "does not include Presence into backend class" do
+        attributes = instance_double(Mobility::Attributes)
+        expect(attributes).not_to receive(:backend_class)
+        described_class.apply(attributes, false)
+        described_class.apply(attributes, nil)
+      end
     end
   end
 end

--- a/spec/mobility/wrapper_spec.rb
+++ b/spec/mobility/wrapper_spec.rb
@@ -13,8 +13,8 @@ describe Mobility::Wrapper do
 
   describe "#translated_attribute_names" do
     it "returns flattened array of module attributes" do
-      module1 = double("backend module", attributes: ["foo", "bar"])
-      module2 = double("backend module", attributes: ["baz"])
+      module1 = double("attributes", names: ["foo", "bar"])
+      module2 = double("attributes", names: ["baz"])
       wrapper = Mobility::Wrapper.new(model_class)
       wrapper << module1
       wrapper << module2

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -57,7 +57,7 @@ describe Mobility do
         backend_module = model.ancestors.find { |a| a.class == Mobility::Attributes }
         expect(backend_module).not_to be_nil
         expect(backend_module.attributes).to eq ["title"]
-        expect(backend_module.options).to eq(foo: :bar, model_class: MyModel)
+        expect(backend_module.options).to eq(Mobility.default_options.merge(foo: :bar, model_class: MyModel))
       end
 
       it "defines translated_attribute_names" do

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -54,10 +54,10 @@ describe Mobility do
         expect(Mobility::Attributes).to receive(:new).and_call_original
         model.include Mobility
         model.translates :title, backend: :null, foo: :bar
-        backend_module = model.ancestors.find { |a| a.class == Mobility::Attributes }
-        expect(backend_module).not_to be_nil
-        expect(backend_module.attributes).to eq ["title"]
-        expect(backend_module.options).to eq(Mobility.default_options.merge(foo: :bar, model_class: MyModel))
+        attributes = model.ancestors.find { |a| a.class == Mobility::Attributes }
+        expect(attributes).not_to be_nil
+        expect(attributes.names).to eq ["title"]
+        expect(attributes.options).to eq(Mobility.default_options.merge(foo: :bar, model_class: MyModel))
       end
 
       it "defines translated_attribute_names" do


### PR DESCRIPTION
Currently there is a lot of hard-coded dependencies between options-setting in
the `Mobility::Attributes` class and the various backend modules (cache,
fallbacks, etc.), whereas these should really be independent.

I'm going to try to restructure things so that modules can be defined in such a
way that `Mobility::Attributes` does not need to explicitly know anything about
them when including them from options.