### PR TITLE
Update for AR 5.2.0.rc2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,8 @@ group :development, :test do
     elsif ENV['RAILS_VERSION'] == '5.1'
       gem 'activerecord', '>= 5.1', '< 5.2'
     else
-      git 'https://github.com/rails/rails.git', branch: '5-2-stable' do
-        gem 'activerecord'
-        gem 'railties'
-      end
+      gem 'activerecord', '>= 5.2.0.rc2', '< 5.3'
+      gem 'railties', '>= 5.2.0.rc2', '< 5.3'
     end
     gem "generator_spec", '~> 0.9.4'
   elsif ENV['ORM'] == 'sequel'

--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,10 @@ group :development, :test do
     elsif ENV['RAILS_VERSION'] == '5.1'
       gem 'activerecord', '>= 5.1', '< 5.2'
     else
-      # TODO: change to '>= 5.2.0.beta1, < 5.3'
-      #   once dirty specs pass in 5.2.0.rc1
-      gem 'activerecord', '5.2.0.beta2'
-      gem 'railties', '5.2.0.beta2'
+      git 'https://github.com/rails/rails.git', branch: '5-2-stable' do
+        gem 'activerecord'
+        gem 'railties'
+      end
     end
     gem "generator_spec", '~> 0.9.4'
   elsif ENV['ORM'] == 'sequel'

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -252,7 +252,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
           Mobility.locale = :ja
           expect(article.title).to eq(nil)
           expect(article.content).to eq(nil)
-          article.update_attributes!(title: "新規記事", content: "昔々あるところに…")
+          article.update!(title: "新規記事", content: "昔々あるところに…")
           expect(article.title).to eq("新規記事")
           expect(article.content).to eq("昔々あるところに…")
           expect(Article.count).to eq(1)
@@ -310,7 +310,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
       # sure we clean them up when the model is destroyed.
       it "cleans up all associated translations, regardless of key" do
         article = Article.create(title: "foo title", content: "foo content")
-        Mobility.with_locale(:ja) { article.update_attributes(title: "あああ", content: "ばばば") }
+        Mobility.with_locale(:ja) { article.update(title: "あああ", content: "ばばば") }
         article.save
 
         # Create translations on another model, to check they do not get destroyed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-ENV['RAILS_VERSION']  ||= "5.1"
+ENV['RAILS_VERSION']  ||= "5.2"
 ENV['SEQUEL_VERSION'] ||= "4"
 
 if !ENV['ORM'].nil? && !ENV['ORM'].empty?

--- a/spec/support/shared_examples/cache_key_examples.rb
+++ b/spec/support/shared_examples/cache_key_examples.rb
@@ -5,7 +5,7 @@ shared_examples_for "cache key"  do |model_class_name, attribute=:title|
     model = model_class.create!(attribute => "foo")
     original_cache_key = model.cache_key
     travel 1.second do
-      model.update_attributes!(attribute => "bar")
+      model.update!(attribute => "bar")
     end
     expect(model.cache_key).to_not eq(original_cache_key)
   end


### PR DESCRIPTION
Specs fail on 5.2.0.rc1, but some changes in that version have been [reverted](https://github.com/rails/rails/commit/5fcbdcfb574c731841be12764c50d9587b58345f), so I've updated the Gemfile to look at master and I'll try to fix the remaining issues here.

Against master at this time, six specs (related to dirty attribute tracking) are currently failing.