### PR TITLE
Check joins_values to determine if query has been joined already

### DIFF
--- a/lib/mobility/backends/active_record/table/query_methods.rb
+++ b/lib/mobility/backends/active_record/table/query_methods.rb
@@ -43,8 +43,7 @@ module Mobility
 
       def define_join_method(association_name, translation_class, foreign_key: nil, table_name: nil, **)
         define_method :"join_#{association_name}" do |**options|
-          return self if (@__mobility_table_joined || []).include?(table_name)
-          (@__mobility_table_joined ||= []) << table_name
+          return self if joins_values.any? { |v| v.left.name == table_name.to_s }
           t = translation_class.arel_table
           m = arel_table
           join_type = options[:outer_join] ? Arel::Nodes::OuterJoin : Arel::Nodes::InnerJoin


### PR DESCRIPTION
This is simpler and avoids mutating the relation.