### PR TITLE
Refactor test schemas so AR and Sequel can run on same db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
     gem 'pry-byebug'
     gem 'sqlite3'
     gem 'mysql2', '~> 0.4.9'
-    gem 'pg'
+    gem 'pg', '< 1.0'
   end
 end
 

--- a/spec/active_record/models.rb
+++ b/spec/active_record/models.rb
@@ -5,6 +5,7 @@ class Post < ActiveRecord::Base
 end
 
 class FallbackPost < ActiveRecord::Base
+  self.table_name = "posts"
   extend Mobility
   translates :title, :content, backend: :key_value, cache: true, locale_accessors: true, dirty: true, fallbacks: true
 end

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -10,22 +10,13 @@ module Mobility
         def up
           create_table "posts" do |t|
             t.boolean :published
-          end
-
-          create_table "post_metadatas" do |t|
-            t.string  :metadata
-            t.integer :post_id
-          end
-
-          create_table "fallback_posts" do |t|
-            t.boolean :published
+            t.timestamps
           end
 
           create_table "articles" do |t|
             t.string :slug
             t.boolean :published
-            t.datetime "created_at", null: false
-            t.datetime "updated_at", null: false
+            t.timestamps
           end
 
           create_table "article_translations" do |t|
@@ -33,23 +24,27 @@ module Mobility
             t.integer :article_id
             t.string :title
             t.text :content
+            t.timestamps
           end
 
           create_table "multitable_posts" do |t|
             t.string :slug
             t.boolean :published
+            t.timestamps
           end
 
           create_table "multitable_post_translations" do |t|
             t.string :locale
             t.integer :multitable_post_id
             t.string :title
+            t.timestamps
           end
 
           create_table "multitable_post_foo_translations" do |t|
             t.string :locale
             t.integer :multitable_post_id
             t.string :foo
+            t.timestamps
           end
 
           create_table "mobility_string_translations" do |t|
@@ -58,6 +53,7 @@ module Mobility
             t.string  :value,             null: false
             t.integer :translatable_id,   null: false
             t.string  :translatable_type, null: false
+            t.timestamps
           end
           add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
           add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
@@ -69,6 +65,7 @@ module Mobility
             t.text    :value,             null: false
             t.integer :translatable_id,   null: false
             t.string  :translatable_type, null: false
+            t.timestamps
           end
           add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
           add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
@@ -83,16 +80,14 @@ module Mobility
             t.text :author_pt_br
             t.text :author_ru
             t.boolean :published
-            t.datetime "created_at", null: false
-            t.datetime "updated_at", null: false
+            t.timestamps
           end
 
           create_table "serialized_posts" do |t|
             t.text :title
             t.text :content
             t.boolean :published
-            t.datetime "created_at", null: false
-            t.datetime "updated_at", null: false
+            t.timestamps
           end
 
           if ENV['DB'] == 'postgres'
@@ -105,8 +100,7 @@ module Mobility
                 t.jsonb :content, default: ''
               end
               t.boolean :published
-              t.datetime "created_at", null: false
-              t.datetime "updated_at", null: false
+              t.timestamps
             end
 
             execute "CREATE EXTENSION IF NOT EXISTS hstore"
@@ -115,8 +109,7 @@ module Mobility
               t.hstore :title, default: ''
               t.hstore :content, default: ''
               t.boolean :published
-              t.datetime "created_at", null: false
-              t.datetime "updated_at", null: false
+              t.timestamps
             end
           end
         end

--- a/spec/integration/active_record_compatibility_spec.rb
+++ b/spec/integration/active_record_compatibility_spec.rb
@@ -103,7 +103,7 @@ describe "ActiveRecord compatibility", orm: :active_record do
       post = Post.new
       post.title = "foo"
       post.content = "bar"
-      expect(post.attributes).to eq({ "published" => post.published, "id" => post.id, "title" => "foo", "content" => "bar" })
+      expect(post.attributes).to include_hash({ "published" => post.published, "id" => post.id, "title" => "foo", "content" => "bar" })
     end
   end
 
@@ -120,7 +120,7 @@ describe "ActiveRecord compatibility", orm: :active_record do
       post = Post.new
       post.title = "foo"
       post.content = "bar"
-      expect(post.untranslated_attributes).to eq({ "published" => post.published, "id" => post.id })
+      expect(post.untranslated_attributes).to include_hash({ "published" => post.published, "id" => post.id })
     end
   end
 

--- a/spec/mobility/backends/sequel_spec.rb
+++ b/spec/mobility/backends/sequel_spec.rb
@@ -9,8 +9,8 @@ describe "Mobility::Backends::Sequel", orm: :sequel do
       Comment.translates :content, backend: :column
       Comment.translates :title, :author, backend: :key_value
       @comment1 = Comment.create(content: "foo content 1", title: "foo title 1", author: "Foo author 1")
-      Mobility.with_locale(:ja) { @comment1.update(content: "コンテンツ 1", title: "タイトル 1", author: "オーサー 1") }
       @comment2 = Comment.create(                          title: "foo title 2", author: "Foo author 2")
+      Mobility.with_locale(:ja) { @comment1.update(content: "コンテンツ 1", title: "タイトル 1", author: "オーサー 1") }
       Mobility.with_locale(:ja) { @comment2.update(content: "コンテンツ 2",                      author: "オーサー 2") }
       @comment3 = Comment.create(content: "foo content 1")
       @comment4 = Comment.create(content: "foo content 2", title: "foo title 2", author: "Foo author 3")
@@ -19,12 +19,12 @@ describe "Mobility::Backends::Sequel", orm: :sequel do
     describe ".i18n (mobility scope)" do
       describe ".where" do
         it "works with multiple backends" do
-          expect(Comment.i18n.where(content: "foo content 1", title: "foo title 1").select_all(:comments).all).to eq([@comment1])
-          expect(Comment.i18n.where(content: "foo content 1", title: nil).select_all(:comments).all).to eq([@comment3])
+          expect(Comment.i18n.where(content: "foo content 1", title: "foo title 1").select_all(:comments).map(&:id)).to eq([@comment1.id])
+          expect(Comment.i18n.where(content: "foo content 1", title: nil).select_all(:comments).map(&:id)).to eq([@comment3.id])
 
           Mobility.locale = :ja
           expect(Comment.i18n.where(content: "foo content 1", title: "foo title 1").select_all(:comments).all).to eq([])
-          expect(Comment.i18n.where(content: "コンテンツ 1", title: "タイトル 1").select_all(:comments).all).to eq([@comment1])
+          expect(Comment.i18n.where(content: "コンテンツ 1", title: "タイトル 1").select_all(:comments).map(&:id)).to eq([@comment1.id])
         end
       end
     end

--- a/spec/mobility/plugins/sequel/dirty_spec.rb
+++ b/spec/mobility/plugins/sequel/dirty_spec.rb
@@ -73,7 +73,7 @@ describe Mobility::Plugins::Sequel::Dirty, orm: :sequel do
         article.save
 
         expect(article.column_changed?(:title)).to eq(false)
-        expect(article.previous_changes).to eq({ :title_en => ["foo", "bar"]})
+        expect(article.previous_changes).to include_hash({ :title_en => ["foo", "bar"]})
       end
     end
 
@@ -112,8 +112,8 @@ describe Mobility::Plugins::Sequel::Dirty, orm: :sequel do
 
       article.save
 
-      expect(article.previous_changes).to eq({title_en: ["English title 1", "English title 2"],
-                                              title_fr: ["Titre en Francais 1", "Titre en Francais 2"]})
+      expect(article.previous_changes).to include_hash(title_en: ["English title 1", "English title 2"],
+                                                       title_fr: ["Titre en Francais 1", "Titre en Francais 2"])
     end
 
     it "resets changes when locale is set to original value" do

--- a/spec/sequel/models.rb
+++ b/spec/sequel/models.rb
@@ -6,7 +6,7 @@ class Post < Sequel::Model
   translates :content, backend: :key_value, cache: true, locale_accessors: true, dirty: true, type: :text
 end
 
-class FallbackPost < Sequel::Model
+class FallbackPost < Sequel::Model(DB[:posts])
   plugin :mobility
   translates :title, :content, backend: :key_value, cache: true, locale_accessors: true, dirty: true, fallbacks: true
 end

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -119,8 +119,8 @@ module Mobility
           if ENV['DB'] == 'postgres'
             DB.create_table? :jsonb_posts do
               primary_key :id
-              jsonb       :title
-              jsonb       :content
+              jsonb       :title,      default: '""'
+              jsonb       :content,    default: '""'
               TrueClass   :published
               DateTime    :created_at, allow_null: false
               DateTime    :updated_at, allow_null: false
@@ -129,8 +129,8 @@ module Mobility
             DB.run "CREATE EXTENSION IF NOT EXISTS hstore"
             DB.create_table? :hstore_posts do
               primary_key :id
-              hstore      :title
-              hstore      :content
+              hstore      :title,      default: ''
+              hstore      :content,    default: ''
               TrueClass   :published
               DateTime    :created_at, allow_null: false
               DateTime    :updated_at, allow_null: false

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -1,4 +1,5 @@
 require "sequel/extensions/migration"
+Sequel::Model.plugin :timestamps, update_on_create: true
 
 module Mobility
   module Test
@@ -8,23 +9,24 @@ module Mobility
           DB.create_table? :posts do
             primary_key :id
             TrueClass   :published
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           DB.create_table? :post_metadatas do
             primary_key :id
             String      :metadata
             Integer     :post_id
-          end
-
-          DB.create_table? :fallback_posts do
-            primary_key :id
-            TrueClass   :published
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           DB.create_table? :articles do
             primary_key :id
             String      :slug
             TrueClass   :published
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           DB.create_table? :article_translations do
@@ -33,11 +35,15 @@ module Mobility
             String      :locale
             String      :title
             String      :content, size: 65535
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           DB.create_table? :multitable_posts do
             primary_key :id
             TrueClass   :published
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           DB.create_table? :multitable_post_translations do
@@ -45,6 +51,8 @@ module Mobility
             Integer     :multitable_post_id
             String      :locale
             String      :title
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
 
@@ -53,6 +61,8 @@ module Mobility
             Integer     :multitable_post_id
             String      :locale
             String      :foo
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           DB.create_table? :mobility_text_translations do
@@ -62,6 +72,8 @@ module Mobility
             String      :value,             null: false, size: 65535
             Integer     :translatable_id,   null: false
             String      :translatable_type, null: false
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
             index [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
             index [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
           end
@@ -73,6 +85,8 @@ module Mobility
             String      :value,             null: false
             Integer     :translatable_id,   null: false
             String      :translatable_type, null: false
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
             index [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
             index [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
             index [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
@@ -89,6 +103,8 @@ module Mobility
             String      :author_pt_br
             String      :author_ru
             TrueClass   :published
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           DB.create_table? :serialized_posts do
@@ -96,6 +112,8 @@ module Mobility
             String      :title,         size: 65535
             String      :content,       size: 65535
             TrueClass   :published
+            DateTime    :created_at, allow_null: false
+            DateTime    :updated_at, allow_null: false
           end
 
           if ENV['DB'] == 'postgres'
@@ -104,6 +122,8 @@ module Mobility
               jsonb       :title
               jsonb       :content
               TrueClass   :published
+              DateTime    :created_at, allow_null: false
+              DateTime    :updated_at, allow_null: false
             end
 
             DB.run "CREATE EXTENSION IF NOT EXISTS hstore"
@@ -112,6 +132,8 @@ module Mobility
               hstore      :title
               hstore      :content
               TrueClass   :published
+              DateTime    :created_at, allow_null: false
+              DateTime    :updated_at, allow_null: false
             end
           end
         end

--- a/spec/support/matchers/include_hash.rb
+++ b/spec/support/matchers/include_hash.rb
@@ -1,0 +1,6 @@
+RSpec::Matchers.define :include_hash do |expected|
+  match do |actual|
+    return false if actual.nil?
+    expected.values == actual.values_at(*expected.keys)
+  end
+end

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -374,9 +374,9 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
       instance.send(:"#{attribute1}=", "Title")
       instance.save
       match = query_scope.send(finder_method, "Title")
-      expect(match).to eq(instance)
+      expect(match.id).to eq(instance.id)
       Mobility.locale = :ja
-      expect(query_scope.send(finder_method, "タイトル")).to eq(instance)
+      expect(query_scope.send(finder_method, "タイトル").id).to eq(instance.id)
       expect(query_scope.send(finder_method, "foo")).to be_nil
     end
 


### PR DESCRIPTION
Currently, the Sequel model tables are missing timestamps, and both AR and Sequel have some unnecessary tables, etc., result being that tests for each ORM cannot be run on the same table (so I need to drop and rebuild the table every time I switch from one to the other). This is kind of a pain.

These changes line up both ORMs so that tables are the same for both.