### PR TITLE
Test against ActiveRecord 5.2.0.beta.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
   - DB=postgres ORM=active_record RAILS_VERSION=5.1
   - DB=mysql ORM=active_record RAILS_VERSION=5.1
   - DB=sqlite3 ORM=active_record RAILS_VERSION=5.1
+  - DB=postgres ORM=active_record RAILS_VERSION=latest
+  - DB=mysql ORM=active_record RAILS_VERSION=latest
+  - DB=sqlite3 ORM=active_record RAILS_VERSION=latest
   - DB=postgres ORM=sequel SEQUEL_VERSION=4.41
   - DB=mysql ORM=sequel SEQUEL_VERSION=4.41
   - DB=sqlite3 ORM=sequel SEQUEL_VERSION=4.41
@@ -23,6 +26,11 @@ env:
   - DB=mysql ORM=sequel SEQUEL_VERSION=4.46
   - DB=sqlite3 ORM=sequel SEQUEL_VERSION=4.46
   - DB=sqlite3 ORM= TEST_PERFORMANCE=true
+matrix:
+  allow_failures:
+    - env: DB=postgres ORM=active_record RAILS_VERSION=latest
+    - env: DB=mysql ORM=active_record RAILS_VERSION=latest
+    - env: DB=sqlite3 ORM=active_record RAILS_VERSION=latest
 before_script:
   - bundle exec rake db:create db:up
 before_install: gem install bundler -v 1.12.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - DB=sqlite3 ORM=sequel SEQUEL_VERSION=4.46
   - DB=sqlite3 ORM= TEST_PERFORMANCE=true
 matrix:
+  fast_finish: true
   allow_failures:
     - env: DB=postgres ORM=active_record RAILS_VERSION=latest
     - env: DB=mysql ORM=active_record RAILS_VERSION=latest

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ group :development, :test do
       gem 'activerecord', '>= 5.0', '< 5.1'
     elsif ENV['RAILS_VERSION'] == '4.2'
       gem 'activerecord', '>= 4.2.6', '< 5.0'
+    elsif ENV['RAILS_VERSION'] == 'latest'
+      gem 'activerecord', '5.2.0.beta1'
+      gem 'railties', '5.2.0.beta1'
     else
       gem 'activerecord', '>= 5.1', '< 5.2'
     end


### PR DESCRIPTION
There are a bunch of changes coming up relating to how attributes are treated in ActiveModel and ActiveRecord. I just ran the test suite against the beta version of AR 5.2 and there are 26 failures, mostly relating to AR::Dirty.

In parallel I'm working on supporting some of the new AR::Dirty methods like `saved_changes` in #111, in response to #106, but I'm wondering if these changes will just make the transition to 5.2.0 harder. For now I'll continue on #111 but here I'm adding the latest AR versions to the build with `allow_failures`, so we can see what we will need to do to make this all work.