### PR TITLE
Use trusty on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-dist: precise
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
I forgot there was a `dist: precise` in the .travis.yml...