### PR TITLE
Make default plugin handle Procs more gracefully

### DIFF
--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -5,11 +5,12 @@ module Mobility
 Defines value or proc to fall through to if return value from getter would
 otherwise be nil.
 
-If default is a proc, it is passed a hash with four keyword arguments:
-- +model+: the model instance
-- +attribute+: the attribute name (a String)
-- +locale+: the locale (a Symbol)
-- +options+: hash of options passed in to accessor
+If default is a +Proc+, it will be called with the context of the model, and
+passed arguments:
+- the attribute name (a String)
+- the locale (a Symbol)
+- hash of options passed in to accessor
+The proc can accept zero to three arguments (see examples below)
 
 @example With default enabled (falls through to default value)
   class Post
@@ -46,7 +47,7 @@ If default is a proc, it is passed a hash with four keyword arguments:
 @example Using Proc as default
   class Post
     extend Mobility
-    translates :title, default: lambda { |attribute:, locale:| "#{attribute} in #{locale}" }
+    translates :title, default: lambda { |attribute, locale| "#{attribute} in #{locale}" }
   end
 
   Mobility.locale = :en
@@ -54,7 +55,7 @@ If default is a proc, it is passed a hash with four keyword arguments:
   post.title
   #=> "title in en"
 
-  post.title(default: lambda { |model:| model.class.name.to_s })
+  post.title(default: lambda { self.class.name.to_s })
   #=> "Post"
 =end
     class Default < Module
@@ -70,10 +71,9 @@ If default is a proc, it is passed a hash with four keyword arguments:
           default = options.has_key?(:default) ? options.delete(:default) : default_option
           if (value = super(locale, options)).nil?
             return default unless default.is_a?(Proc)
-            default.call(model: model,
-                         attribute: attribute,
-                         locale: locale,
-                         options: options)
+            args = [attribute, locale, options]
+            args = args.first(default.arity) unless default.arity < 0
+            model.instance_exec(*args, &default)
           else
             value
           end


### PR DESCRIPTION
Currently, you can use the `default` plugin with a `Proc`, with the proc being passed the model, attribute name, locale and options as keyword arguments. This ends up being quite clumsy to handle in practice.

This PR changes things so that instead, the context in the proc becomes the model, and the proc is passed up to three arguments: attribute, locale, options, but depending on the proc's arity it will only be passed enough arguments so that it can handle them.

This way, you can e.g. do this:

```
class Post < ApplicationRecord
  extend Mobility
  translates :title, default: lambda { |attr| self[attr] }
end
```

...and this will default to reading the `title` column if the `title` attribute is not defined on the backend (`self[attr]` is equivalent to `read_attribute(attr)`).