### PR TITLE
Enable fallbacks when fallback option is true

### DIFF
--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -98,7 +98,7 @@ locale was +nil+.
           if fallback == false || (fallback.nil? && fallbacks.nil?)
             super(locale, options)
           else
-            (fallback ? [locale, *fallback] : fallbacks[locale]).detect do |fallback_locale|
+            (fallback.is_a?(Symbol) ? [locale, *fallback] : fallbacks[locale]).detect do |fallback_locale|
               value = super(fallback_locale, options)
               break value if Util.present?(value)
             end

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -49,6 +49,10 @@ describe Mobility::Plugins::Fallbacks do
         expect(subject.read(:"en-US", fallback: false)).to eq(nil)
       end
 
+      it "falls through to fallback locale when fallback: true option is passed" do
+        expect(subject.read(:"en-US", fallback: true)).to eq("foo")
+      end
+
       it "uses locale passed in as value of fallback option when present" do
         expect(subject.read(:"en-US", fallback: :ja)).to eq("フー")
       end


### PR DESCRIPTION
Currently passing `fallback: true` acts like `fallback: false` because `true` is interpreted as a locale rather than a boolean.