### PR TITLE
Set default table backend association name to "translations"

### DIFF
--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -109,10 +109,10 @@ columns to that table.
         if (association_name = options[:association_name]).present?
           options[:subclass_name] ||= association_name.to_s.singularize.camelize.freeze
         else
-          options[:association_name] = :model_translations
+          options[:association_name] = :translations
           options[:subclass_name] ||= :Translation
         end
-        %i[foreign_key association_name subclass_name].each { |key| options[key] = options[key].to_sym }
+        %i[foreign_key association_name subclass_name table_name].each { |key| options[key] = options[key].to_sym }
       end
       # @!endgroup
 

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -43,7 +43,7 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
         if association_name = options[:association_name]
           options[:subclass_name] ||= camelize(singularize(association_name))
         else
-          options[:association_name] = :model_translations
+          options[:association_name] = :translations
           options[:subclass_name] ||= :Translation
         end
         %i[table_name foreign_key association_name subclass_name].each { |key| options[key] = options[key].to_sym }

--- a/spec/mobility/backends/sequel/table_spec.rb
+++ b/spec/mobility/backends/sequel/table_spec.rb
@@ -18,7 +18,6 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel do
   end
 
   context "with standard options applied" do
-    let(:described_class) { Mobility::Backend::Sequel::KeyValue }
     let(:translation_class) { Article::Translation }
 
     before do
@@ -142,6 +141,29 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel do
             end
           end
         end
+      end
+    end
+
+    describe ".configure" do
+      let(:options) { { model_class: Article } }
+      it "sets association_name" do
+        described_class.configure(options)
+        expect(options[:association_name]).to eq(:translations)
+      end
+
+      it "sets subclass_name" do
+        described_class.configure(options)
+        expect(options[:subclass_name]).to eq(:Translation)
+      end
+
+      it "sets table_name" do
+        described_class.configure(options)
+        expect(options[:table_name]).to eq(:article_translations)
+      end
+
+      it "sets foreign_key" do
+        described_class.configure(options)
+        expect(options[:foreign_key]).to eq(:article_id)
       end
     end
 


### PR DESCRIPTION
Rather than `model_translations`, which is what it currently is (in 0.2.0).

Globalize uses `translations` and I think it's more intuitive. Previously I was concerned about conflicts with other gems or models that may use the method `translations`, but now that Mobility has a default options configuration, anyone wanting to avoid such conflicts can simply set:

```ruby
Mobility.config.default_options = {
   association_name: :my_translations
}
```

... or whatever, to avoid any possible conflict. For the vast majority of people, `post.translations` will work fine.