### PR TITLE
Fix initialization error when inheriting

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -254,7 +254,7 @@ module Mobility
     end
 
     def inherited(subclass)
-      subclass.instance_variable_set(:@mobility, @mobility.dup)
+      subclass.instance_variable_set(:@mobility, mobility.dup)
       super
     end
   end


### PR DESCRIPTION
Depending on loading order, `@mobility` may have not been initialized yet, so use method to ensure we aren't trying to dup nil.

Resolves #82.