### PR TITLE
Upgrade i18n dependency and test against 1.0.0

### DIFF
--- a/mobility.gemspec
+++ b/mobility.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'request_store', '~> 1.0'
-  spec.add_dependency 'i18n', '>= 0.6.10', '< 0.10'
+  spec.add_dependency 'i18n', '>= 0.6.10', '< 1.1'
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner", '~> 1.5', '>= 1.5.3'
   spec.add_development_dependency "rake", '~> 12', '>= 12.2.1'


### PR DESCRIPTION
i18n version [1.0.0](https://rubygems.org/gems/i18n/versions/1.0.0) was released a few days ago, but Mobility has a dependency on i18n < 1.0. Updating the dependency to include 1.0 to see if specs pass.