### PR TITLE
Add spec checking that dup'ed model translations are different objects

### DIFF
--- a/spec/support/shared_examples/dup_examples.rb
+++ b/spec/support/shared_examples/dup_examples.rb
@@ -17,6 +17,10 @@ shared_examples_for "dupable model"  do |model_class_name, attribute=:title|
     save_or_raise(dupped_instance)
     expect(dupped_instance.send(attribute)).to eq(instance.send(attribute))
 
+    # Ensure duped instances are pointing to different objects
+    instance_backend.write(:en, "bar")
+    expect(dupped_backend.read(:en)).to eq("foo")
+
     # Ensure we haven't mucked with the original instance
     instance.reload
 
@@ -34,6 +38,10 @@ shared_examples_for "dupable model"  do |model_class_name, attribute=:title|
 
     save_or_raise(instance)
     save_or_raise(dupped_instance)
+
+    # Ensure duped instances are pointing to different objects
+    instance.send("#{attribute}=", "bar")
+    expect(dupped_instance.send(attribute)).to eq("foo")
 
     # Ensure we haven't mucked with the original instance
     instance.reload


### PR DESCRIPTION
Working on the KeyValue `dup` fix (for #123), I noticed that the specs added in #84 would pass even if translations were not actually copied but actually were just pointing to the same object. So I added a simple spec verifying that changing the value of the attribute on the original instance should not change the value of the attribute on the dup'ed instance.

cc @pwim