### PR TITLE
Ensure cache_key is invalidated when updating translations

### DIFF
--- a/lib/mobility/active_record/translation.rb
+++ b/lib/mobility/active_record/translation.rb
@@ -4,7 +4,7 @@ module Mobility
     class Translation < ::ActiveRecord::Base
       self.abstract_class = true
 
-      belongs_to :translatable, polymorphic: true
+      belongs_to :translatable, polymorphic: true, touch: true
 
       validates :key, presence: true, uniqueness: { scope: [:translatable_id, :translatable_type, :locale] }
       validates :translatable, presence: true

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -136,7 +136,8 @@ columns to that table.
         translation_class.belongs_to :translated_model,
           class_name:  name,
           foreign_key: options[:foreign_key],
-          inverse_of:  association_name
+          inverse_of:  association_name,
+          touch: true
 
         module_name = "MobilityArTable#{association_name.to_s.camelcase}"
         unless const_defined?(module_name)

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -24,6 +24,8 @@ module Mobility
           create_table "articles" do |t|
             t.string :slug
             t.boolean :published
+            t.datetime "created_at", null: false
+            t.datetime "updated_at", null: false
           end
 
           create_table "article_translations" do |t|
@@ -81,12 +83,16 @@ module Mobility
             t.text :author_pt_br
             t.text :author_ru
             t.boolean :published
+            t.datetime "created_at", null: false
+            t.datetime "updated_at", null: false
           end
 
           create_table "serialized_posts" do |t|
             t.text :title
             t.text :content
             t.boolean :published
+            t.datetime "created_at", null: false
+            t.datetime "updated_at", null: false
           end
 
           if ENV['DB'] == 'postgres'
@@ -99,6 +105,8 @@ module Mobility
                 t.jsonb :content, default: ''
               end
               t.boolean :published
+              t.datetime "created_at", null: false
+              t.datetime "updated_at", null: false
             end
 
             execute "CREATE EXTENSION IF NOT EXISTS hstore"
@@ -107,6 +115,8 @@ module Mobility
               t.hstore :title, default: ''
               t.hstore :content, default: ''
               t.boolean :published
+              t.datetime "created_at", null: false
+              t.datetime "updated_at", null: false
             end
           end
         end

--- a/spec/mobility/backends/active_record/column_spec.rb
+++ b/spec/mobility/backends/active_record/column_spec.rb
@@ -30,6 +30,8 @@ describe "Mobility::Backends::ActiveRecord::Column", orm: :active_record do
 
     subject { comment }
 
+    include_cache_key_examples "Comment", :content
+
     describe "#read" do
       it "returns attribute in locale from appropriate column" do
         aggregate_failures do

--- a/spec/mobility/backends/active_record/hstore_spec.rb
+++ b/spec/mobility/backends/active_record/hstore_spec.rb
@@ -26,6 +26,7 @@ describe "Mobility::Backends::ActiveRecord::Hstore", orm: :active_record, db: :p
     include_querying_examples 'HstorePost'
     include_validation_examples 'HstorePost'
     include_dup_examples 'HstorePost'
+    include_cache_key_examples 'HstorePost'
 
     describe "non-text values" do
       it "converts non-string types to strings when saving" do

--- a/spec/mobility/backends/active_record/jsonb_spec.rb
+++ b/spec/mobility/backends/active_record/jsonb_spec.rb
@@ -26,6 +26,7 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
     include_querying_examples 'JsonbPost'
     include_validation_examples 'JsonbPost'
     include_dup_examples 'JsonbPost'
+    include_cache_key_examples 'JsonbPost'
 
     describe "non-text values" do
       it "stores non-string types as-is when saving", rails_version_geq: '5.0' do

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -32,6 +32,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
       let(:article) { Article.new }
       include_accessor_examples "Article"
       include_dup_examples "Article"
+      include_cache_key_examples "Article"
 
       it "finds translation on every read/write" do
         expect(title_backend.send(:translations)).to receive(:find).thrice.and_call_original

--- a/spec/mobility/backends/active_record/serialized_spec.rb
+++ b/spec/mobility/backends/active_record/serialized_spec.rb
@@ -23,6 +23,7 @@ describe "Mobility::Backends::ActiveRecord::Serialized", orm: :active_record do
         include_accessor_examples 'SerializedPost'
         include_serialization_examples 'SerializedPost'
         include_dup_examples 'SerializedPost'
+        include_cache_key_examples 'SerializedPost'
 
         describe "non-text values" do
           it "converts non-string types to strings when saving", rails_version_geq: '5.0' do

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -17,6 +17,7 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
     before { Article.translates :title, :content, backend: :table, cache: false }
     include_accessor_examples "Article"
     include_dup_examples "Article"
+    include_cache_key_examples "Article"
 
     it "finds translation on every read/write" do
       article = Article.new

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -36,6 +36,10 @@ module Helpers
     def include_dup_examples *args
       it_behaves_like "dupable model", *args
     end
+
+    def include_cache_key_examples *args
+      it_behaves_like "cache key", *args
+    end
   end
 
   module ActiveRecord

--- a/spec/support/shared_examples/cache_key_examples.rb
+++ b/spec/support/shared_examples/cache_key_examples.rb
@@ -1,0 +1,10 @@
+shared_examples_for "cache key"  do |model_class_name, attribute=:title|
+  let(:model_class) { constantize(model_class_name) }
+
+  it "changes cache key when translation updated" do
+    model = model_class.create!(attribute => "foo")
+    original_cache_key = model.cache_key
+    model.update_attributes!(attribute => "bar")
+    expect(model.cache_key).to_not eq(original_cache_key)
+  end
+end


### PR DESCRIPTION
For the table and key_value backends, this means the model itself is touched when updating a translation.

Fixes #101.