### PR TITLE
Test integration with AR's update_attribute method

### DIFF
--- a/spec/mobility/backends/active_record/column_spec.rb
+++ b/spec/mobility/backends/active_record/column_spec.rb
@@ -109,5 +109,9 @@ describe "Mobility::Backends::ActiveRecord::Column", orm: :active_record do
       include_querying_examples 'Comment', :content, :author
       include_validation_examples 'Comment', :content, :author
     end
+
+    describe "ar integration" do
+      include_ar_integration_examples "Comment", :content
+    end
   end
 end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backends/active_record/hstore_spec.rb
+++ b/spec/mobility/backends/active_record/hstore_spec.rb
@@ -25,6 +25,7 @@ describe "Mobility::Backends::ActiveRecord::Hstore", orm: :active_record, db: :p
     include_serialization_examples 'HstorePost'
     include_querying_examples 'HstorePost'
     include_validation_examples 'HstorePost'
+    include_ar_integration_examples "HstorePost"
 
     describe "non-text values" do
       it "converts non-string types to strings when saving" do

--- a/spec/mobility/backends/active_record/jsonb_spec.rb
+++ b/spec/mobility/backends/active_record/jsonb_spec.rb
@@ -25,6 +25,7 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
     include_serialization_examples 'JsonbPost'
     include_querying_examples 'JsonbPost'
     include_validation_examples 'JsonbPost'
+    include_ar_integration_examples 'JsonbPost'
 
     describe "non-text values" do
       it "stores non-string types as-is when saving", rails_version_geq: '5.0' do

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -31,6 +31,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
     context "without cache" do
       let(:article) { Article.new }
       include_accessor_examples "Article"
+      include_ar_integration_examples "Article"
 
       it "finds translation on every read/write" do
         expect(title_backend.send(:translations)).to receive(:find).thrice.and_call_original

--- a/spec/mobility/backends/active_record/serialized_spec.rb
+++ b/spec/mobility/backends/active_record/serialized_spec.rb
@@ -22,6 +22,7 @@ describe "Mobility::Backends::ActiveRecord::Serialized", orm: :active_record do
         before { SerializedPost.translates :title, :content, backend: :serialized, format: :yaml, cache: false, presence: false }
         include_accessor_examples 'SerializedPost'
         include_serialization_examples 'SerializedPost'
+        include_ar_integration_examples 'SerializedPost'
 
         describe "non-text values" do
           it "converts non-string types to strings when saving", rails_version_geq: '5.0' do

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -30,6 +30,7 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
   context "with cache" do
     before { Article.translates :title, :content, backend: :table, cache: true }
     include_accessor_examples "Article"
+    include_ar_integration_examples "Article"
 
     it "only fetches translation once per locale" do
       article = Article.new

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -52,6 +52,10 @@ module Helpers
     def include_validation_examples *args
       it_behaves_like "AR Model validation", *args
     end
+
+    def include_ar_integration_examples *args
+      it_behaves_like "AR integration", *args
+    end
   end
 
   module Sequel

--- a/spec/support/shared_examples/ar_integration_examples.rb
+++ b/spec/support/shared_examples/ar_integration_examples.rb
@@ -1,0 +1,10 @@
+shared_examples_for "AR integration" do |model_class_name, attribute=:title|
+  let(:model_class) { model_class_name.constantize }
+
+  it "persits with update_attribute" do
+    model = model_class.create(attribute => "foo")
+    expect(model.update_attribute(attribute, "bar")).to eq(true)
+    expect(model.send(attribute)).to eq("bar")
+    expect(model.reload.send(attribute)).to eq("bar")
+  end
+end


### PR DESCRIPTION
Appears to be broken in the key_value/table backends. Works under Rails 5.0 if dirty plugin is enabled. Does not work even if the plugin is enabled under Rails 5.1.

Looking at update_column itself, it seems to rely on dirty handling, only saving if there are changes, which explains why it doesn't work without the dirty plugin in Rails 5.0. It's not so obvious to me why it would be broken under 5.1, and this possibly means there's something off with the dirty plugin under 5.1.