### PR TITLE
Refactor find_by for translated attributes

### DIFF
--- a/lib/mobility/backends/active_record/column/query_methods.rb
+++ b/lib/mobility/backends/active_record/column/query_methods.rb
@@ -10,12 +10,6 @@ module Mobility
         define_method :where! do |opts, *rest|
           super(q.convert_opts(opts), *rest)
         end
-
-        attributes.each do |attribute|
-          define_method :"find_by_#{attribute}" do |value|
-            find_by(Column.column_name_for(attribute) => value)
-          end
-        end
       end
 
       def extended(relation)

--- a/lib/mobility/backends/active_record/key_value/query_methods.rb
+++ b/lib/mobility/backends/active_record/key_value/query_methods.rb
@@ -9,12 +9,6 @@ module Mobility
 
         define_join_method(association_name, class_name)
         define_query_methods(association_name)
-
-        attributes.each do |attribute|
-          define_method :"find_by_#{attribute}" do |value|
-            find_by(attribute.to_sym => value)
-          end
-        end
       end
 
       def extended(relation)

--- a/lib/mobility/backends/active_record/query_methods.rb
+++ b/lib/mobility/backends/active_record/query_methods.rb
@@ -11,6 +11,12 @@ models. For details see backend-specific subclasses.
         # @param [Array<String>] attributes Translated attributes
         def initialize(attributes, _)
           @attributes = attributes
+
+          attributes.each do |attribute|
+            define_method :"find_by_#{attribute}" do |value|
+              find_by(attribute.to_sym => value)
+            end
+          end
         end
 
         # @param [ActiveRecord::Relation] relation Relation being extended

--- a/lib/mobility/backends/active_record/table/query_methods.rb
+++ b/lib/mobility/backends/active_record/table/query_methods.rb
@@ -11,12 +11,6 @@ module Mobility
 
         define_join_method(association_name, translation_class, **options)
         define_query_methods(association_name, translation_class, **options)
-
-        attributes.each do |attribute|
-          define_method :"find_by_#{attribute}" do |value|
-            find_by(attribute.to_sym => value)
-          end
-        end
       end
 
       def extended(relation)

--- a/lib/mobility/backends/sequel/column/query_methods.rb
+++ b/lib/mobility/backends/sequel/column/query_methods.rb
@@ -18,12 +18,6 @@ module Mobility
             end
           end
         end
-
-        attributes.each do |attribute|
-          define_method :"first_by_#{attribute}" do |value|
-            where(attribute.to_sym => value).first
-          end
-        end
       end
     end
   end

--- a/lib/mobility/backends/sequel/container/query_methods.rb
+++ b/lib/mobility/backends/sequel/container/query_methods.rb
@@ -11,16 +11,8 @@ module Mobility
 
       def initialize(attributes, options)
         super
-        column_name = @column_name = options[:column_name]
-
+        @column_name = options[:column_name]
         define_query_methods
-
-        attributes.each do |attribute|
-          define_method :"first_by_#{attribute}" do |value|
-            where(::Sequel.pg_jsonb_op(column_name)[Mobility.locale.to_s].contains({ attribute => value })).
-              select_all(model.table_name).first
-          end
-        end
       end
 
       private

--- a/lib/mobility/backends/sequel/hstore/query_methods.rb
+++ b/lib/mobility/backends/sequel/hstore/query_methods.rb
@@ -8,23 +8,10 @@ module Mobility
     class Sequel::Hstore::QueryMethods < Sequel::QueryMethods
       include Sequel::PgQueryMethods
 
-      def initialize(attributes, _)
-        super
-
-        define_query_methods
-
-        attributes.each do |attribute|
-          define_method :"first_by_#{attribute}" do |value|
-            where(::Sequel.hstore(attribute.to_sym).contains(::Sequel.hstore({ Mobility.locale.to_s => value }))).
-              select_all(model.table_name).first
-          end
-        end
-      end
-
       private
 
       def matches(key, value, locale)
-        build_op(key).contains(locale => value.to_s)
+        build_op(key)[locale] =~ value.to_s
       end
 
       def has_locale(key, locale)

--- a/lib/mobility/backends/sequel/jsonb/query_methods.rb
+++ b/lib/mobility/backends/sequel/jsonb/query_methods.rb
@@ -8,19 +8,6 @@ module Mobility
     class Sequel::Jsonb::QueryMethods < Sequel::QueryMethods
       include Sequel::PgQueryMethods
 
-      def initialize(attributes, _)
-        super
-
-        define_query_methods
-
-        attributes.each do |attribute|
-          define_method :"first_by_#{attribute}" do |value|
-            where(::Sequel.pg_jsonb_op(attribute).contains({ Mobility.locale => value })).
-              select_all(model.table_name).first
-          end
-        end
-      end
-
       private
 
       def matches(key, value, locale)

--- a/lib/mobility/backends/sequel/key_value/query_methods.rb
+++ b/lib/mobility/backends/sequel/key_value/query_methods.rb
@@ -8,12 +8,6 @@ module Mobility
 
         define_join_method(association_name, class_name)
         define_query_methods(association_name)
-
-        attributes.each do |attribute|
-          define_method :"first_by_#{attribute}" do |value|
-            where(attribute => value).select_all(model.table_name).first
-          end
-        end
       end
 
       private

--- a/lib/mobility/backends/sequel/pg_query_methods.rb
+++ b/lib/mobility/backends/sequel/pg_query_methods.rb
@@ -18,6 +18,10 @@ jsonb columns.)
 
 =end
       module PgQueryMethods
+        def initialize(attributes, _)
+          super
+          define_query_methods
+        end
 
         # Create query for conditions and translated keys
         # @note This is a destructive action, it will alter +cond+.

--- a/lib/mobility/backends/sequel/query_methods.rb
+++ b/lib/mobility/backends/sequel/query_methods.rb
@@ -13,6 +13,12 @@ models. For details see backend-specific subclasses.
         # @param [Array<String>] attributes Translated attributes
         def initialize(attributes, _)
           @attributes = attributes.map!(&:to_sym)
+
+          attributes.each do |attribute|
+            define_method :"first_by_#{attribute}" do |value|
+              where(attribute.to_sym => value).select_all(model.table_name).first
+            end
+          end
         end
 
         def extract_attributes(cond)

--- a/lib/mobility/backends/sequel/table/query_methods.rb
+++ b/lib/mobility/backends/sequel/table/query_methods.rb
@@ -9,12 +9,6 @@ module Mobility
 
         define_join_method(association_name, translation_class, **options)
         define_query_methods(association_name, translation_class, **options)
-
-        attributes.each do |attribute|
-          define_method :"first_by_#{attribute}" do |value|
-            where(attribute => value).select_all(model.table_name).first
-          end
-        end
       end
 
       def define_join_method(association_name, translation_class, table_name: nil, foreign_key: nil, **)


### PR DESCRIPTION
In #159, I changed how the jsonb and container backends query on translated attributes, but I noticed that this wasn't applying to some `first_by_<x>`-type queries in Sequel. The reason is that some code had not been updated to the new format, but I realized it's much easier to just refactor all this `first_by_<x>` (Sequel) + `find_by_<x>` (AR) method code to define these methods *once*, basically as an alias independent of the backend query details.

This improves consistency and also chops off about 50 lines of code :smile: