### PR TITLE
Use module_eval to define query scope, and name module

### DIFF
--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -7,13 +7,18 @@ Module loading ActiveRecord-specific classes for Mobility models.
   module ActiveRecord
     require "mobility/active_record/uniqueness_validator"
 
-    def self.included(model_class)
-      query_method = Module.new do
-        define_method Mobility.query_method do
-          all
-        end
+    class QueryMethod < Module
+      def initialize(query_method)
+        module_eval <<-EOM, __FILE__, __LINE__ + 1
+          def #{query_method}
+            all
+          end
+        EOM
       end
-      model_class.extend query_method
+    end
+
+    def self.included(model_class)
+      model_class.extend QueryMethod.new(Mobility.query_method)
       unless model_class.const_defined?(:UniquenessValidator)
         model_class.const_set(:UniquenessValidator,
                               Class.new(::Mobility::ActiveRecord::UniquenessValidator))


### PR DESCRIPTION
Small change: we should avoid `define_method` whenever possible, for performance reasons. Also, I'd like to start naming modules, even if they are just a subclass of `Module`, to make them easier to see in the chain of ancestors.