### PR TITLE
Remove namespace from default association names

### DIFF
--- a/lib/mobility/backend/active_record/key_value.rb
+++ b/lib/mobility/backend/active_record/key_value.rb
@@ -50,7 +50,7 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
 
       # @!group Backend Configuration
       # @option options [Symbol] type (:text) Column type to use
-      # @option options [Symbol] association_name (:mobility_text_translations) Name of association method
+      # @option options [Symbol] association_name (:text_translations) Name of association method
       # @option options [String,Class] class_name ({Mobility::ActiveRecord::TextTranslation}) Translation class
       # @raise [ArgumentError] if type is not either :text or :string
       def self.configure(options)
@@ -58,7 +58,7 @@ Implements the {Mobility::Backend::KeyValue} backend for ActiveRecord models.
         type = options[:type]
         options[:class_name] ||= Mobility::ActiveRecord.const_get("#{type.capitalize}Translation".freeze)
         options[:class_name] = options[:class_name].constantize if options[:class_name].is_a?(String)
-        options[:association_name] ||= options[:class_name].table_name.to_sym
+        options[:association_name] ||= :"#{options[:type]}_translations"
         %i[type association_name].each { |key| options[key] = options[key].to_sym }
       end
       # @!endgroup

--- a/lib/mobility/backend/active_record/table.rb
+++ b/lib/mobility/backend/active_record/table.rb
@@ -112,7 +112,7 @@ columns to that table.
       # @!endgroup
 
       # @!group Backend Configuration
-      # @option options [Symbol] association_name (:mobility_model_translations)
+      # @option options [Symbol] association_name (:model_translations)
       #   Name of association method
       # @option options [Symbol] table_name Name of translation table
       # @option options [Symbol] foreign_key Name of foreign key
@@ -125,7 +125,7 @@ columns to that table.
         if (association_name = options[:association_name]).present?
           options[:subclass_name] ||= association_name.to_s.singularize.camelize.freeze
         else
-          options[:association_name] = :mobility_model_translations
+          options[:association_name] = :model_translations
           options[:subclass_name] ||= :Translation
         end
         %i[foreign_key association_name subclass_name].each { |key| options[key] = options[key].to_sym }

--- a/lib/mobility/backend/key_value.rb
+++ b/lib/mobility/backend/key_value.rb
@@ -5,26 +5,27 @@ module Mobility
 Stores attribute translation as attribute/value pair on a shared translations
 table, using a polymorphic relationship between a translation class and models
 using the backend. By default, two tables are assumed to be present supporting
-string and text translations: a +mobility_text_translations+ table for text-valued translations and a
-+mobility_string_translations+ table for string-valued translations (the only
-difference being the column type of the +value+ column on the table).
+string and text translations: a +mobility_text_translations+ table for
+text-valued translations and a +string_translations+ table for
+string-valued translations (the only difference being the column type of the
++value+ column on the table).
 
 ==Backend Options
 
 ===+association_name+
 
-Name of association on model. Defaults to +mobility_text_translations+ (if
-+type+ is +:text+) or +mobility_string_translations+ (if +type+ is +:string+).
-If specified, ensure name does not overlap with other methods on model or with
-the association name used by other backends on model (otherwise one will
-overwrite the other).
+Name of association on model. Defaults to +text_translations+ (if +type+ is
++:text+) or +string_translations+ (if +type+ is +:string+). If specified,
+ensure name does not overlap with other methods on model or with the
+association name used by other backends on model (otherwise one will overwrite
+the other).
 
 ===+type+
 
 Currently, either +:text+ or +:string+ is supported. Determines which class to
 use for translations, which in turn determines which table to use to store
-translations (by default +mobility_text_translations+ for text type,
-+mobility_string_translations+ for string type).
+translations (by default +text_translations+ for text type,
++string_translations+ for string type).
 
 ===+class_name+
 

--- a/lib/mobility/backend/sequel/key_value.rb
+++ b/lib/mobility/backend/sequel/key_value.rb
@@ -46,7 +46,7 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
 
       # @!group Backend Configuration
       # @option options [Symbol,String] type (:text) Column type to use
-      # @option options [Symbol] associaiton_name (:mobility_text_translations) Name of association method
+      # @option options [Symbol] associaiton_name (:text_translations) Name of association method
       # @option options [Symbol] class_name ({Mobility::Sequel::TextTranslation}) Translation class
       # @raise [CacheRequired] if cache is disabled
       # @raise [ArgumentError] if type is not either :text or :string
@@ -56,7 +56,7 @@ Implements the {Mobility::Backend::KeyValue} backend for Sequel models.
         type = options[:type]
         options[:class_name] ||= Mobility::Sequel.const_get("#{type.capitalize}Translation".freeze)
         options[:class_name] = options[:class_name].constantize if options[:class_name].is_a?(String)
-        options[:association_name] ||= options[:class_name].table_name.to_sym
+        options[:association_name] ||= :"#{options[:type]}_translations"
         %i[type association_name].each { |key| options[key] = options[key].to_sym }
       end
       # @!endgroup

--- a/lib/mobility/backend/sequel/table.rb
+++ b/lib/mobility/backend/sequel/table.rb
@@ -37,7 +37,7 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
       end
 
       # @!group Backend Configuration
-      # @option options [Symbol] association_name (:mobility_model_translations) Name of association method
+      # @option options [Symbol] association_name (:model_translations) Name of association method
       # @option options [Symbol] table_name Name of translation table
       # @option options [Symbol] foreign_key Name of foreign key
       # @option options [Symbol] subclass_name Name of subclass to append to model class to generate translation class
@@ -50,7 +50,7 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
         if (association_name = options[:association_name]).present?
           options[:subclass_name] ||= association_name.to_s.singularize.camelize
         else
-          options[:association_name] = :mobility_model_translations
+          options[:association_name] = :model_translations
           options[:subclass_name] ||= :Translation
         end
         %i[table_name foreign_key association_name subclass_name].each { |key| options[key] = options[key].to_sym }
@@ -85,7 +85,7 @@ Implements the {Mobility::Backend::Table} backend for Sequel models.
         callback_methods = Module.new do
           define_method :after_save do
             super()
-            cache_accessor = instance_variable_get(:"@__#{association_name}_cache")
+            cache_accessor = instance_variable_get(:"@__mobility_#{association_name}_cache")
             cache_accessor.each_value do |translation|
               translation.id ? translation.save : send("add_#{association_name.to_s.singularize}", translation)
             end if cache_accessor

--- a/lib/mobility/backend/table.rb
+++ b/lib/mobility/backend/table.rb
@@ -36,8 +36,8 @@ For more details, see examples in {Mobility::Backend::ActiveRecord::Table}.
 
 ===+association_name+
 
-Name of association on model. Defaults to +:mobility_model_translations+. If
-specified, ensure name does not overlap with other methods on model or with the
+Name of association on model. Defaults to +:model_translations+. If specified,
+ensure name does not overlap with other methods on model or with the
 association name used by other backends on model (otherwise one will overwrite
 the other).
 
@@ -90,11 +90,11 @@ set.
         private
 
         def cache
-          model_cache || model.instance_variable_set(:"@__#{association_name}_cache", {})
+          model_cache || model.instance_variable_set(:"@__mobility_#{association_name}_cache", {})
         end
 
         def model_cache
-          model.instance_variable_get(:"@__#{association_name}_cache")
+          model.instance_variable_get(:"@__mobility_#{association_name}_cache")
         end
 
         def clear_cache

--- a/spec/mobility/active_record_compatibility_spec.rb
+++ b/spec/mobility/active_record_compatibility_spec.rb
@@ -30,11 +30,11 @@ describe "ActiveRecord compatibility", orm: :active_record do
 
     it "updates cache when translations association is modified directly" do
       expect(post.title).to eq("foo title")
-      post.send(:mobility_string_translations).first.value = "association changed value"
+      post.send(post.title_backend.association_name).first.value = "association changed value"
       expect(post.title).to eq("association changed value")
       post.title = "writer changed value"
       expect(post.title).to eq("writer changed value")
-      post.send(:mobility_string_translations).first.value = "association changed value"
+      post.send(post.title_backend.association_name).first.value = "association changed value"
       post.save
       expect(Post.first.title).to eq("association changed value")
     end

--- a/spec/mobility/backend/active_record/table_spec.rb
+++ b/spec/mobility/backend/active_record/table_spec.rb
@@ -15,7 +15,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
     it "finds translation on every read/write" do
       article = Article.new
       title_backend = article.mobility_backend_for("title")
-      expect(title_backend.model.mobility_model_translations).to receive(:find).thrice.and_call_original
+      expect(title_backend.model.model_translations).to receive(:find).thrice.and_call_original
       title_backend.write(:en, "foo")
       title_backend.write(:en, "bar")
       expect(title_backend.read(:en)).to eq("bar")
@@ -31,7 +31,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
       title_backend = article.mobility_backend_for("title")
 
       aggregate_failures do
-        expect(title_backend.model.mobility_model_translations).to receive(:find).twice.and_call_original
+        expect(title_backend.model.model_translations).to receive(:find).twice.and_call_original
         title_backend.write(:en, "foo")
         title_backend.write(:en, "bar")
         expect(title_backend.read(:en)).to eq("bar")
@@ -110,7 +110,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
       it "builds translation if no translation exists" do
         expect {
           title_backend.read(:de)
-        }.to change(subject.send(:mobility_model_translations), :size).by(1)
+        }.to change(subject.send(:model_translations), :size).by(1)
       end
 
       describe "reading back written attributes" do
@@ -129,7 +129,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
         it "creates translation for locale" do
           expect {
             title_backend.write(:en, "New Article")
-          }.to change(subject.send(:mobility_model_translations), :size).by(1)
+          }.to change(subject.send(title_backend.association_name), :size).by(1)
 
           expect { subject.save! }.to change(Article::Translation, :count).by(1)
         end
@@ -138,7 +138,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
           title_backend.write(:en, "New Article")
           content_backend.write(:en, "Lorum ipsum...")
 
-          translation = subject.send(:mobility_model_translations).first
+          translation = subject.send(title_backend.association_name).first
 
           aggregate_failures do
             expect(translation.title).to eq("New Article")
@@ -160,7 +160,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
         it "does not create new translation for locale" do
           expect {
             title_backend.write(:en, "New Article")
-          }.not_to change(subject.send(:mobility_model_translations), :size)
+          }.not_to change(subject.send(title_backend.association_name), :size)
         end
 
         it "updates value attribute on existing translation" do
@@ -168,7 +168,7 @@ describe Mobility::Backend::ActiveRecord::Table, orm: :active_record do
           subject.save!
           subject.reload
 
-          translation = subject.send(:mobility_model_translations).first
+          translation = subject.send(title_backend.association_name).first
 
           aggregate_failures do
             expect(translation.title).to eq("New New Article")

--- a/spec/mobility/backend/sequel/table_spec.rb
+++ b/spec/mobility/backend/sequel/table_spec.rb
@@ -18,7 +18,7 @@ describe Mobility::Backend::Sequel::Table, orm: :sequel do
   it "only fetches translation once per locale" do
     article = Article.new
     title_backend = article.mobility_backend_for("title")
-    expect(title_backend.model.mobility_model_translations).to receive(:find).twice.and_call_original
+    expect(article.send(article.title_backend.association_name)).to receive(:find).twice.and_call_original
     title_backend.write(:en, "foo")
     title_backend.write(:en, "bar")
     expect(title_backend.read(:en)).to eq("bar")
@@ -118,7 +118,7 @@ describe Mobility::Backend::Sequel::Table, orm: :sequel do
           subject.save
           subject.reload
 
-          translation = subject.mobility_model_translations.first
+          translation = subject.send(title_backend.association_name).first
 
           aggregate_failures do
             expect(translation.title).to eq("New New Article")


### PR DESCRIPTION
Currently the KeyValue and Table backends use association names like `mobility_string_translations` and `mobility_model_translations`, but the `mobility_` prefix is not really necessary - if for whatever reason there were a conflict in a model, the name can be changed using the `association_name` option.

This PR removes this prefix so that you don't need to type so many characters to get the model associations.