### PR TITLE
Use element operator instead of contains for jsonb querying

### DIFF
--- a/lib/mobility/backends/active_record/container/query_methods.rb
+++ b/lib/mobility/backends/active_record/container/query_methods.rb
@@ -14,7 +14,7 @@ module Mobility
 
       private
 
-      def contains_value(key, value, locale)
+      def matches(key, value, locale)
         build_infix(:'->',
                     build_infix(:'->', column, quote(locale)),
                     quote(key)).eq(quote(value.to_json))

--- a/lib/mobility/backends/active_record/container/query_methods.rb
+++ b/lib/mobility/backends/active_record/container/query_methods.rb
@@ -15,9 +15,9 @@ module Mobility
       private
 
       def contains_value(key, value, locale)
-        build_infix(:'@>',
+        build_infix(:'->',
                     build_infix(:'->', column, quote(locale)),
-                    quote({ key => value }.to_json))
+                    quote(key)).eq(quote(value.to_json))
       end
 
       def has_locale(key, locale)

--- a/lib/mobility/backends/active_record/hstore/query_methods.rb
+++ b/lib/mobility/backends/active_record/hstore/query_methods.rb
@@ -8,7 +8,7 @@ module Mobility
 
       private
 
-      def contains_value(key, value, locale)
+      def matches(key, value, locale)
         build_infix(:'->', arel_table[key], quote(locale)).eq(quote(value.to_s))
       end
     end

--- a/lib/mobility/backends/active_record/jsonb/query_methods.rb
+++ b/lib/mobility/backends/active_record/jsonb/query_methods.rb
@@ -9,7 +9,7 @@ module Mobility
       private
 
       def contains_value(key, value, locale)
-        build_infix(:'@>', arel_table[key], quote({locale => value }.to_json))
+        build_infix(:'->', arel_table[key], quote(locale)).eq(quote(value.to_json))
       end
     end
   end

--- a/lib/mobility/backends/active_record/jsonb/query_methods.rb
+++ b/lib/mobility/backends/active_record/jsonb/query_methods.rb
@@ -8,7 +8,7 @@ module Mobility
 
       private
 
-      def contains_value(key, value, locale)
+      def matches(key, value, locale)
         build_infix(:'->', arel_table[key], quote(locale)).eq(quote(value.to_json))
       end
     end

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -4,7 +4,7 @@ module Mobility
 =begin
 
 Defines query methods for Postgres backends. Including class must define a
-single method, +contains_value+, which accepts a column, value and locale to
+single method, +matches+, which accepts a column, value and locale to
 match, and returns an Arel node.
 
 This module avoids 99% duplication between hstore and jsonb backend querying
@@ -70,7 +70,7 @@ code.
             Array.wrap(values).map { |value|
               value.nil? ?
                 has_locale(key, locale).not :
-                contains_value(key, value, locale)
+                matches(key, value, locale)
             }.inject(&:or)
           }.inject(&:and)
         end
@@ -87,14 +87,14 @@ code.
             values = opts.delete(key)
 
             Array.wrap(values).map { |value|
-              contains_value(key, value, locale).not
+              matches(key, value, locale).not
             }.inject(has_locale(key, locale), &:and)
           }.inject(&:and)
         end
 
         private
 
-        def contains_value(_key, _value, _locale)
+        def matches(_key, _value, _locale)
           raise NotImplementedError
         end
 

--- a/lib/mobility/backends/sequel/container/query_methods.rb
+++ b/lib/mobility/backends/sequel/container/query_methods.rb
@@ -25,7 +25,7 @@ module Mobility
 
       private
 
-      def contains_value(key, value, locale)
+      def matches(key, value, locale)
         build_op(column_name)[locale][key.to_s] =~ value.to_json
       end
 

--- a/lib/mobility/backends/sequel/container/query_methods.rb
+++ b/lib/mobility/backends/sequel/container/query_methods.rb
@@ -26,7 +26,7 @@ module Mobility
       private
 
       def contains_value(key, value, locale)
-        build_op(column_name)[locale].contains({ key.to_s => value }.to_json)
+        build_op(column_name)[locale][key.to_s] =~ value.to_json
       end
 
       def has_locale(key, locale)

--- a/lib/mobility/backends/sequel/hstore/query_methods.rb
+++ b/lib/mobility/backends/sequel/hstore/query_methods.rb
@@ -23,7 +23,7 @@ module Mobility
 
       private
 
-      def contains_value(key, value, locale)
+      def matches(key, value, locale)
         build_op(key).contains(locale => value.to_s)
       end
 

--- a/lib/mobility/backends/sequel/jsonb/query_methods.rb
+++ b/lib/mobility/backends/sequel/jsonb/query_methods.rb
@@ -23,7 +23,7 @@ module Mobility
 
       private
 
-      def contains_value(key, value, locale)
+      def matches(key, value, locale)
         build_op(key)[locale] =~ value.to_json
       end
 

--- a/lib/mobility/backends/sequel/jsonb/query_methods.rb
+++ b/lib/mobility/backends/sequel/jsonb/query_methods.rb
@@ -24,7 +24,7 @@ module Mobility
       private
 
       def contains_value(key, value, locale)
-        build_op(key).contains({ locale => value }.to_json)
+        build_op(key)[locale] =~ value.to_json
       end
 
       def has_locale(key, locale)

--- a/lib/mobility/backends/sequel/pg_query_methods.rb
+++ b/lib/mobility/backends/sequel/pg_query_methods.rb
@@ -6,14 +6,14 @@ module Mobility
 Defines query methods for Postgres backends. Including class must define two
 private methods:
 
-- a private method +contains_value+ which takes a key (column name), value and
+- a private method +matches+ which takes a key (column name), value and
   locale and returns an SQL expression, and checks that the column has the
   specified value in the specified locale
 - a private method +has_locale+ which takes a key (column name) and locale, and
   returns an SQL expression which checks that the column has a value in the
   locale
 
-(The +contains_value+ method is implemented slightly differently for hstore and
+(The +matches+ method is implemented slightly differently for hstore and
 jsonb columns.)
 
 =end
@@ -66,13 +66,13 @@ jsonb columns.)
           locale = Mobility.locale.to_s
 
           if invert
-            has_locale(key, locale) & ~contains_value(key, value, locale)
+            has_locale(key, locale) & ~matches(key, value, locale)
           else
-            value.nil? ? ~has_locale(key, locale) : contains_value(key, value, locale)
+            value.nil? ? ~has_locale(key, locale) : matches(key, value, locale)
           end
         end
 
-        def contains_value(_key, _value, _locale)
+        def matches(_key, _value, _locale)
           raise NotImplementedError
         end
 

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -41,7 +41,7 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
           expect(post.title).to eq(value)
           post.save
 
-          post = ContainerPost.first
+          post = ContainerPost.last
           expect(post.title).to eq(value)
         end
 
@@ -56,7 +56,9 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
       end
 
       it_behaves_like "container translated value", :integer, 1
-      it_behaves_like "container translated value", :hash,    { "a" => "b" }
+      it_behaves_like "container translated value", :hash,    { "a" => "b" } do
+        before { ContainerPost.create(title: { "a" => "b", "c" => "d" }) }
+      end
       it_behaves_like "container translated value", :array,   [1, "a", nil]
     end
   end

--- a/spec/mobility/backends/active_record/jsonb_spec.rb
+++ b/spec/mobility/backends/active_record/jsonb_spec.rb
@@ -42,7 +42,7 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
           expect(post.title).to eq(value)
           post.save
 
-          post = JsonbPost.first
+          post = JsonbPost.last
           expect(post.title).to eq(value)
         end
 
@@ -57,7 +57,9 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
       end
 
       it_behaves_like "jsonb translated value", :integer, 1
-      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" }
+      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" } do
+        before { JsonbPost.create(title: { "a" => "b", "c" => "d" }) }
+      end
       it_behaves_like "jsonb translated value", :array,   [1, "a", nil]
     end
   end

--- a/spec/mobility/backends/sequel/container_spec.rb
+++ b/spec/mobility/backends/sequel/container_spec.rb
@@ -39,7 +39,7 @@ describe "Mobility::Backends::Sequel::Container", orm: :sequel, db: :postgres do
           expect(post.title).to eq(value)
           post.save
 
-          post = ContainerPost.first
+          post = ContainerPost.last
           expect(post.title).to eq(value)
         end
 
@@ -54,7 +54,9 @@ describe "Mobility::Backends::Sequel::Container", orm: :sequel, db: :postgres do
       end
 
       it_behaves_like "jsonb translated value", :integer, 1
-      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" }
+      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" } do
+        before { ContainerPost.create(title: { "a" => "b", "c" => "d" }) }
+      end
       it_behaves_like "jsonb translated value", :array,   [1, "a", nil]
     end
   end

--- a/spec/mobility/backends/sequel/jsonb_spec.rb
+++ b/spec/mobility/backends/sequel/jsonb_spec.rb
@@ -40,7 +40,7 @@ describe "Mobility::Backends::Sequel::Jsonb", orm: :sequel, db: :postgres do
           expect(post.title).to eq(value)
           post.save
 
-          post = JsonbPost.first
+          post = JsonbPost.last
           expect(post.title).to eq(value)
         end
 
@@ -55,7 +55,9 @@ describe "Mobility::Backends::Sequel::Jsonb", orm: :sequel, db: :postgres do
       end
 
       it_behaves_like "jsonb translated value", :integer, 1
-      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" }
+      it_behaves_like "jsonb translated value", :hash,    { "a" => "b" } do
+        before { JsonbPost.create(title: { "a" => "b", "c" => "d" }) }
+      end
       it_behaves_like "jsonb translated value", :array,   [1, "a", nil]
     end
   end


### PR DESCRIPTION
Currently, queries on jsonb columns in the `Jsonb` and `Container` backends are performed using the "contains" operator (`@>`). This works fine for string/integer/boolean values, but for hash valued-translations it returns a match even if the hash contains other keys/values (i.e. it does not perform an exact match).

Instead of using "contains" (`@>`), we can also use the normal element operator (`->`), so for a query `Post.i18n.where(title: { "a" => "b" })`, instead of this:

```sql
SELECT "posts".* FROM "posts" WHERE ("posts"."title" @> '{"en":{"a":"b"}}')
```

we instead get this:

```sql
SELECT "posts".* FROM "posts" WHERE (("posts"."title" -> 'en') = '{"a":"b"}')
```

The first SQL will match a post with a title value `'{"a":"b","c":"d"}'`, but the second will not.

Although this is an edge case, I think in general it's also better not to use the jsonb-specific contains operator if it's not really necessary anyway.