### PR TITLE
Backends with Enumerable

### DIFF
--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -163,7 +163,7 @@ with other backends.
     end
 
     # Yield each attribute name to block
-    # @yield [String] Attribute
+    # @yieldparam [String] Attribute
     def each &block
       names.each(&block)
     end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -188,7 +188,7 @@ with other backends.
       define_method "#{attribute}?" do |locale: Mobility.locale, **options|
         return super() if options.delete(:super)
         Mobility.enforce_available_locales!(locale)
-        Util.present?(mobility_backend_for(attribute).read(locale.to_sym, options))
+        mobility_backend_for(attribute).present?(locale.to_sym, options)
       end
     end
 

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -90,7 +90,7 @@ On top of this, a backend will normally:
 
     # List locales available for this backend.
     # @return [Array<String>] Array of avialable locales
-    def list
+    def locales
       map(&:itself)
     end
 

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -65,7 +65,7 @@ On top of this, a backend will normally:
     end
 
     # @!macro [new] backend_reader
-    #   Gets the translated value for provided locale from configured backend
+    #   Gets the translated value for provided locale from configured backend.
     #   @param [Symbol] locale Locale to read
     #   @return [Object] Value of translation
     #
@@ -74,6 +74,12 @@ On top of this, a backend will normally:
     #   @param [Symbol] locale Locale to write
     #   @param [Object] value Value to write
     #   @return [Object] Updated value
+
+    # @param [Symbol] locale Locale to read
+    # @return [TrueClass,FalseClass] Whether translation is present for locale
+    def present?(locale, options = {})
+      Util.present?(read(locale, options))
+    end
 
     # Extend included class with +setup+ method
     def self.included(base)

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -175,12 +175,10 @@ On top of this, a backend will normally:
     end
 
     Translation = Struct.new(:backend, :locale) do
-      def read(options = {})
-        backend.read(locale, options)
-      end
-
-      def write(value, options = {})
-        backend.write(locale, value, options)
+      %w[read write].each do |accessor|
+        define_method accessor do |*args|
+          backend.send(accessor, locale, *args)
+        end
       end
     end
   end

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -91,7 +91,7 @@ On top of this, a backend will normally:
     # List locales available for this backend.
     # @return [Array<String>] Array of avialable locales
     def locales
-      map(&:itself)
+      to_a
     end
 
     # @param [Symbol] locale Locale to read

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -175,8 +175,12 @@ On top of this, a backend will normally:
     end
 
     Translation = Struct.new(:backend, :locale) do
-      def value
-        backend.read(locale)
+      def read(options = {})
+        backend.read(locale, options)
+      end
+
+      def write(value, options = {})
+        backend.write(locale, value, options)
       end
     end
   end

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -37,7 +37,7 @@ On top of this, a backend will normally:
       # ...
     end
 
-    def each
+    def each_locale
       # ...
     end
 
@@ -85,13 +85,19 @@ On top of this, a backend will normally:
     # @!macro [new] backend_iterator
     #   Yields locales available for this attribute.
     #   @yieldparam [Symbol] Locale
+    def each_locale
+    end
+
+    # Yields translations to block
+    # @yieldparam [Mobility::Backend::Translation] Translation
     def each
+      each_locale { |locale| yield Translation.new(self, locale) }
     end
 
     # List locales available for this backend.
-    # @return [Array<String>] Array of avialable locales
+    # @return [Array<String>] Array of available locales
     def locales
-      to_a
+      map(&:locale)
     end
 
     # @param [Symbol] locale Locale to read
@@ -165,6 +171,12 @@ On top of this, a backend will normally:
       # @note This is currently only called by Plugins::Cache.
       def apply_plugin(_)
         false
+      end
+    end
+
+    Translation = Struct.new(:backend, :locale) do
+      def value
+        backend.read(locale)
       end
     end
   end

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -91,7 +91,7 @@ On top of this, a backend will normally:
     # List locales available for this backend.
     # @return [Array<String>] Array of avialable locales
     def list
-      map &:itself
+      map(&:itself)
     end
 
     # @param [Symbol] locale Locale to read

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -9,9 +9,8 @@ Defines a minimum set of shared components included in any backend. These are:
 - a reader returning the +model+ on which the backend is defined ({#model})
 - a reader returning the +attribute+ for which the backend is defined
   ({#attribute})
-- a reader returning +options+ configuring the backend ({#options})
-- a constructor setting these three elements (+model+, +attribute+, +options+),
-  and extracting fallbacks from the options hash ({#initialize})
+- a constructor setting these two elements (+model+, +attribute+), and
+  extracting fallbacks from the options hash ({#initialize})
 - a +setup+ method adding any configuration code to the model class
   ({Setup#setup})
 
@@ -19,6 +18,8 @@ On top of this, a backend will normally:
 
 - implement a +read+ instance method to read from the backend
 - implement a +write+ instance method to write to the backend
+- implement an +each+ instance method to iterate through available locales
+  (used to define other +Enumerable+ traversal and search methods)
 - implement a +configure+ class method to apply any normalization to the
   options hash
 - call the +setup+ method yielding attributes and options to configure the
@@ -28,11 +29,15 @@ On top of this, a backend will normally:
   class MyBackend
     include Mobility::Backend
 
-    def read(locale, **options)
+    def read(locale, options = {})
       # ...
     end
 
-    def write(locale, value, **options)
+    def write(locale, value, options = {})
+      # ...
+    end
+
+    def each
       # ...
     end
 
@@ -50,6 +55,8 @@ On top of this, a backend will normally:
 =end
 
   module Backend
+    include Enumerable
+
     # @return [String] Backend attribute
     attr_reader :attribute
 
@@ -74,6 +81,18 @@ On top of this, a backend will normally:
     #   @param [Symbol] locale Locale to write
     #   @param [Object] value Value to write
     #   @return [Object] Updated value
+
+    # @!macro [new] backend_iterator
+    #   Yields locales available for this attribute.
+    #   @yieldparam [Symbol] Locale
+    def each
+    end
+
+    # List locales available for this backend.
+    # @return [Array<String>] Array of avialable locales
+    def list
+      map &:itself
+    end
 
     # @param [Symbol] locale Locale to read
     # @return [TrueClass,FalseClass] Whether translation is present for locale

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -18,7 +18,7 @@ On top of this, a backend will normally:
 
 - implement a +read+ instance method to read from the backend
 - implement a +write+ instance method to write to the backend
-- implement an +each+ instance method to iterate through available locales
+- implement an +each_locale+ instance method to iterate through available locales
   (used to define other +Enumerable+ traversal and search methods)
 - implement a +configure+ class method to apply any normalization to the
   options hash
@@ -95,7 +95,7 @@ On top of this, a backend will normally:
     end
 
     # List locales available for this backend.
-    # @return [Array<String>] Array of available locales
+    # @return [Array<Symbol>] Array of available locales
     def locales
       map(&:locale)
     end

--- a/lib/mobility/backends/active_record/column.rb
+++ b/lib/mobility/backends/active_record/column.rb
@@ -47,7 +47,7 @@ or locales.)
       # @!endgroup
 
       # @!macro backend_iterator
-      def each
+      def each_locale
         available_locales.each { |l| yield(l) if present?(l) }
       end
 

--- a/lib/mobility/backends/active_record/column.rb
+++ b/lib/mobility/backends/active_record/column.rb
@@ -40,13 +40,31 @@ or locales.)
         model.read_attribute(column(locale))
       end
 
-      # @!group Backend Accessors
       # @!macro backend_writer
       def write(locale, value, _ = {})
         model.send(:write_attribute, column(locale), value)
       end
+      # @!endgroup
+
+      # @!macro backend_iterator
+      def each
+        available_locales.each { |l| yield(l) if present?(l) }
+      end
 
       setup_query_methods(QueryMethods)
+
+      private
+
+      def available_locales
+        @available_locales ||= get_column_locales
+      end
+
+      def get_column_locales
+        column_name_regex = /\A#{attribute}_([a-z]{2}(_[a-z]{2})?)\z/.freeze
+        model.class.columns.map do |c|
+          (match = c.name.match(column_name_regex)) && match[1].to_sym
+        end.compact
+      end
     end
   end
 end

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -91,10 +91,6 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
         translation ||= translations.build(locale: locale, key: attribute)
         translation
       end
-
-      def translations
-        model.send(association_name)
-      end
     end
   end
 end

--- a/lib/mobility/backends/active_record/pg_hash.rb
+++ b/lib/mobility/backends/active_record/pg_hash.rb
@@ -14,7 +14,7 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
       include HashValued
 
       # @!macro backend_iterator
-      def each
+      def each_locale
         super { |l| yield l.to_sym }
       end
 

--- a/lib/mobility/backends/active_record/pg_hash.rb
+++ b/lib/mobility/backends/active_record/pg_hash.rb
@@ -13,6 +13,11 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
       include ActiveRecord
       include HashValued
 
+      # @!macro backend_iterator
+      def each
+        super { |l| yield l.to_sym }
+      end
+
       def translations
         model.read_attribute(attribute)
       end

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -149,12 +149,6 @@ columns to that table.
         translation ||= translations.build(locale: locale)
         translation
       end
-
-      private
-
-      def translations
-        model.send(association_name)
-      end
     end
   end
 end

--- a/lib/mobility/backends/hash_valued.rb
+++ b/lib/mobility/backends/hash_valued.rb
@@ -19,6 +19,11 @@ Defines read and write methods that access the value at a key with value
         translations[locale] = value
       end
       # @!endgroup
+
+      # @!macro backend_iterator
+      def each
+        translations.each { |l, _| yield l }
+      end
     end
   end
 end

--- a/lib/mobility/backends/hash_valued.rb
+++ b/lib/mobility/backends/hash_valued.rb
@@ -21,7 +21,7 @@ Defines read and write methods that access the value at a key with value
       # @!endgroup
 
       # @!macro backend_iterator
-      def each
+      def each_locale
         translations.each { |l, _| yield l }
       end
     end

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -67,7 +67,7 @@ class.
       # @!endgroup
 
       # @!macro backend_iterator
-      def each
+      def each_locale
         translations.each { |t| yield(t.locale.to_sym) if t.key == attribute }
       end
 

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -66,6 +66,17 @@ class.
       end
       # @!endgroup
 
+      # @!macro backend_iterator
+      def each
+        translations.each { |t| yield(t.locale.to_sym) if t.key == attribute }
+      end
+
+      private
+
+      def translations
+        model.send(association_name)
+      end
+
       def self.included(backend)
         backend.extend ClassMethods
       end
@@ -84,7 +95,7 @@ class.
         # @return (see Backend::Setup#apply_plugin)
         def apply_plugin(name)
           if name == :cache
-            include Cache
+            include self::Cache
             true
           else
             super

--- a/lib/mobility/backends/sequel/column.rb
+++ b/lib/mobility/backends/sequel/column.rb
@@ -29,7 +29,7 @@ Implements the {Mobility::Backends::Column} backend for Sequel models.
       end
 
       # @!macro backend_iterator
-      def each
+      def each_locale
         available_locales.each { |l| yield(l) if present?(l) }
       end
 

--- a/lib/mobility/backends/sequel/column.rb
+++ b/lib/mobility/backends/sequel/column.rb
@@ -28,7 +28,25 @@ Implements the {Mobility::Backends::Column} backend for Sequel models.
         model[column] = value if model.columns.include?(column)
       end
 
+      # @!macro backend_iterator
+      def each
+        available_locales.each { |l| yield(l) if present?(l) }
+      end
+
       setup_query_methods(QueryMethods)
+
+      private
+
+      def available_locales
+        @available_locales ||= get_column_locales
+      end
+
+      def get_column_locales
+        column_name_regex = /\A#{attribute}_([a-z]{2}(_[a-z]{2})?)\z/.freeze
+        model.columns.map do |c|
+          (match = c.to_s.match(column_name_regex)) && match[1].to_sym
+        end.compact
+      end
     end
   end
 end

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -121,6 +121,16 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
       end
 
       class CacheRequired < ::StandardError; end
+
+      module Cache
+        include KeyValue::Cache
+
+        private
+
+        def translations
+          (model.send(association_name) + cache.values).uniq
+        end
+      end
     end
   end
 end

--- a/lib/mobility/backends/sequel/pg_hash.rb
+++ b/lib/mobility/backends/sequel/pg_hash.rb
@@ -17,7 +17,7 @@ jsonb).
       include StringifyLocale
 
       # @!macro backend_iterator
-      def each
+      def each_locale
         super { |l| yield l.to_sym }
       end
 

--- a/lib/mobility/backends/sequel/pg_hash.rb
+++ b/lib/mobility/backends/sequel/pg_hash.rb
@@ -16,6 +16,11 @@ jsonb).
       include HashValued
       include StringifyLocale
 
+      # @!macro backend_iterator
+      def each
+        super { |l| yield l.to_sym }
+      end
+
       def translations
         model[attribute.to_sym]
       end

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -92,16 +92,22 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
       setup_query_methods(QueryMethods)
 
       def translation_for(locale, _)
-        translation = translations.find { |t| t.locale == locale.to_s }
+        translation = model.send(association_name).find { |t| t.locale == locale.to_s }
         translation ||= translation_class.new(locale: locale)
         translation
       end
 
-      private
+      module Cache
+        include Table::Cache
 
-      def translations
-        model.send(association_name)
+        private
+
+        def translations
+          (model.send(association_name) + cache.values).uniq
+        end
       end
+
+      private
 
       class CacheRequired < ::StandardError; end
     end

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -107,8 +107,6 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
         end
       end
 
-      private
-
       class CacheRequired < ::StandardError; end
     end
   end

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -86,7 +86,7 @@ set.
       # @!endgroup
 
       # @!macro backend_iterator
-      def each
+      def each_locale
         translations.map { |t| yield t.locale.to_sym }
       end
 

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -87,7 +87,7 @@ set.
 
       # @!macro backend_iterator
       def each_locale
-        translations.map { |t| yield t.locale.to_sym }
+        translations.each { |t| yield t.locale.to_sym }
       end
 
       private

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -85,6 +85,17 @@ set.
       end
       # @!endgroup
 
+      # @!macro backend_iterator
+      def each
+        translations.map { |t| yield t.locale.to_sym }
+      end
+
+      private
+
+      def translations
+        model.send(association_name)
+      end
+
       def self.included(backend)
         backend.extend ClassMethods
       end
@@ -95,7 +106,7 @@ set.
         # @return (see Backend::Setup#apply_plugin)
         def apply_plugin(name)
           if name == :cache
-            include Cache
+            include self::Cache
             true
           else
             super

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -45,7 +45,7 @@ describe Mobility::Backend do
       end
     end
 
-    describe "#list" do
+    describe "#locales" do
       it "maps locales to array" do
         backend_class.class_eval do
           def each
@@ -54,7 +54,7 @@ describe Mobility::Backend do
           end
         end
         backend = backend_class.new(model, attribute)
-        expect(backend.list).to eq([:ja, :en])
+        expect(backend.locales).to eq([:ja, :en])
       end
     end
 

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -48,7 +48,7 @@ describe Mobility::Backend do
     describe "#locales" do
       it "maps locales to array" do
         backend_class.class_eval do
-          def each
+          def each_locale
             yield :ja
             yield :en
           end

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -33,7 +33,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
       include_accessor_examples "Article"
 
       it "finds translation on every read/write" do
-        expect(title_backend.translations).to receive(:find).thrice.and_call_original
+        expect(title_backend.send(:translations)).to receive(:find).thrice.and_call_original
         title_backend.write(:en, "foo")
         title_backend.write(:en, "bar")
         expect(title_backend.read(:en)).to eq("bar")
@@ -46,7 +46,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
       include_accessor_examples "Article"
 
       it "only fetches translation once per locale" do
-        expect(title_backend.translations).to receive(:find).twice.and_call_original
+        expect(title_backend.send(:translations)).to receive(:find).twice.and_call_original
         title_backend.write(:en, "foo")
         title_backend.write(:en, "bar")
         expect(title_backend.read(:en)).to eq("bar")

--- a/spec/mobility/backends/sequel/key_value_spec.rb
+++ b/spec/mobility/backends/sequel/key_value_spec.rb
@@ -12,7 +12,7 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel do
       Article.include Mobility
     end
     backend_class_with_cache = Class.new(described_class)
-    backend_class_with_cache.include(Mobility::Backends::Table::Cache)
+    backend_class_with_cache.apply_plugin(:cache)
 
     include_backend_examples backend_class_with_cache, 'Article'
   end

--- a/spec/mobility/backends/sequel/table_spec.rb
+++ b/spec/mobility/backends/sequel/table_spec.rb
@@ -12,7 +12,7 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel do
       Article.include Mobility
     end
     backend_class_with_cache = Class.new(described_class)
-    backend_class_with_cache.include(Mobility::Backends::KeyValue::Cache)
+    backend_class_with_cache.apply_plugin(:cache)
 
     include_backend_examples backend_class_with_cache, 'Article'
   end

--- a/spec/support/shared_examples/backend_examples.rb
+++ b/spec/support/shared_examples/backend_examples.rb
@@ -1,18 +1,29 @@
 shared_examples_for "Mobility backend" do |backend_class, model_class, attribute="title"|
+  let(:backend) do
+    model_class = model_class.constantize if model_class.is_a?(String)
+
+    options = { model_class: model_class }
+    backend_class.configure(options) if backend_class.respond_to?(:configure)
+    backend_class.setup_model(model_class, [attribute], options)
+
+    Class.new(backend_class).new(model_class.new, attribute, options)
+  end
+
   describe "accessors" do
     it "can be called without options hash" do
-      model_class = model_class.constantize if model_class.is_a?(String)
-
-      # Reproduce backend setup in Mobility::Attributes
-      options = { model_class: model_class }
-      backend_class.configure(options) if backend_class.respond_to?(:configure)
-      backend_class.setup_model(model_class, [attribute], options)
-      backend = Class.new(backend_class).new(model_class.new, attribute, options)
-      # end
-
       backend.write(Mobility.locale, "foo")
       backend.read(Mobility.locale)
       expect(backend.read(Mobility.locale)).to eq("foo")
+    end
+  end
+
+  describe "iterators" do
+    it "iterates through locales" do
+      backend.write(:en, "foo")
+      backend.write(:ja, "bar")
+      backend.write(:ru, "baz")
+
+      expect { |b| backend.each &b }.to yield_successive_args(:en, :ja, :ru)
     end
   end
 end

--- a/spec/support/shared_examples/backend_examples.rb
+++ b/spec/support/shared_examples/backend_examples.rb
@@ -23,7 +23,12 @@ shared_examples_for "Mobility backend" do |backend_class, model_class, attribute
       backend.write(:ja, "bar")
       backend.write(:ru, "baz")
 
-      expect { |b| backend.each &b }.to yield_successive_args(:en, :ja, :ru)
+      expect { |b| backend.each_locale &b }.to yield_successive_args(:en, :ja, :ru)
+      expect { |b| backend.each &b }.to yield_successive_args(
+        Mobility::Backend::Translation.new(backend, :en),
+        Mobility::Backend::Translation.new(backend, :ja),
+        Mobility::Backend::Translation.new(backend, :ru))
+      expect(backend.locales).to eq([:en, :ja, :ru])
     end
   end
 end


### PR DESCRIPTION
Resolves #39.

This is a relatively small change, but an important one. Currently backends don't strictly "know" what translations they have. They only know how to query for a translation in a locale, or write to that locale.

There are many cases where you'd want to know what locales are available independent of the implementing backend, so it makes sense to add a method to get locales.

Originally I was just going to add a `locales` method which would do this, but then it occurred to me that hey, this is Ruby, so let's make it more flexible by doing it the Ruby way. So instead of defining a `locales` method, I simply defined an `each` method on every backend which yields each locale successively to a block.

In `Mobility::Backend`, I then also added a `list` method which gets the list of locales from the iterator. I also included `Enumerable` so that you can now call any enumerable method ont he backend and it apply it to the locales, which you can then build off to do anything you'd really want to do:

```ruby
post = Post.create(title: "My Title")
backend = post.title_backend
backend.find { |locale| backend.read(locale) == "My Title" }
```

The only thing I hesitated about slightly was whether the iterator should pass the locale *and* the translated value. I think in the end though, considering that for some backends it might be expensive to do operations which fetch values, it's better to implement the minimum, and on top of that you can read/write any value with `read` and `write`.

In the example above, you can get just a list of locales with `post.title_backend.list`:

```ruby
post = Post.create(title: "My Title")
Mobility.with_locale(:ja) { post.title = "タイトル" }
post.title_backend.list
```

@cbothner @jnylen Have a look and see what you think.