### PR TITLE
Move translated_attribute_names to Mobility::ActiveRecord

### DIFF
--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -16,6 +16,7 @@ Module loading ActiveRecord-specific classes for Mobility models.
       model_class.extend query_method
       model_class.const_set(:UniquenessValidator,
                             Class.new(::Mobility::ActiveRecord::UniquenessValidator))
+      model_class.delegate :translated_attribute_names, to: :class
     end
   end
 end

--- a/lib/mobility/plugins/active_record/attribute_methods.rb
+++ b/lib/mobility/plugins/active_record/attribute_methods.rb
@@ -25,7 +25,6 @@ instance. See {Mobility::Plugins::AttributeMethods} for further details.
               attributes.merge(name.to_s => send(name))
             end)
           end
-          delegate :translated_attribute_names, to: :class
         end
 
         def included(model_class)

--- a/spec/integration/active_record_compatibility_spec.rb
+++ b/spec/integration/active_record_compatibility_spec.rb
@@ -122,6 +122,13 @@ describe "ActiveRecord compatibility", orm: :active_record do
       post.content = "bar"
       expect(post.untranslated_attributes).to eq({ "published" => post.published, "id" => post.id })
     end
-
   end
+
+  describe "#translated_attribute_names" do
+    it "delegates to class method" do
+      post = Post.new
+      expect(post.translated_attribute_names).to match_array(%w[title content])
+    end
+  end
+
 end

--- a/spec/mobility/active_record_spec.rb
+++ b/spec/mobility/active_record_spec.rb
@@ -2,16 +2,26 @@ require "spec_helper"
 
 describe Mobility::ActiveRecord, orm: :active_record do
   before do
-    stub_const 'MyModel', Class.new(ActiveRecord::Base)
-    MyModel.include Mobility::ActiveRecord
+    stub_const 'Article', Class.new(ActiveRecord::Base)
+    Article.include Mobility::ActiveRecord
   end
 
   describe ".i18n" do
     it "extends class with .i18n scope method" do
       scope = double('scope')
-      expect(MyModel).to receive(:all).and_return(scope)
+      expect(Article).to receive(:all).and_return(scope)
 
-      expect(MyModel.i18n).to eq(scope)
+      expect(Article.i18n).to eq(scope)
+    end
+  end
+
+  describe "#translated_attribute_names" do
+    it "delegates to class" do
+      Article.instance_eval do
+        def translated_attribute_names; end
+      end
+      expect(Article).to receive(:translated_attribute_names).and_return(["foo"])
+      expect(Article.new.translated_attribute_names).to eq(["foo"])
     end
   end
 end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/plugins/active_record/attribute_methods_spec.rb
+++ b/spec/mobility/plugins/active_record/attribute_methods_spec.rb
@@ -25,12 +25,6 @@ describe Mobility::Plugins::ActiveRecord::AttributeMethods, orm: :active_record 
 
   subject { Article.new }
 
-  describe "#translated_attribute_names" do
-    it 'returns title' do
-      expect(subject.translated_attribute_names).to include('title')
-    end
-  end
-
   describe "#translated_attributes" do
     it "returns hash of translated attribute names/values" do
       expect(subject.translated_attributes).to eq("title" => "foo")


### PR DESCRIPTION
Fixes #131