### PR TITLE
Explain write methods behaviour toards persisting translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ word.name_backend.read(:en)
 Internally, all methods for accessing translated attributes ultimately end up
 reading and writing from the backend instance this way.
 
+The `write` methods do not call underlying backend's methods to persist the change.
+This is up to the user (e.g. with ActiveRecord you should call `save` write
+the changes to the database.
+
 ### Setting the Locale
 
 It may not always be desirable to use `I18n.locale` to set the locale for

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -65,10 +65,12 @@ On top of this, a backend will normally:
     end
 
     # @!macro [new] backend_reader
+    #   Gets the translated value for provided locale from configured backend
     #   @param [Symbol] locale Locale to read
     #   @return [Object] Value of translation
     #
     # @!macro [new] backend_writer
+    #   Updates translation for provided locale without calling backend's methods to persist the changes.
     #   @param [Symbol] locale Locale to write
     #   @param [Object] value Value to write
     #   @return [Object] Updated value


### PR DESCRIPTION
I was writing some acceptance tests when I noticed the translated fields not shown. 

I like the current behaviour where it's up to user to call `save` but the method name kind of implies writing to somewhere. So I think this small adition to docs could avoid some confusion in the future.

If you approve this change, should I also document it elsewhere? I noticed the backends each implement the `write` method so there is no one place to add it. What do you think?