### PR TITLE
Query on translated json value with Sequel ORM

### DIFF
--- a/lib/mobility/backends/active_record/hstore/query_methods.rb
+++ b/lib/mobility/backends/active_record/hstore/query_methods.rb
@@ -8,8 +8,8 @@ module Mobility
 
       private
 
-      def contains_value(column, value)
-        build_infix(:'->', column, quoted_locale).eq(Arel::Nodes.build_quoted(value.to_s))
+      def contains_value(column, value, locale)
+        build_infix(:'->', column, quote(locale)).eq(quote(value.to_s))
       end
     end
   end

--- a/lib/mobility/backends/active_record/jsonb/query_methods.rb
+++ b/lib/mobility/backends/active_record/jsonb/query_methods.rb
@@ -8,8 +8,8 @@ module Mobility
 
       private
 
-      def contains_value(column, value)
-        build_infix(:'@>', column, Arel::Nodes.build_quoted({ Mobility.locale => value }.to_json))
+      def contains_value(column, value, locale)
+        build_infix(:'@>', column, quote({locale => value }.to_json))
       end
     end
   end

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -67,7 +67,9 @@ code.
             next has_locale(column, locale).not if values.nil?
 
             Array.wrap(values).map { |value|
-              value.nil? ? has_locale(column, locale).not : contains_value(column, value, locale)
+              value.nil? ?
+                has_locale(column, locale).not :
+                contains_value(column, value, locale)
             }.inject(&:or)
           }.inject(&:and)
         end
@@ -85,11 +87,9 @@ code.
             column = arel_table[key.to_sym]
             values = opts.delete(key)
 
-            next has_locale(column, locale) if values.nil?
-
             Array.wrap(values).map { |value|
-              has_locale(column, locale).and(contains_value(column, value, locale).not)
-            }.inject(&:and)
+              contains_value(column, value, locale).not
+            }.inject(has_locale(column, locale), &:and)
           }.inject(&:and)
         end
 

--- a/lib/mobility/backends/sequel/hstore/query_methods.rb
+++ b/lib/mobility/backends/sequel/hstore/query_methods.rb
@@ -23,8 +23,16 @@ module Mobility
 
       private
 
-      def build_pg_op(v)
-        ::Sequel.hstore_op(v)
+      def contains_value(key, value, locale)
+        build_op(key).contains(locale => value.to_s)
+      end
+
+      def has_locale(key, locale)
+        build_op(key).has_key?(locale)
+      end
+
+      def build_op(key)
+        ::Sequel.hstore_op(key)
       end
     end
   end

--- a/lib/mobility/backends/sequel/jsonb/query_methods.rb
+++ b/lib/mobility/backends/sequel/jsonb/query_methods.rb
@@ -23,8 +23,16 @@ module Mobility
 
       private
 
-      def build_pg_op(v)
-        ::Sequel.pg_jsonb_op(v)
+      def contains_value(key, value, locale)
+        build_op(key).contains({ locale => value }.to_json)
+      end
+
+      def has_locale(key, locale)
+        build_op(key).has_key?(locale)
+      end
+
+      def build_op(key)
+        ::Sequel.pg_jsonb_op(key)
       end
     end
   end

--- a/spec/mobility/backends/sequel/jsonb_spec.rb
+++ b/spec/mobility/backends/sequel/jsonb_spec.rb
@@ -28,21 +28,35 @@ describe "Mobility::Backends::Sequel::Jsonb", orm: :sequel, db: :postgres do
 
     describe "non-text values" do
       it "stores non-string types as-is when saving" do
-        post = JsonbPost.new
         backend = post.mobility_backend_for("title")
         backend.write(:en, { foo: :bar } )
         post.save
         expect(post[:title]).to eq({ "en" => { "foo" => "bar" }})
       end
 
-      it "stores integer values" do
-        post.title = 1
-        expect(post.title).to eq(1)
-        post.save
+      shared_examples_for "jsonb translated value" do |name, value|
+        it "stores #{name} values" do
+          post.title = value
+          expect(post.title).to eq(value)
+          post.save
 
-        post = JsonbPost.first
-        expect(post.title).to eq(1)
+          post = JsonbPost.first
+          expect(post.title).to eq(value)
+        end
+
+        it "queries on #{name} values" do
+          skip "arrays treated as array of values, not value to match" if name == :array
+          post1 = JsonbPost.create(title: "foo")
+          post2 = JsonbPost.create(title: value)
+
+          expect(JsonbPost.i18n.where(title: "foo").first).to eq(post1)
+          expect(JsonbPost.i18n.where(title: value).first).to eq(post2)
+        end
       end
+
+      it_behaves_like "jsonb translated value", :integer, 1
+      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" }
+      it_behaves_like "jsonb translated value", :array,   [1, "a", nil]
     end
   end
 


### PR DESCRIPTION
Currently, querying support covers non-string types in ActiveRecord, e.g.:

```ruby
post = Post.create(title: { "a" => "b" })
Post.i18n.find_by(title: { "a" => "b" })
```

will work, but this will not work with Sequel because the code currently converts the queried value to a string, which does not match.

This modifies the Sequel query method code to work like ActiveRecord, and adds specs checking that all types are handled, with the exception of arrays (arrays are treated as a set of values to be matched rather than a single array value to be matched, see #90).