### PR TITLE
Add new jsonb container backend

### DIFF
--- a/lib/mobility/backends/active_record/container/query_methods.rb
+++ b/lib/mobility/backends/active_record/container/query_methods.rb
@@ -1,0 +1,31 @@
+require "mobility/backends/active_record/jsonb"
+
+module Mobility
+  module Backends
+    class ActiveRecord::Container::QueryMethods < ActiveRecord::QueryMethods
+      include ActiveRecord::PgQueryMethods
+      attr_reader :column_name, :column
+
+      def initialize(_attributes, options)
+        super
+        @column_name = options[:column_name]
+        @column      = arel_table[@column_name]
+      end
+
+      private
+
+      def contains_value(key, value, locale)
+        build_infix(:'@>',
+                    build_infix(:'->', column, quote(locale)),
+                    quote({ key => value }.to_json))
+      end
+
+      def has_locale(key, locale)
+        build_infix(:'?', column, quote(locale)).and(
+          build_infix(:'?',
+                      build_infix(:'->', column, quote(locale)),
+                      quote(key)))
+      end
+    end
+  end
+end

--- a/lib/mobility/backends/active_record/hstore/query_methods.rb
+++ b/lib/mobility/backends/active_record/hstore/query_methods.rb
@@ -8,8 +8,8 @@ module Mobility
 
       private
 
-      def contains_value(column, value, locale)
-        build_infix(:'->', column, quote(locale)).eq(quote(value.to_s))
+      def contains_value(key, value, locale)
+        build_infix(:'->', arel_table[key], quote(locale)).eq(quote(value.to_s))
       end
     end
   end

--- a/lib/mobility/backends/active_record/jsonb/query_methods.rb
+++ b/lib/mobility/backends/active_record/jsonb/query_methods.rb
@@ -8,8 +8,8 @@ module Mobility
 
       private
 
-      def contains_value(column, value, locale)
-        build_infix(:'@>', column, quote({locale => value }.to_json))
+      def contains_value(key, value, locale)
+        build_infix(:'@>', arel_table[key], quote({locale => value }.to_json))
       end
     end
   end

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -15,8 +15,12 @@ code.
 
 =end
       module PgQueryMethods
-        def initialize(attributes, _)
+        attr_reader :arel_table
+
+        def initialize(attributes, options)
           super
+          @arel_table = options[:model_class].arel_table
+
           q = self
 
           define_method :where! do |opts, *rest|
@@ -61,7 +65,6 @@ code.
         def create_where_query!(opts, keys, arel_table)
           locale = Mobility.locale
           keys.map { |key|
-            column = arel_table[key]
             values = opts.delete(key)
 
             next has_locale(key, locale).not if values.nil?

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -26,7 +26,7 @@ code.
           define_method :where! do |opts, *rest|
             if i18n_keys = q.extract_attributes(opts)
               opts = opts.with_indifferent_access
-              query = q.create_where_query!(opts, i18n_keys, arel_table)
+              query = q.create_where_query!(opts, i18n_keys)
 
               opts.empty? ? super(query) : super(opts, *rest).where(query)
             else
@@ -38,13 +38,12 @@ code.
         def extended(relation)
           super
           q = self
-          m = relation.model.arel_table
 
           mod = Module.new do
             define_method :not do |opts, *rest|
               if i18n_keys = q.extract_attributes(opts)
                 opts = opts.with_indifferent_access
-                query = q.create_not_query!(opts, i18n_keys, m)
+                query = q.create_not_query!(opts, i18n_keys)
 
                 super(opts, *rest).where(query)
               else
@@ -60,9 +59,8 @@ code.
         #
         # @param [Hash] opts Hash of attribute/value pairs
         # @param [Array] keys Translated attribute names
-        # @param [Arel::Table] arel_table Model or relation's arel table
         # @return [Arel::Node] Arel node to pass to +where+
-        def create_where_query!(opts, keys, arel_table)
+        def create_where_query!(opts, keys)
           locale = Mobility.locale
           keys.map { |key|
             values = opts.delete(key)
@@ -77,14 +75,13 @@ code.
           }.inject(&:and)
         end
 
-        # Create +not+ query for options hash, translated keys and arel_table
+        # Create +not+ query for options hash and translated keys
         # @note This is a destructive operation, it will modify +opts+.
         #
         # @param [Hash] opts Hash of attribute/value pairs
         # @param [Array] keys Translated attribute names
-        # @param [Arel::Table] arel_table Model or relation's arel table
         # @return [Arel::Node] Arel node to pass to +where+
-        def create_not_query!(opts, keys, arel_table)
+        def create_not_query!(opts, keys)
           locale = Mobility.locale
           keys.map { |key|
             values = opts.delete(key)

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -64,12 +64,12 @@ code.
             column = arel_table[key]
             values = opts.delete(key)
 
-            next has_locale(column, locale).not if values.nil?
+            next has_locale(key, locale).not if values.nil?
 
             Array.wrap(values).map { |value|
               value.nil? ?
-                has_locale(column, locale).not :
-                contains_value(column, value, locale)
+                has_locale(key, locale).not :
+                contains_value(key, value, locale)
             }.inject(&:or)
           }.inject(&:and)
         end
@@ -84,23 +84,22 @@ code.
         def create_not_query!(opts, keys, arel_table)
           locale = Mobility.locale
           keys.map { |key|
-            column = arel_table[key.to_sym]
             values = opts.delete(key)
 
             Array.wrap(values).map { |value|
-              contains_value(column, value, locale).not
-            }.inject(has_locale(column, locale), &:and)
+              contains_value(key, value, locale).not
+            }.inject(has_locale(key, locale), &:and)
           }.inject(&:and)
         end
 
         private
 
-        def contains_value(_column, _value, _locale)
+        def contains_value(_key, _value, _locale)
           raise NotImplementedError
         end
 
-        def has_locale(column, locale)
-          build_infix(:'?', column, quote(locale))
+        def has_locale(key, locale)
+          build_infix(:'?', arel_table[key], quote(locale))
         end
 
         def build_infix(*args)

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -143,13 +143,13 @@ columns to that table.
 
         module_name = "MobilityArTable#{association_name.to_s.camelcase}"
         unless const_defined?(module_name)
-          callback_methods = Module.new do
+          dupable = Module.new do
             define_method :initialize_dup do |source|
               super(source)
               self.send("#{association_name}=", source.send(association_name).map(&:dup))
             end
           end
-          include const_set(module_name, callback_methods)
+          include const_set(module_name, dupable)
         end
 
         include DestroyEmptyTranslations

--- a/lib/mobility/backends/container.rb
+++ b/lib/mobility/backends/container.rb
@@ -1,0 +1,25 @@
+module Mobility
+  module Backends
+
+=begin
+
+Stores translations for multiple attributes on a single shared Postgres jsonb
+column (called a "container").
+
+==Backend Options
+
+===+column_name+
+
+Name of the column for the translations container (where translations are
+stored).
+
+@see Mobility::Backends::ActiveRecord::Container
+@see Mobility::Backends::Sequel::Container
+@see https://www.postgresql.org/docs/current/static/datatype-json.html PostgreSQL Documentation for JSON Types
+
+=end
+    module Container
+      extend Backend::OrmDelegator
+    end
+  end
+end

--- a/lib/mobility/backends/sequel/container.rb
+++ b/lib/mobility/backends/sequel/container.rb
@@ -1,0 +1,99 @@
+module Mobility
+  module Backends
+=begin
+
+Implements the {Mobility::Backends::Container} backend for Sequel models.
+
+=end
+    class Sequel::Container
+      include Sequel
+
+      require 'mobility/backends/sequel/container/query_methods'
+
+      # @return [Symbol] name of container column
+      attr_reader :column_name
+
+      # @!macro backend_constructor
+      # @option options [Symbol] column_name Name of container column
+      def initialize(model, attribute, options = {})
+        super
+        @column_name = options[:column_name]
+      end
+
+      # @!group Backend Accessors
+      #
+      # @note Translation may be a string, integer, boolean, hash or array
+      #   since value is stored on a JSON hash.
+      # @param [Symbol] locale Locale to read
+      # @param [Hash] options
+      # @return [String,Integer,Boolean] Value of translation
+      def read(locale, _ = nil)
+        model_translations(locale)[attribute]
+      end
+
+      # @note Translation may be a string, integer, boolean, hash or array
+      #   since value is stored on a JSON hash.
+      # @param [Symbol] locale Locale to write
+      # @param [String,Integer,Boolean] value Value to write
+      # @param [Hash] options
+      # @return [String,Integer,Boolean] Updated value
+      def write(locale, value, _ = nil)
+        set_attribute_translation(locale, value)
+        model_translations(locale)[attribute]
+      end
+      # @!endgroup
+      #
+      # @!group Backend Configuration
+      # @option options [Symbol] column_name (:translations) Name of column on which to store translations
+      def self.configure(options)
+        options[:column_name] ||= :translations
+      end
+      # @!endgroup
+      #
+      # @!macro backend_iterator
+      def each_locale
+        model[column_name].each do |l, _|
+          yield l.to_sym unless read(l).nil?
+        end
+      end
+
+      setup do |attributes, options|
+        column_name = options[:column_name]
+        before_validation = Module.new do
+          define_method :before_validation do
+            self[column_name].each do |k, v|
+              v.delete_if { |_locale, translation| Util.blank?(translation) }
+              self[column_name].delete(k) if v.empty?
+            end
+            super()
+          end
+        end
+        include before_validation
+        include Mobility::Sequel::HashInitializer.new(column_name)
+
+        plugin :defaults_setter
+        attributes.each { |attribute| default_values[attribute.to_sym] = {} }
+      end
+
+      setup_query_methods(QueryMethods)
+
+      private
+
+      def model_translations(locale)
+        model[column_name][locale.to_s] ||= {}
+      end
+
+      def set_attribute_translation(locale, value)
+        translations = model[column_name] || {}
+        translations[locale.to_s] ||= {}
+        # Explicitly mark translations column as changed if value changed,
+        # otherwise Sequel will not detect it.
+        # TODO: Find a cleaner/easier way to do this.
+        if translations[locale.to_s][attribute] != value
+          model.instance_variable_set(:@changed_columns, model.changed_columns | [column_name])
+        end
+        translations[locale.to_s][attribute] = value
+      end
+    end
+  end
+end

--- a/lib/mobility/backends/sequel/container/query_methods.rb
+++ b/lib/mobility/backends/sequel/container/query_methods.rb
@@ -1,0 +1,41 @@
+require "mobility/backends/sequel/pg_query_methods"
+require "mobility/backends/sequel/query_methods"
+
+Sequel.extension :pg_json, :pg_json_ops
+
+module Mobility
+  module Backends
+    class Sequel::Container::QueryMethods < Sequel::QueryMethods
+      include Sequel::PgQueryMethods
+      attr_reader :column_name
+
+      def initialize(attributes, options)
+        super
+        column_name = @column_name = options[:column_name]
+
+        define_query_methods
+
+        attributes.each do |attribute|
+          define_method :"first_by_#{attribute}" do |value|
+            where(::Sequel.pg_jsonb_op(column_name)[Mobility.locale.to_s].contains({ attribute => value })).
+              select_all(model.table_name).first
+          end
+        end
+      end
+
+      private
+
+      def contains_value(key, value, locale)
+        build_op(column_name)[locale].contains({ key.to_s => value }.to_json)
+      end
+
+      def has_locale(key, locale)
+        build_op(column_name).has_key?(locale) & build_op(column_name)[locale].has_key?(key.to_s)
+      end
+
+      def build_op(key)
+        ::Sequel.pg_jsonb_op(key)
+      end
+    end
+  end
+end

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -3,6 +3,7 @@ require "mobility/util"
 require "mobility/backends/sequel"
 require "mobility/backends/key_value"
 require "mobility/sequel/column_changes"
+require "mobility/sequel/hash_initializer"
 require "mobility/sequel/string_translation"
 require "mobility/sequel/text_translation"
 
@@ -82,7 +83,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
         end
         include callback_methods
 
-        include Mobility::Sequel::ColumnChanges.new(attributes)
+        include Mobility::Sequel::ColumnChanges.new(*attributes)
 
         private
 

--- a/lib/mobility/backends/sequel/pg_hash.rb
+++ b/lib/mobility/backends/sequel/pg_hash.rb
@@ -27,11 +27,7 @@ jsonb).
       end
 
       setup do |attributes|
-        method_overrides = Module.new do
-          define_method :initialize_set do |values|
-            attributes.each { |attribute| self[attribute.to_sym] = {} }
-            super(values)
-          end
+        before_validation = Module.new do
           define_method :before_validation do
             attributes.each do |attribute|
               self[attribute.to_sym].delete_if { |_, v| Util.blank?(v) }
@@ -39,8 +35,9 @@ jsonb).
             super()
           end
         end
-        include method_overrides
-        include Mobility::Sequel::ColumnChanges.new(attributes)
+        include before_validation
+        include Mobility::Sequel::HashInitializer.new(*attributes)
+        include Mobility::Sequel::ColumnChanges.new(*attributes)
 
         plugin :defaults_setter
         attributes.each { |attribute| default_values[attribute.to_sym] = {} }

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -83,7 +83,7 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
         end
         include callback_methods
 
-        include Mobility::Sequel::ColumnChanges.new(attributes)
+        include Mobility::Sequel::ColumnChanges.new(*attributes)
       end
 
       setup_query_methods(QueryMethods)

--- a/lib/mobility/sequel/column_changes.rb
+++ b/lib/mobility/sequel/column_changes.rb
@@ -8,7 +8,7 @@ setter method is called.
 =end
     class ColumnChanges < Module
       # @param [Array<String>] attributes Backend attributes
-      def initialize(attributes)
+      def initialize(*attributes)
         attributes.each do |attribute|
           define_method "#{attribute}=".freeze do |value, **options|
             if !options[:super] && send(attribute) != value

--- a/lib/mobility/sequel/hash_initializer.rb
+++ b/lib/mobility/sequel/hash_initializer.rb
@@ -1,0 +1,19 @@
+module Mobility
+  module Sequel
+=begin
+
+Internal class used to initialize column value(s) by default to a hash.
+
+=end
+    class HashInitializer < Module
+      def initialize(*columns)
+        class_eval <<-EOM, __FILE__, __LINE__ + 1
+          def initialize_set(values)
+            #{columns.map { |c| "self[:#{c}] = {}" }.join(';')}
+            super
+          end
+        EOM
+      end
+    end
+  end
+end

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -103,6 +103,16 @@ module Mobility
               t.timestamps
             end
 
+            create_table "container_posts" do |t|
+              if ::ActiveRecord::VERSION::STRING < '5.0'
+                t.jsonb :translations, default: '{}'
+              else
+                t.jsonb :translations, default: ''
+              end
+              t.boolean :published
+              t.timestamps
+            end
+
             execute "CREATE EXTENSION IF NOT EXISTS hstore"
 
             create_table "hstore_posts" do |t|

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db: :postgres do
+  require "mobility/backends/active_record/container"
+  extend Helpers::ActiveRecord
+  before do
+    stub_const 'ContainerPost', Class.new(ActiveRecord::Base)
+    ContainerPost.extend Mobility
+  end
+
+  context "with no plugins applied" do
+    include_backend_examples described_class, (Class.new(ActiveRecord::Base) do
+      extend Mobility
+      self.table_name = 'container_posts'
+    end)
+  end
+
+  context "with standard plugins applied" do
+    let(:backend) { post.mobility_backend_for("title") }
+
+    before { ContainerPost.translates :title, :content, backend: :container, presence: false, cache: false }
+    let(:post) { ContainerPost.new }
+
+    include_accessor_examples 'ContainerPost'
+    include_querying_examples 'ContainerPost'
+    include_validation_examples 'ContainerPost'
+    include_dup_examples 'ContainerPost'
+    include_cache_key_examples 'ContainerPost'
+
+    describe "non-text values" do
+      it "stores non-string types as-is when saving", rails_version_geq: '5.0' do
+        backend = post.mobility_backend_for("title")
+        backend.write(:en, { foo: :bar } )
+        post.save
+        expect(post[:translations]).to eq({ "en" => { "title" => { "foo" => "bar" }}})
+      end
+
+      shared_examples_for "container translated value" do |name, value|
+        it "stores #{name} values" do
+          post.title = value
+          expect(post.title).to eq(value)
+          post.save
+
+          post = ContainerPost.first
+          expect(post.title).to eq(value)
+        end
+
+        it "queries on #{name} values" do
+          skip "arrays treated as array of values, not value to match" if name == :array
+          post1 = ContainerPost.create(title: "foo")
+          post2 = ContainerPost.create(title: value)
+
+          expect(ContainerPost.i18n.find_by(title: "foo")).to eq(post1)
+          expect(ContainerPost.i18n.find_by(title: value)).to eq(post2)
+        end
+      end
+
+      it_behaves_like "container translated value", :integer, 1
+      it_behaves_like "container translated value", :hash,    { "a" => "b" }
+      it_behaves_like "container translated value", :array,   [1, "a", nil]
+    end
+  end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backends/sequel/container_spec.rb
+++ b/spec/mobility/backends/sequel/container_spec.rb
@@ -58,4 +58,20 @@ describe "Mobility::Backends::Sequel::Container", orm: :sequel, db: :postgres do
       it_behaves_like "jsonb translated value", :array,   [1, "a", nil]
     end
   end
+
+  context "with a different column_name" do
+    before(:all) do
+      DB.create_table!(:foo_posts) { primary_key :id; jsonb :foo, default: '""'; TrueClass :published }
+    end
+    before(:each) do
+      stub_const 'FooPost', Class.new(Sequel::Model)
+      FooPost.dataset = DB[:foo_posts]
+      FooPost.extend Mobility
+      FooPost.translates :title, :content, backend: :container, presence: false, cache: false, column_name: :foo
+    end
+    after(:all) { DB.drop_table?(:foo_posts) }
+
+    include_accessor_examples 'FooPost'
+    include_querying_examples 'FooPost'
+  end
 end if Mobility::Loaded::Sequel && ENV['DB'] == 'postgres'

--- a/spec/mobility/backends/sequel/container_spec.rb
+++ b/spec/mobility/backends/sequel/container_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe "Mobility::Backends::Sequel::Container", orm: :sequel, db: :postgres do
+  require "mobility/backends/sequel/container"
+  extend Helpers::Sequel
+  before do
+    stub_const 'ContainerPost', Class.new(Sequel::Model)
+    ContainerPost.dataset = DB[:container_posts]
+    ContainerPost.extend Mobility
+  end
+
+  context "with no plugins applied" do
+    include_backend_examples described_class, (Class.new(Sequel::Model(:container_posts)) do
+      extend Mobility
+    end)
+  end
+
+  context "with standard plugins applied" do
+    let(:backend) { post.mobility_backend_for("title") }
+
+    before { ContainerPost.translates :title, :content, backend: :container, presence: false, cache: false }
+    let(:post) { ContainerPost.new }
+
+    include_accessor_examples 'ContainerPost'
+    include_querying_examples 'ContainerPost'
+    include_dup_examples 'ContainerPost'
+
+    describe "non-text values" do
+      it "stores non-string types as-is when saving" do
+        backend = post.mobility_backend_for("title")
+        backend.write(:en, { foo: :bar } )
+        post.save
+        expect(post[:translations]).to eq({ "en" => { "title" => { "foo" => "bar" }}})
+      end
+
+      shared_examples_for "jsonb translated value" do |name, value|
+        it "stores #{name} values" do
+          post.title = value
+          expect(post.title).to eq(value)
+          post.save
+
+          post = ContainerPost.first
+          expect(post.title).to eq(value)
+        end
+
+        it "queries on #{name} values" do
+          skip "arrays treated as array of values, not value to match" if name == :array
+          post1 = ContainerPost.create(title: "foo")
+          post2 = ContainerPost.create(title: value)
+
+          expect(ContainerPost.i18n.where(title: "foo").first).to eq(post1)
+          expect(ContainerPost.i18n.where(title: value).first).to eq(post2)
+        end
+      end
+
+      it_behaves_like "jsonb translated value", :integer, 1
+      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" }
+      it_behaves_like "jsonb translated value", :array,   [1, "a", nil]
+    end
+  end
+end if Mobility::Loaded::Sequel && ENV['DB'] == 'postgres'

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -126,6 +126,14 @@ module Mobility
               DateTime    :updated_at, allow_null: false
             end
 
+            DB.create_table? :container_posts do
+              primary_key :id
+              jsonb       :translations, default: '""'
+              TrueClass   :published
+              DateTime    :created_at, allow_null: false
+              DateTime    :updated_at, allow_null: false
+            end
+
             DB.run "CREATE EXTENSION IF NOT EXISTS hstore"
             DB.create_table? :hstore_posts do
               primary_key :id


### PR DESCRIPTION
This is the first new backend to be added to Mobility since all the original ones were introduced in v0.1.x. I was inspired to add it looking at the Elixir hex package named [Trans](https://hex.pm/packages/trans), which stores all translations for a model in a single depth-2 jsonb column (`translations`). I've seen this also discussed [elsewhere](https://github.com/denkGroot/Spina/issues/266#issuecomment-312824064), and thought it would be interesting to implement.

This implementation piggy-backs on parts of the existing Jsonb backend, but in other parts is entirely independent. Specs seem to be passing.

Regarding naming, I'm using the term "container" since this is what Trans uses. In the code I've called the backend "JsonbContainer", but this is quite a mouthful so I'm thinking of just renaming it "container", so you'd use it like this:

```ruby
class Post
  extend Mobility
  translates :title, backend: :container
end
```

... or of course just set `config.default_backend = :container`.

Curious if anyone has any thoughts on this (backend itself, implementation, naming, etc.)