### PR TITLE
Refactor backend cache

### DIFF
--- a/lib/mobility/active_model/backend_resetter.rb
+++ b/lib/mobility/active_model/backend_resetter.rb
@@ -9,7 +9,7 @@ Backend resetter for ActiveModel models. Adds hook to reset backend when
     class BackendResetter < Mobility::BackendResetter
 
       # (see Mobility::BackendResetter#initialize)
-      def initialize(attributes)
+      def initialize(attribute_names)
         super
 
         model_reset_method = @model_reset_method

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -148,7 +148,7 @@ On top of this, a backend will normally:
       # Called from option modules to apply custom processing for this backend.
       # Name is the name of the option module.
       # @param [Symbol] name Name of option module
-      # @return [Boolean]
+      # @return [Boolean] Whether the module was applied
       # @note This is currently only called by Backend::Cache.
       def apply_module(_)
         false

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -49,22 +49,23 @@ On top of this, a backend will normally:
 =end
 
   module Backend
-    autoload :ActiveModel,  'mobility/backend/active_model'
-    autoload :ActiveRecord, 'mobility/backend/active_record'
-    autoload :Cache,        'mobility/backend/cache'
-    autoload :Column,       'mobility/backend/column'
-    autoload :Default,      'mobility/backend/default'
-    autoload :Dirty,        'mobility/backend/dirty'
-    autoload :Fallbacks,    'mobility/backend/fallbacks'
-    autoload :Hstore,       'mobility/backend/hstore'
-    autoload :Jsonb,        'mobility/backend/jsonb'
-    autoload :KeyValue,     'mobility/backend/key_value'
-    autoload :Null,         'mobility/backend/null'
-    autoload :OrmDelegator, 'mobility/backend/orm_delegator'
-    autoload :Presence,     'mobility/backend/presence'
-    autoload :Sequel,       'mobility/backend/sequel'
-    autoload :Serialized,   'mobility/backend/serialized'
-    autoload :Table,        'mobility/backend/table'
+    autoload :ActiveModel,       'mobility/backend/active_model'
+    autoload :ActiveRecord,      'mobility/backend/active_record'
+    autoload :Cache,             'mobility/backend/cache'
+    autoload :Column,            'mobility/backend/column'
+    autoload :Default,           'mobility/backend/default'
+    autoload :Dirty,             'mobility/backend/dirty'
+    autoload :Fallbacks,         'mobility/backend/fallbacks'
+    autoload :Hstore,            'mobility/backend/hstore'
+    autoload :Jsonb,             'mobility/backend/jsonb'
+    autoload :KeyValue,          'mobility/backend/key_value'
+    autoload :Null,              'mobility/backend/null'
+    autoload :OrmDelegator,      'mobility/backend/orm_delegator'
+    autoload :Presence,          'mobility/backend/presence'
+    autoload :Sequel,            'mobility/backend/sequel'
+    autoload :Serialized,        'mobility/backend/serialized'
+    autoload :Table,             'mobility/backend/table'
+    autoload :TranslationCacher, 'mobility/backend/translation_cacher'
 
     # @return [String] Backend attribute
     attr_reader :attribute
@@ -142,6 +143,15 @@ On top of this, a backend will normally:
       # @return [self] returns itself
       def for(_)
         self
+      end
+
+      # Called from option modules to apply custom processing for this backend.
+      # Name is the name of the option module.
+      # @param [Symbol] name Name of option module
+      # @return [Boolean]
+      # @note This is currently only called by Backend::Cache.
+      def apply_module(_)
+        false
       end
     end
   end

--- a/lib/mobility/backend/active_record/hash_valued.rb
+++ b/lib/mobility/backend/active_record/hash_valued.rb
@@ -24,11 +24,6 @@ Internal class used by ActiveRecord backends that store values as a hash.
       def translations
         model.read_attribute(attribute)
       end
-      alias_method :new_cache, :translations
-
-      def write_to_cache?
-        true
-      end
 
       setup do |attributes|
         attributes.each { |attribute| store attribute, coder: Coder }

--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -38,13 +38,13 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
 
       # @!group Backend Accessors
       # @!macro backend_reader
-      def read(locale, **_)
-        translation_for(locale).value
+      def read(locale, options = {})
+        translation_for(locale, options).value
       end
 
       # @!macro backend_reader
-      def write(locale, value, **_)
-        translation_for(locale).tap { |t| t.value = value }.value
+      def write(locale, value, options = {})
+        translation_for(locale, options).tap { |t| t.value = value }.value
       end
       # @!endgroup
 
@@ -101,22 +101,10 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
 
       setup_query_methods(QueryMethods)
 
-      # @!group Cache Methods
-      # @return [KeyValue::TranslationsCache]
-      def new_cache
-        KeyValue::TranslationsCache.new(self)
-      end
-
-      # @return [Boolean]
-      def write_to_cache?
-        true
-      end
-      # @!endgroup
-
       # Returns translation for a given locale, or builds one if none is present.
       # @param [Symbol] locale
       # @return [Mobility::ActiveRecord::TextTranslation,Mobility::ActiveRecord::StringTranslation]
-      def translation_for(locale)
+      def translation_for(locale, _options = {})
         translation = translations.find { |t| t.key == attribute && t.locale == locale.to_s }
         translation ||= translations.build(locale: locale, key: attribute)
         translation

--- a/lib/mobility/backend/active_record/serialized.rb
+++ b/lib/mobility/backend/active_record/serialized.rb
@@ -38,7 +38,10 @@ Implements {Mobility::Backend::Serialized} backend for ActiveRecord models.
       end
       # @!endgroup
 
-      # @see Backend::Serialized
+      # @!group Backend Configuration
+      # @param (see Backend::Serialized.configure)
+      # @option (see Backend::Serialized.configure)
+      # @raise (see Backend::Serialized.configure)
       def self.configure(options)
         Serialized.configure(options)
       end
@@ -57,13 +60,6 @@ Implements {Mobility::Backend::Serialized} backend for ActiveRecord models.
       def translations
         model.read_attribute(attribute)
       end
-      alias_method :new_cache, :translations
-
-      # @return [Boolean]
-      def write_to_cache?
-        true
-      end
-      # @!endgroup
 
       %w[yaml json].each do |format|
         class_eval <<-EOM, __FILE__, __LINE__ + 1

--- a/lib/mobility/backend/cache.rb
+++ b/lib/mobility/backend/cache.rb
@@ -5,8 +5,8 @@ module Mobility
 Caches values fetched from the backend so subsequent fetches can be performed
 more quickly. The cache stores cached values in a simple hash, which is not
 optimal for some storage strategies, so some backends (KeyValue, Table) use a
-custom module through the {Mobility::Backend::Setup#apply_module} hook. For details see the
-documentation for these backends.
+custom module through the {Mobility::Backend::Setup#apply_module} hook. For
+details see the documentation for these backends.
 
 The cache is reset when one of a set of events happens (saving, reloading,
 etc.). See {BackendResetter} for details.

--- a/lib/mobility/backend/cache.rb
+++ b/lib/mobility/backend/cache.rb
@@ -3,18 +3,10 @@ module Mobility
 =begin
 
 Caches values fetched from the backend so subsequent fetches can be performed
-more quickly.
-
-By default, the cache stores cached values in a simple hash, returned from the
-{new_cache} method added to the including backend instance class. To use a
-different cache class, simply define a +new_cache+ method in the backend and
-return a new instance of the cache class (many backends do this, see
-{Mobility::Backend::KeyValue} for one example.)
-
-The cache is reset by the {clear_cache} method, which by default simply assigns
-the result of {new_cache} to the +@cache+ instance variable. This behaviour can
-also be customized by defining a +new_cache+ method on the backend class (see
-{Mobility::Backend::ActiveRecord::Table#new_cache} for an example of a backend that does this).
+more quickly. The cache stores cached values in a simple hash, which is not
+optimal for some storage strategies, so some backends (KeyValue, Table) use a
+custom module through the {Mobility::Backend::Setup#apply_module} hook. For details see the
+documentation for these backends.
 
 The cache is reset when one of a set of events happens (saving, reloading,
 etc.). See {BackendResetter} for details.
@@ -24,99 +16,37 @@ Values are added to the cache in two ways:
 1. first read from backend
 2. any write to backend
 
-The latter can be customized by defining the {write_to_cache?} method, which by
-default returns +false+. If set to +true+, then writes will only update the
-cache and not hit the backend. This is a sensible setting in case the cache is
-actually an object which directly stores the translation (see one of the
-ORM-specific implementations of {Mobility::Backend::KeyValue} for examples of
-this).
-
 =end
     module Cache
       # Applies cache option module to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option_value
       def self.apply(attributes, option_value)
-        attributes.backend_class.include(self) if option_value
+        if option_value
+          backend_class = attributes.backend_class
+          backend_class.include(self) unless backend_class.apply_module(:cache)
+
+          model_class = attributes.model_class
+          model_class.include BackendResetter.for(model_class).new(attributes.names) { clear_cache }
+        end
       end
 
       # @group Backend Accessors
+      #
       # @!macro backend_reader
       # @option options [Boolean] cache
       #   *false* to disable cache.
-      def read(locale, options = {})
-        return super if options.delete(:cache) == false
-        if write_to_cache? || cache.has_key?(locale)
-          cache[locale]
-        else
-          cache[locale] = super
-        end
-      end
+      # @!method read(locale, value, options = {})
+      include TranslationCacher.new(:read)
 
       # @!macro backend_writer
       # @option options [Boolean] cache
       #   *false* to disable cache.
       def write(locale, value, options = {})
         return super if options.delete(:cache) == false
-        cache[locale] = write_to_cache? ? value : super
+        cache[locale] = super
       end
       # @!endgroup
-
-      # Adds hook to {Backend::Setup#setup_model} to include instance of
-      # model-specific {BackendResetter} subclass when setting up
-      # model class, to trigger cache resetting at specific events (saving,
-      # reloading, etc.)
-      module Setup
-        # @param model_class Model class
-        # @param [Array<String>] attributes Backend attributes
-        def setup_model(model_class, attributes, _options = {})
-          super
-          model_class.include BackendResetter.for(model_class).new(attributes) { clear_cache }
-        end
-      end
-
-      # @!group Cache Methods
-      # @!parse
-      #   def new_cache
-      #     {}
-      #   end
-      #
-      # @!parse
-      #   def write_to_cache?
-      #     false
-      #   end
-      #
-      # @!parse
-      #   def clear_cache
-      #     @cache = new_cache
-      #   end
-      # @!endgroup
-
-      # Includes cache methods to backend (unless they are already defined) and
-      # extends backend class with {Mobility::Cache::Setup} for backend resetting.
-      def self.included(backend_class)
-        backend_class.class_eval do
-          extend Setup
-
-          def new_cache
-            {}
-          end unless method_defined?(:new_cache)
-
-          def write_to_cache?
-            false
-          end unless method_defined?(:write_to_cache?)
-
-          def clear_cache
-            @cache = new_cache
-          end unless method_defined?(:clear_cache)
-        end
-      end
-
-      private
-
-      def cache
-        @cache ||= new_cache
-      end
     end
   end
 end

--- a/lib/mobility/backend/key_value.rb
+++ b/lib/mobility/backend/key_value.rb
@@ -53,31 +53,16 @@ class.
           options[:type] = (options[:type] || :text).to_sym
           raise ArgumentError, "type must be one of: [text, string]" unless [:text, :string].include?(options[:type])
         end
-      end
 
-      # Simple cache to memoize translations as a hash so they can be fetched
-      # quickly.
-      class TranslationsCache
-        # @param backend Instance of KeyValue backend to cache
-        # @return [TranslationsCache]
-        def initialize(backend)
-          @cache = Hash.new { |hash, locale| hash[locale] = backend.translation_for(locale) }
-        end
-
-        # @param locale [Symbol] Locale to fetch
-        def [](locale)
-          @cache[locale].value
-        end
-
-        # @param locale [Symbol] Locale to set
-        # @param value [String] Value to set
-        def []=(locale, value)
-          @cache[locale].value = value
-        end
-
-        # @yield [locale, translation]
-        def each_translation &block
-          @cache.each_value(&block)
+        # Apply custom processing for option module
+        # @param (see Backend::Setup#apply_module)
+        def apply_module(name)
+          if name == :cache
+            include TranslationCacher.new(:translation_for)
+            true
+          else
+            super
+          end
         end
       end
     end

--- a/lib/mobility/backend/key_value.rb
+++ b/lib/mobility/backend/key_value.rb
@@ -56,6 +56,7 @@ class.
 
         # Apply custom processing for option module
         # @param (see Backend::Setup#apply_module)
+        # @return (see Backend::Setup#apply_module)
         def apply_module(name)
           if name == :cache
             include TranslationCacher.new(:translation_for)

--- a/lib/mobility/backend/sequel/hash_valued.rb
+++ b/lib/mobility/backend/sequel/hash_valued.rb
@@ -22,13 +22,6 @@ Internal class used by Sequel backends that store values as a hash.
       def translations
         model.send("#{attribute}_before_mobility")
       end
-      alias_method :new_cache, :translations
-
-      # @return [Boolean]
-      def write_to_cache?
-        true
-      end
-      # @!endgroup
 
       setup do |attributes|
         method_overrides = Module.new do

--- a/lib/mobility/backend/sequel/serialized.rb
+++ b/lib/mobility/backend/sequel/serialized.rb
@@ -45,7 +45,10 @@ Sequel serialization plugin.
       end
       # @!endgroup
 
-      # @see Backend::Serialized
+      # @!group Backend Configuration
+      # @param (see Backend::Serialized.configure)
+      # @option (see Backend::Serialized.configure)
+      # @raise (see Backend::Serialized.configure)
       def self.configure(options)
         Serialized.configure(options)
       end
@@ -87,18 +90,6 @@ Sequel serialization plugin.
           model.deserialized_values[attribute_] = deserialize_value(attribute_, serialized_value)
         end
       end
-
-      # @!group Cache Methods
-      # @return [Hash]
-      def new_cache
-        translations
-      end
-
-      # @return [Boolean]
-      def write_to_cache?
-        true
-      end
-      # @!endgroup
 
       # @note The original serialization_modification_detection plugin sets
       #   +@original_deserialized_values+ to be +@deserialized_values+, which

--- a/lib/mobility/backend/serialized.rb
+++ b/lib/mobility/backend/serialized.rb
@@ -32,6 +32,7 @@ Format for serialization. Either +:yaml+ (default) or +:json+.
           options[:format] = options[:format].downcase.to_sym
           raise ArgumentError, "Serialized backend only supports yaml or json formats." unless [:yaml, :json].include?(options[:format])
         end
+        # @!endgroup
 
         def serializer_for(format)
           lambda do |obj|

--- a/lib/mobility/backend/table.rb
+++ b/lib/mobility/backend/table.rb
@@ -71,6 +71,7 @@ set.
       module ClassMethods
         # Apply custom processing for option module
         # @param (see Backend::Setup#apply_module)
+        # @return (see Backend::Setup#apply_module)
         def apply_module(name)
           if name == :cache
             include Cache

--- a/lib/mobility/backend/translation_cacher.rb
+++ b/lib/mobility/backend/translation_cacher.rb
@@ -1,0 +1,38 @@
+module Mobility
+  module Backend
+=begin
+
+Creates a module to cache a given translation fetch method. The cacher defines
+private methods +cache+ and +clear_cache+ to access and clear, respectively, a
+translations hash.
+
+This cacher is used to cache translation values in {Mobility::Backend::Cache},
+and also to cache translation *records* in {Mobility::Backend::Table} and
+{Mobility::Backend::KeyValue}.
+
+=end
+    class TranslationCacher < Module
+      # @param [Symbol] fetch_method Name of translation fetch method to cache
+      def initialize(fetch_method)
+        define_method fetch_method do |locale, options = {}|
+          return super(locale, options) if options.delete(:cache) == false
+          if cache.has_key?(locale)
+            cache[locale]
+          else
+            cache[locale] = super(locale, options)
+          end
+        end
+
+        define_method :cache do
+          @cache ||= {}
+        end
+
+        define_method :clear_cache do
+          @cache = {}
+        end
+
+        private :cache, :clear_cache
+      end
+    end
+  end
+end

--- a/lib/mobility/backend_resetter.rb
+++ b/lib/mobility/backend_resetter.rb
@@ -13,15 +13,15 @@ Resets backend cache when reset events occur.
 
 =end
   class BackendResetter < Module
-    # @param [Array<String>] attributes Attributes whose backends should be reset
+    # @param [Array<String>] attribute_names Names of attributes whose backends should be reset
     # @yield Backend to reset as context for block
     # @raise [ArgumentError] if no block is provided.
-    def initialize(attributes, &block)
+    def initialize(attribute_names, &block)
       raise ArgumentError, "block required" unless block_given?
       @model_reset_method = Proc.new do
-        attributes.each do |attribute|
-          if @mobility_backends && @mobility_backends[attribute]
-            @mobility_backends[attribute].instance_eval(&block)
+        attribute_names.each do |name|
+          if @mobility_backends && @mobility_backends[name]
+            @mobility_backends[name].instance_eval(&block)
           end
         end
       end

--- a/lib/mobility/sequel/backend_resetter.rb
+++ b/lib/mobility/sequel/backend_resetter.rb
@@ -12,14 +12,12 @@ method is called.
       def included(model_class)
         model_reset_method = @model_reset_method
 
-        model_class.class_eval do
-          mod = Module.new do
-            define_method :refresh do
-              super().tap { instance_eval(&model_reset_method) }
-            end
+        mod = Module.new do
+          define_method :refresh do
+            super().tap { instance_eval(&model_reset_method) }
           end
-          include mod
         end
+        model_class.include mod
       end
     end
   end

--- a/spec/mobility/backend/active_record/serialized_spec.rb
+++ b/spec/mobility/backend/active_record/serialized_spec.rb
@@ -75,13 +75,6 @@ describe Mobility::Backend::ActiveRecord::Serialized, orm: :active_record do
       expect(post).to receive(:read_attribute).once.and_call_original
       2.times { backend.read(:en) }
     end
-
-    it "uses cached serialized attribute for writes" do
-      post = SerializedPost.new
-      backend = post.mobility_backend_for("title")
-      expect(post).to receive(:read_attribute).once.and_call_original
-      2.times { backend.write(:en, "foo") }
-    end
   end
 
   describe "mobility scope (.i18n)" do

--- a/spec/mobility/backend/active_record/table_spec.rb
+++ b/spec/mobility/backend/active_record/table_spec.rb
@@ -22,13 +22,13 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
       title_backend = article.mobility_backend_for("title")
       content_backend = article.mobility_backend_for("content")
       title_backend.read(:en)
-      expect(article.__mobility_model_translations_cache.size).to eq(1)
+      expect(article.instance_variable_get(:@__mobility_model_translations_cache).size).to eq(1)
       content_backend.read(:en)
-      expect(article.__mobility_model_translations_cache.size).to eq(1)
+      expect(article.instance_variable_get(:@__mobility_model_translations_cache).size).to eq(1)
       content_backend.read(:ja)
-      expect(article.__mobility_model_translations_cache.size).to eq(2)
-      content_backend.clear_cache
-      expect(article.__mobility_model_translations_cache.size).to eq(0)
+      expect(article.instance_variable_get(:@__mobility_model_translations_cache).size).to eq(2)
+      content_backend.send(:clear_cache)
+      expect(article.instance_variable_get(:@__mobility_model_translations_cache).size).to eq(0)
     end
   end
 

--- a/spec/mobility/backend/sequel/serialized_spec.rb
+++ b/spec/mobility/backend/sequel/serialized_spec.rb
@@ -69,13 +69,6 @@ describe Mobility::Backend::Sequel::Serialized, orm: :sequel do
       expect(backend).to receive(:translations).once.and_call_original
       2.times { backend.read(:en) }
     end
-
-    it "uses cached serialized attribute for writes" do
-      post = SerializedPost.new
-      backend = post.mobility_backend_for("title")
-      expect(backend).to receive(:translations).once.and_call_original
-      2.times { backend.write(:en, "foo") }
-    end
   end
 
   describe "mobility scope (.i18n)" do

--- a/spec/mobility/backend/sequel/table_spec.rb
+++ b/spec/mobility/backend/sequel/table_spec.rb
@@ -15,6 +15,17 @@ describe Mobility::Backend::Sequel::Table, orm: :sequel do
 
   include_accessor_examples "Article"
 
+  it "only fetches translation once per locale" do
+    article = Article.new
+    title_backend = article.mobility_backend_for("title")
+    expect(title_backend.model.mobility_model_translations).to receive(:find).twice.and_call_original
+    title_backend.write(:en, "foo")
+    title_backend.write(:en, "bar")
+    expect(title_backend.read(:en)).to eq("bar")
+    title_backend.write(:fr, "baz")
+    expect(title_backend.read(:fr)).to eq("baz")
+  end
+
   # Using Article to test separate backends with separate tables fails
   # when these specs are run together with other specs, due to code
   # assigning subclasses (Article::Translation, Article::FooTranslation).


### PR DESCRIPTION
The current code is unnecessarily complicated. This PR simplifies things so that backends can include a custom module through an `apply_module` hook. This allows KeyValue and Table backends to modify the Cache module they use just slightly to achieve the same result.

A module builder called `TranslationCacher` is shared by all cacheing strategies to cache reads; the only difference is which method is cached: in the default Cache module, `read` is cached; in KeyValue and Table backends, `translation_for` is cached (so that the translation record itself is cached, rather than the translation value).