### PR TITLE
When duping an object with translations, also dup the translations

### DIFF
--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -138,13 +138,16 @@ columns to that table.
           foreign_key: options[:foreign_key],
           inverse_of:  association_name
 
+        module_name = "MobilityArTable#{association_name.to_s.camelcase}"
+        unless const_defined?(module_name)
           callback_methods = Module.new do
             define_method :initialize_dup do |source|
               super(source)
               self.send("#{association_name}=", source.send(association_name).map(&:dup))
             end
           end
-          include callback_methods
+          include const_set(module_name, callback_methods)
+        end
       end
 
       setup_query_methods(QueryMethods)

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -137,6 +137,14 @@ columns to that table.
           class_name:  name,
           foreign_key: options[:foreign_key],
           inverse_of:  association_name
+
+          callback_methods = Module.new do
+            define_method :initialize_dup do |source|
+              super(source)
+              self.send("#{association_name}=", source.send(association_name).map(&:dup))
+            end
+          end
+          include callback_methods
       end
 
       setup_query_methods(QueryMethods)

--- a/spec/mobility/backends/active_record/column_spec.rb
+++ b/spec/mobility/backends/active_record/column_spec.rb
@@ -62,6 +62,7 @@ describe "Mobility::Backends::ActiveRecord::Column", orm: :active_record do
 
     describe "Model accessors" do
       include_accessor_examples 'Comment', :content, :author
+      include_dup_examples 'Comment', :content
     end
 
     describe "with locale accessors" do

--- a/spec/mobility/backends/active_record/hstore_spec.rb
+++ b/spec/mobility/backends/active_record/hstore_spec.rb
@@ -25,6 +25,7 @@ describe "Mobility::Backends::ActiveRecord::Hstore", orm: :active_record, db: :p
     include_serialization_examples 'HstorePost'
     include_querying_examples 'HstorePost'
     include_validation_examples 'HstorePost'
+    include_dup_examples 'HstorePost'
 
     describe "non-text values" do
       it "converts non-string types to strings when saving" do

--- a/spec/mobility/backends/active_record/jsonb_spec.rb
+++ b/spec/mobility/backends/active_record/jsonb_spec.rb
@@ -25,6 +25,7 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
     include_serialization_examples 'JsonbPost'
     include_querying_examples 'JsonbPost'
     include_validation_examples 'JsonbPost'
+    include_dup_examples 'JsonbPost'
 
     describe "non-text values" do
       it "stores non-string types as-is when saving", rails_version_geq: '5.0' do

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -31,6 +31,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
     context "without cache" do
       let(:article) { Article.new }
       include_accessor_examples "Article"
+      include_dup_examples "Article"
 
       it "finds translation on every read/write" do
         expect(title_backend.send(:translations)).to receive(:find).thrice.and_call_original

--- a/spec/mobility/backends/active_record/serialized_spec.rb
+++ b/spec/mobility/backends/active_record/serialized_spec.rb
@@ -22,6 +22,7 @@ describe "Mobility::Backends::ActiveRecord::Serialized", orm: :active_record do
         before { SerializedPost.translates :title, :content, backend: :serialized, format: :yaml, cache: false, presence: false }
         include_accessor_examples 'SerializedPost'
         include_serialization_examples 'SerializedPost'
+        include_dup_examples 'SerializedPost'
 
         describe "non-text values" do
           it "converts non-string types to strings when saving", rails_version_geq: '5.0' do

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -16,6 +16,7 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
   context "without cache" do
     before { Article.translates :title, :content, backend: :table, cache: false }
     include_accessor_examples "Article"
+    include_dup_examples "Article"
 
     it "finds translation on every read/write" do
       article = Article.new

--- a/spec/mobility/backends/sequel/column_spec.rb
+++ b/spec/mobility/backends/sequel/column_spec.rb
@@ -112,5 +112,9 @@ describe "Mobility::Backends::Sequel::Column", orm: :sequel do
     describe "mobility dataset (.i18n)" do
       include_querying_examples 'Comment', :content, :author
     end
+
+    describe "dup" do
+      include_dup_examples 'Comment', :content
+    end
   end
 end if Mobility::Loaded::Sequel

--- a/spec/mobility/backends/sequel/hstore_spec.rb
+++ b/spec/mobility/backends/sequel/hstore_spec.rb
@@ -25,6 +25,7 @@ describe "Mobility::Backends::Sequel::Hstore", orm: :sequel, db: :postgres do
     include_accessor_examples 'HstorePost'
     #include_serialization_examples 'HstorePost'
     include_querying_examples 'HstorePost'
+    include_dup_examples 'HstorePost'
 
     describe "non-text values" do
       it "converts non-string types to strings when saving" do

--- a/spec/mobility/backends/sequel/jsonb_spec.rb
+++ b/spec/mobility/backends/sequel/jsonb_spec.rb
@@ -24,6 +24,7 @@ describe "Mobility::Backends::Sequel::Jsonb", orm: :sequel, db: :postgres do
     include_accessor_examples 'JsonbPost'
     include_serialization_examples 'JsonbPost'
     include_querying_examples 'JsonbPost'
+    include_dup_examples 'JsonbPost'
 
     describe "non-text values" do
       it "stores non-string types as-is when saving" do

--- a/spec/mobility/backends/sequel/key_value_spec.rb
+++ b/spec/mobility/backends/sequel/key_value_spec.rb
@@ -34,6 +34,7 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel do
     end
 
     include_accessor_examples 'Article'
+    include_dup_examples 'Article'
 
     describe "cache" do
       let(:article) { Article.new }

--- a/spec/mobility/backends/sequel/serialized_spec.rb
+++ b/spec/mobility/backends/sequel/serialized_spec.rb
@@ -22,6 +22,7 @@ describe "Mobility::Backends::Sequel::Serialized", orm: :sequel do
         before { SerializedPost.translates :title, :content, backend: :serialized, format: :yaml, cache: false, presence: false }
         include_accessor_examples 'SerializedPost'
         include_serialization_examples 'SerializedPost'
+        include_dup_examples 'SerializedPost'
 
         describe "non-text values" do
           it "converts non-string types to strings when saving" do

--- a/spec/mobility/backends/sequel/table_spec.rb
+++ b/spec/mobility/backends/sequel/table_spec.rb
@@ -28,6 +28,7 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel do
     end
 
     include_accessor_examples "Article"
+    include_dup_examples "Article"
 
     it "only fetches translation once per locale" do
       article = Article.new

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -32,6 +32,10 @@ module Helpers
     def include_backend_examples *args
       it_behaves_like "Mobility backend", *args
     end
+
+    def include_dup_examples *args
+      it_behaves_like "dupable model", *args
+    end
   end
 
   module ActiveRecord

--- a/spec/support/shared_examples/dup_examples.rb
+++ b/spec/support/shared_examples/dup_examples.rb
@@ -1,0 +1,59 @@
+shared_examples_for "dupable model"  do |model_class_name, attribute=:title|
+  let(:model_class) { constantize(model_class_name) }
+
+  it "dups persisted model" do
+    skip_if_duping_not_implemented
+    instance = model_class.new
+    instance_backend = instance.send("#{attribute}_backend")
+    instance_backend.write(:en, "foo")
+    instance_backend.write(:ja, "ほげ")
+    save_or_raise(instance)
+
+    dupped_instance = instance.dup
+    dupped_backend = dupped_instance.send("#{attribute}_backend")
+    expect(dupped_backend.read(:en)).to eq("foo")
+    expect(dupped_backend.read(:ja)).to eq("ほげ")
+
+    save_or_raise(dupped_instance)
+    expect(dupped_instance.send(attribute)).to eq(instance.send(attribute))
+
+    # Ensure we haven't mucked with the original instance
+    instance.reload
+
+    expect(instance_backend.read(:en)).to eq("foo")
+    expect(instance_backend.read(:ja)).to eq("ほげ")
+  end
+
+  it "dups new record" do
+    skip_if_duping_not_implemented
+    instance = model_class.new(attribute => "foo")
+    dupped_instance = instance.dup
+
+    expect(instance.send(attribute)).to eq("foo")
+    expect(dupped_instance.send(attribute)).to eq("foo")
+
+    save_or_raise(instance)
+    save_or_raise(dupped_instance)
+
+    # Ensure we haven't mucked with the original instance
+    instance.reload
+    dupped_instance.reload
+
+    expect(instance.send(attribute)).to eq("foo")
+    expect(dupped_instance.send(attribute)).to eq("foo")
+  end
+
+  def save_or_raise(instance)
+    if instance.respond_to?(:save!)
+      instance.save!
+    else
+      instance.save
+    end
+  end
+
+  def skip_if_duping_not_implemented
+    if described_class < Mobility::Backends::KeyValue
+      skip "Duping has not been properly implemented"
+    end
+  end
+end


### PR DESCRIPTION
I noticed mobility doesn't support duping translations [like globalize does]( https://github.com/globalize/globalize/blob/ef1e362f3144b2276d89f47407c67ffa3fc1f9f2/lib/globalize/active_record/instance_methods.rb#L98-L105). 

I took a stab at implementing it, but not sure if this is the right approach.

Also, it wasn't clear for me where to put the test. I'm assuming you want to test something like this against every backend. Where should I add real tests?