### PR TITLE
Move accessor method to keyword argument in Attributes

### DIFF
--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -17,7 +17,7 @@ understanding and designing backends.
 Since {Attributes} is a subclass of +Module+, including an instance of it is
 like including a module. Creating an instance like this:
 
-  Attributes.new(:accessor, ["title"], backend: :my_backend, locale_accessors: [:en, :ja], cache: true, fallbacks: true)
+  Attributes.new("title", backend: :my_backend, locale_accessors: [:en, :ja], cache: true, fallbacks: true)
 
 will generate an anonymous module that behaves like this:
 
@@ -128,7 +128,7 @@ with other backends.
     # @param [Hash] backend_options Backend options hash
     # @option backend_options [Class] model_class Class of model
     # @raise [ArgumentError] if method is not reader, writer or accessor
-    def initialize(method, *attribute_names, backend: Mobility.default_backend, **backend_options)
+    def initialize(*attribute_names, method: :accessor, backend: Mobility.default_backend, **backend_options)
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)
       @method = method
       @options = Mobility.default_options.merge(backend_options)

--- a/lib/mobility/translates.rb
+++ b/lib/mobility/translates.rb
@@ -61,7 +61,7 @@ passed to accessors to configure backend (see example below).
     %w[accessor reader writer].each do |method|
       class_eval <<-EOM, __FILE__, __LINE__ + 1
         def mobility_#{method}(*args, **options, &block)
-          attributes = Attributes.new(:#{method}, *args, options)
+          attributes = Attributes.new(*args, method: :#{method}, **options)
           attributes.backend.instance_eval(&block) if block_given?
           include attributes
         end

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -30,17 +30,17 @@ describe Mobility::Attributes do
 
   describe "initializing" do
     it "raises ArgumentError if method is not reader, writer or accessor" do
-      expect { described_class.new(:foo) }.to raise_error(ArgumentError)
+      expect { described_class.new(method: :foo) }.to raise_error(ArgumentError)
     end
 
     it "raises BackendRequired error if backend is nil and no default is set" do
-      expect { described_class.new(:accessor, "title") }.to raise_error(Mobility::BackendRequired)
+      expect { described_class.new("title") }.to raise_error(Mobility::BackendRequired)
     end
 
     it "does not raise error if backend is nil but default_backend is set" do
       original_default_backend = Mobility.config.default_backend
       Mobility.config.default_backend = :null
-      expect { described_class.new(:accessor, "title") }.not_to raise_error
+      expect { described_class.new("title") }.not_to raise_error
       Mobility.config.default_backend = original_default_backend
     end
   end
@@ -50,17 +50,17 @@ describe Mobility::Attributes do
 
     it "calls configure on backend class with options merged with default options" do
       expect(backend_class).to receive(:configure).with(expected_options)
-      attributes = described_class.new(:accessor, "title", backend: backend_class, foo: "bar")
+      attributes = described_class.new("title", backend: backend_class, foo: "bar")
       Article.include attributes
     end
 
     it "calls setup_model on backend class with model_class, attributes, and options merged with default options" do
       expect(backend_class).to receive(:setup_model).with(Article, ["title"], expected_options)
-      Article.include described_class.new(:accessor, "title", backend: backend_class, foo: "bar")
+      Article.include described_class.new("title", backend: backend_class, foo: "bar")
     end
 
     it "includes module in model_class.mobility" do
-      attributes = described_class.new(:accessor, "title", backend: backend_class)
+      attributes = described_class.new("title", backend: backend_class)
       Article.include attributes
       expect(Article.mobility.modules).to eq([attributes])
     end
@@ -68,13 +68,13 @@ describe Mobility::Attributes do
     describe "cache" do
       it "includes Plugins::Cache into backend when options[:cache] is not false" do
         clean_options.delete(:cache)
-        attributes = described_class.new(:accessor, "title", backend: backend_class, **clean_options)
+        attributes = described_class.new("title", backend: backend_class, **clean_options)
         Article.include attributes
         expect(attributes.backend_class.ancestors).to include(Mobility::Plugins::Cache)
       end
 
       it "does not include Plugins::Cache into backend when options[:cache] is false" do
-        attributes = described_class.new(:accessor, "title", backend: backend_class, **clean_options)
+        attributes = described_class.new("title", backend: backend_class, **clean_options)
         Article.include attributes
         expect(attributes.backend_class.ancestors).not_to include(Mobility::Plugins::Cache)
       end
@@ -82,7 +82,7 @@ describe Mobility::Attributes do
 
     describe "defining attribute backend on model" do
       before do
-        Article.include described_class.new(:accessor, "title", backend: backend_class, foo: "bar")
+        Article.include described_class.new("title", backend: backend_class, foo: "bar")
       end
       let(:article) { Article.new }
       let(:expected_options) { { foo: "bar", **Mobility.default_options, model_class: Article } }
@@ -178,14 +178,14 @@ describe Mobility::Attributes do
       end
 
       describe "method = :accessor" do
-        before { Article.include described_class.new(:accessor, "title", backend: backend_class) }
+        before { Article.include described_class.new("title", backend: backend_class) }
 
         it_behaves_like "reader"
         it_behaves_like "writer"
       end
 
       describe "method = :reader" do
-        before { Article.include described_class.new(:reader, "title", backend: backend_class) }
+        before { Article.include described_class.new("title", backend: backend_class, method: :reader) }
 
         it_behaves_like "reader"
 
@@ -196,7 +196,7 @@ describe Mobility::Attributes do
       end
 
       describe "method = :writer" do
-        before { Article.include described_class.new(:writer, "title", backend: backend_class) }
+        before { Article.include described_class.new("title", backend: backend_class, method: :writer) }
 
         it_behaves_like "writer"
 
@@ -240,14 +240,14 @@ describe Mobility::Attributes do
 
   describe "#each" do
     it "delegates to attributes" do
-      attributes = described_class.new(:accessor, :title, :content, backend: :null)
+      attributes = described_class.new("title", "content", backend: :null)
       expect { |b| attributes.each(&b) }.to yield_successive_args("title", "content")
     end
   end
 
   describe "#backend_name" do
     it "returns backend name" do
-      attributes = described_class.new(:accessor, :title, :content, backend: :null)
+      attributes = described_class.new("title", "content", backend: :null)
       expect(attributes.backend_name).to eq(:null)
     end
   end

--- a/spec/mobility/translates_spec.rb
+++ b/spec/mobility/translates_spec.rb
@@ -11,7 +11,7 @@ describe Mobility::Translates do
       attributes = Module.new do
         def self.each &block; end
       end
-      expect(Mobility::Attributes).to receive(:new).with(:accessor, *attribute_names, {}).and_return(attributes)
+      expect(Mobility::Attributes).to receive(:new).with(*attribute_names, { method: :accessor }).and_return(attributes)
       MyClass.mobility_accessor *attribute_names
     end
 

--- a/spec/performance/attributes_spec.rb
+++ b/spec/performance/attributes_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Mobility::Attributes do
   describe "initializing" do
     specify {
-      expect { described_class.new(:accessor, backend: :null) }.to allocate_under(9).objects
+      expect { described_class.new(backend: :null) }.to allocate_under(9).objects
     }
   end
 
@@ -12,7 +12,7 @@ describe Mobility::Attributes do
       klass = Class.new do
         include Mobility
       end
-      attributes = described_class.new(:accessor, backend: :null)
+      attributes = described_class.new(backend: :null)
       expect { klass.include attributes }.to allocate_under(125).objects
     }
   end


### PR DESCRIPTION
Currently `Mobility::Attributes` takes a `method` argument followed by one or more attribute names, but since in 99% of cases the `method` argument is `:accessor`, it makes more sense to bump this to the keyword arguments (with a default of `method: :accessor`), and just take a list of attributes.