### PR TITLE
Fix generator spec issues with latest AR version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ env:
   - DB=postgres ORM=active_record RAILS_VERSION=5.1
   - DB=mysql ORM=active_record RAILS_VERSION=5.1
   - DB=sqlite3 ORM=active_record RAILS_VERSION=5.1
-  - DB=postgres ORM=active_record RAILS_VERSION=latest
-  - DB=mysql ORM=active_record RAILS_VERSION=latest
-  - DB=sqlite3 ORM=active_record RAILS_VERSION=latest
+  - DB=postgres ORM=active_record RAILS_VERSION=5.2
+  - DB=mysql ORM=active_record RAILS_VERSION=5.2
+  - DB=sqlite3 ORM=active_record RAILS_VERSION=5.2
   - DB=postgres ORM=sequel SEQUEL_VERSION=4.41
   - DB=mysql ORM=sequel SEQUEL_VERSION=4.41
   - DB=sqlite3 ORM=sequel SEQUEL_VERSION=4.41

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development, :test do
       gem 'activerecord', '>= 5.0', '< 5.1'
     elsif ENV['RAILS_VERSION'] == '4.2'
       gem 'activerecord', '>= 4.2.6', '< 5.0'
-    elsif ENV['RAILS_VERSION'] == 'latest'
+    elsif ENV['RAILS_VERSION'] == '5.2'
       gem 'activerecord', '>= 5.2.0.beta1'
       gem 'railties', '>= 5.2.0.beta1'
     else

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -30,7 +30,7 @@ value of the translated attribute if passed to it.
         def write(locale, value, options = {})
           locale_accessor = Mobility.normalize_locale_accessor(attribute, locale)
           if model.changed_attributes.has_key?(locale_accessor) && model.changed_attributes[locale_accessor] == value
-            model.attributes_changed_by_setter.except!(locale_accessor)
+            model.send(:attributes_changed_by_setter).except!(locale_accessor)
           elsif read(locale, options.merge(fallback: false)) != value
             model.send(:attribute_will_change!, locale_accessor)
           end

--- a/lib/mobility/plugins/active_record/dirty.rb
+++ b/lib/mobility/plugins/active_record/dirty.rb
@@ -51,7 +51,7 @@ AR::Dirty plugin adds support for the following persistence-specific methods
               end
             end
             model_class.extend has_attribute
-            model_class.include ReadAttribute
+            model_class.include ReadAttribute if ::ActiveRecord::VERSION::STRING >= '5.2'
           end
 
           private

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
   require "generator_spec/test_case"
   include GeneratorSpec::TestCase
+  include Helpers::Generators
 
   destination File.expand_path("../tmp", __FILE__)
 
@@ -30,6 +31,8 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
     end
 
     it "generates migration for text translations table" do
+      version_string_ = version_string
+
       expect(destination_root).to have_structure {
         directory "db" do
           directory "migrate" do
@@ -37,7 +40,7 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
               if ENV["RAILS_VERSION"] < "5.0"
                 contains "class CreateTextTranslations < ActiveRecord::Migration"
               else
-                contains "class CreateTextTranslations < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                contains "class CreateTextTranslations < ActiveRecord::Migration[#{version_string_}]"
               end
               contains "def change"
               contains "create_table :mobility_text_translations"
@@ -52,6 +55,8 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
     end
 
     it "generates migration for string translations table" do
+      version_string_ = version_string
+
       expect(destination_root).to have_structure {
         directory "db" do
           directory "migrate" do
@@ -59,7 +64,7 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
               if ENV["RAILS_VERSION"] < "5.0"
                 contains "class CreateStringTranslations < ActiveRecord::Migration"
               else
-                contains "class CreateStringTranslations < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                contains "class CreateStringTranslations < ActiveRecord::Migration[#{version_string_}]"
               end
               contains "def change"
               contains "create_table :mobility_string_translations"

--- a/spec/generators/rails/mobility/translations_generator_spec.rb
+++ b/spec/generators/rails/mobility/translations_generator_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record do
   require "generator_spec/test_case"
   include GeneratorSpec::TestCase
+  include Helpers::Generators
   require "rails/generators/mobility/translations_generator"
 
   destination File.expand_path("../tmp", __FILE__)
@@ -17,6 +18,7 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
 
     context "translations table does not yet exist" do
       it "generates table translations migration creating translations table" do
+        version_string_ = version_string
         setup_generator
 
         expect(destination_root).to have_structure {
@@ -26,7 +28,7 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
                 if ENV["RAILS_VERSION"] < "5.0"
                   contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration"
                 else
-                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{version_string_}]"
                 end
                 contains "def change"
                 contains "create_table :post_translations"
@@ -51,6 +53,7 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
       after  { ActiveRecord::Base.connection.drop_table   :post_translations }
 
       it "generates table translations migration adding columns to existing translations table" do
+        version_string_ = version_string
         setup_generator
 
         expect(destination_root).to have_structure {
@@ -60,7 +63,7 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
                 if ENV["RAILS_VERSION"] < "5.0"
                   contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration"
                 else
-                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                  contains "class CreatePostTitleAndContentTranslationsForMobilityTableBackend < ActiveRecord::Migration[#{version_string_}]"
                 end
                 contains "add_column :post_translations, :title, :string"
                 contains "add_index :post_translations, :title"
@@ -95,6 +98,8 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
       end
 
       it "generates column translations migration adding columns for each locale to model table" do
+        version_string_ = version_string
+
         expect(destination_root).to have_structure {
           directory "db" do
             directory "migrate" do
@@ -102,7 +107,7 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
                 if ENV["RAILS_VERSION"] < "5.0"
                   contains "class CreateFooTitleAndContentTranslationsForMobilityColumnBackend < ActiveRecord::Migration"
                 else
-                  contains "class CreateFooTitleAndContentTranslationsForMobilityColumnBackend < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
+                  contains "class CreateFooTitleAndContentTranslationsForMobilityColumnBackend < ActiveRecord::Migration[#{version_string_}]"
                 end
                 contains "add_column :foos, :title_en, :string"
                 contains "add_index  :foos, :title_en"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -78,4 +78,10 @@ module Helpers
       it_behaves_like "Sequel Model with serialized translations", *args
     end
   end
+
+  module Generators
+    def version_string
+      "#{::ActiveRecord::VERSION::MAJOR}.#{::ActiveRecord::VERSION::MINOR}"
+    end
+  end
 end


### PR DESCRIPTION
The generator specs currently use the `RAILS_VERSION` env variable, but we use the string `"latest"` to run specs against the latest versions of AR and Sequel, so those specs are currently failing even though they should actually pass. This fixes that issue.