### PR TITLE
Use pragma comments to freeze strings everywhere

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'i18n'
 require 'request_store'
 require 'mobility/version'
@@ -194,7 +195,7 @@ module Mobility
     #   Mobility.normalize_locale("pt-BR")
     #   #=> "pt_br"
     def normalize_locale(locale = Mobility.locale)
-      "#{locale.to_s.downcase.sub("-", "_")}".freeze
+      "#{locale.to_s.downcase.sub("-", "_")}"
     end
     alias_method :normalized_locale, :normalize_locale
 
@@ -208,7 +209,7 @@ module Mobility
     #   Mobility.normalize_locale_accessor(:bar, "pt-BR")
     #   #=> "bar_pt_br"
     def normalize_locale_accessor(attribute, locale = Mobility.locale)
-      "#{attribute}_#{normalize_locale(locale)}".freeze
+      "#{attribute}_#{normalize_locale(locale)}"
     end
 
     # Raises InvalidLocale exception if the locale passed in is present but not available.

--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mobility
 =begin
 

--- a/lib/mobility/active_record/backend_resetter.rb
+++ b/lib/mobility/active_record/backend_resetter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/active_model/backend_resetter"
 
 module Mobility

--- a/lib/mobility/active_record/string_translation.rb
+++ b/lib/mobility/active_record/string_translation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/active_record/translation"
 
 module Mobility

--- a/lib/mobility/active_record/text_translation.rb
+++ b/lib/mobility/active_record/text_translation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/active_record/translation"
 
 module Mobility

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/util"
 
 module Mobility

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -116,7 +116,7 @@ On top of this, a backend will normally:
     # @return [String] name of backend reader method
     def self.method_name(attribute)
       @backend_method_names ||= {}
-      @backend_method_names[attribute] ||= "#{attribute}_backend".freeze
+      @backend_method_names[attribute] ||= "#{attribute}_backend"
     end
 
     # Defines setup hooks for backend to customize model class.

--- a/lib/mobility/backend/orm_delegator.rb
+++ b/lib/mobility/backend/orm_delegator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mobility
   module Backend
 =begin
@@ -16,15 +17,15 @@ Adds {#for} method to backend to return ORM-specific backend.
       # @param [Class] model_class Class of model
       # @return [Class] Class of backend to use for model
       def for(model_class)
-        namespace = name.split('::'.freeze)
+        namespace = name.split('::')
         if Loaded::ActiveRecord && model_class < ::ActiveRecord::Base
           require_backend("active_record", namespace.last.underscore)
-          const_get(namespace.insert(-2, "ActiveRecord".freeze).join("::".freeze))
+          const_get(namespace.insert(-2, "ActiveRecord").join("::"))
         elsif Loaded::Sequel && model_class < ::Sequel::Model
           require_backend("sequel", namespace.last.underscore)
-          const_get(namespace.insert(-2, "Sequel".freeze).join("::".freeze))
+          const_get(namespace.insert(-2, "Sequel").join("::"))
         else
-          raise ArgumentError, "#{namespace.last} backend can only be used by ActiveRecord or Sequel models".freeze
+          raise ArgumentError, "#{namespace.last} backend can only be used by ActiveRecord or Sequel models"
         end
       end
 

--- a/lib/mobility/backend_resetter.rb
+++ b/lib/mobility/backend_resetter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
 =begin
 

--- a/lib/mobility/backends/active_record/column.rb
+++ b/lib/mobility/backends/active_record/column.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record"
 require "mobility/backends/column"
 

--- a/lib/mobility/backends/active_record/column/query_methods.rb
+++ b/lib/mobility/backends/active_record/column/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record"
 
 module Mobility

--- a/lib/mobility/backends/active_record/container/query_methods.rb
+++ b/lib/mobility/backends/active_record/container/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record/jsonb"
 
 module Mobility

--- a/lib/mobility/backends/active_record/jsonb/query_methods.rb
+++ b/lib/mobility/backends/active_record/jsonb/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mobility/backends/active_record/pg_query_methods'
 require "mobility/backends/active_record/query_methods"
 

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -38,7 +38,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
       def self.configure(options)
         super
         type = options[:type]
-        options[:class_name] ||= Mobility::ActiveRecord.const_get("#{type.capitalize}Translation".freeze)
+        options[:class_name] ||= Mobility::ActiveRecord.const_get("#{type.capitalize}Translation")
         options[:class_name] = options[:class_name].constantize if options[:class_name].is_a?(String)
         options[:association_name] ||= :"#{options[:type]}_translations"
         %i[type association_name].each { |key| options[key] = options[key].to_sym }
@@ -103,7 +103,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
         # Clean up *all* leftover translations of this model, only once.
         def mobility_destroy_key_value_translations
           [:string, :text].freeze.each do |type|
-            Mobility::ActiveRecord.const_get("#{type.capitalize}Translation".freeze).
+            Mobility::ActiveRecord.const_get("#{type.capitalize}Translation").
               where(translatable: self).destroy_all
           end
         end

--- a/lib/mobility/backends/active_record/key_value/query_methods.rb
+++ b/lib/mobility/backends/active_record/key_value/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/active_record/pg_hash.rb
+++ b/lib/mobility/backends/active_record/pg_hash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record"
 require "mobility/backends/hash_valued"
 

--- a/lib/mobility/backends/active_record/serialized.rb
+++ b/lib/mobility/backends/active_record/serialized.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record"
 require "mobility/backends/hash_valued"
 require "mobility/backends/serialized"

--- a/lib/mobility/backends/active_record/serialized/query_methods.rb
+++ b/lib/mobility/backends/active_record/serialized/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -101,7 +101,7 @@ columns to that table.
       #   to append to model class to generate translation class
       def self.configure(options)
         table_name = options[:model_class].table_name
-        options[:table_name]  ||= "#{table_name.singularize}_translations".freeze
+        options[:table_name]  ||= "#{table_name.singularize}_translations"
         options[:foreign_key] ||= table_name.downcase.singularize.camelize.foreign_key
         if (association_name = options[:association_name]).present?
           options[:subclass_name] ||= association_name.to_s.singularize.camelize.freeze
@@ -158,7 +158,7 @@ columns to that table.
       setup_query_methods(QueryMethods)
 
       def translation_for(locale, _)
-        translation = translations.find { |t| t.locale == locale.to_s.freeze }
+        translation = translations.find { |t| t.locale == locale.to_s }
         translation ||= translations.build(locale: locale)
         translation
       end

--- a/lib/mobility/backends/active_record/table/query_methods.rb
+++ b/lib/mobility/backends/active_record/table/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/active_record/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/column.rb
+++ b/lib/mobility/backends/column.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
   module Backends
 =begin

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/plugins/cache"
 
 module Mobility

--- a/lib/mobility/backends/sequel/column.rb
+++ b/lib/mobility/backends/sequel/column.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/sequel"
 require "mobility/backends/column"
 

--- a/lib/mobility/backends/sequel/column/query_methods.rb
+++ b/lib/mobility/backends/sequel/column/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/sequel/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/sequel/container/query_methods.rb
+++ b/lib/mobility/backends/sequel/container/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/sequel/pg_query_methods"
 require "mobility/backends/sequel/query_methods"
 

--- a/lib/mobility/backends/sequel/hstore/query_methods.rb
+++ b/lib/mobility/backends/sequel/hstore/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mobility/backends/sequel/pg_query_methods'
 require "mobility/backends/sequel/query_methods"
 

--- a/lib/mobility/backends/sequel/jsonb/query_methods.rb
+++ b/lib/mobility/backends/sequel/jsonb/query_methods.rb
@@ -1,4 +1,5 @@
-require 'mobility/backends/sequel/pg_query_methods'
+# frozen_string_literal: true
+require "mobility/backends/sequel/pg_query_methods"
 require "mobility/backends/sequel/query_methods"
 
 Sequel.extension :pg_json, :pg_json_ops

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -46,7 +46,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
         super
         raise CacheRequired, "Cache required for Sequel::KeyValue backend" if options[:cache] == false
         type = options[:type]
-        options[:class_name] ||= Mobility::Sequel.const_get("#{type.capitalize}Translation".freeze)
+        options[:class_name] ||= Mobility::Sequel.const_get("#{type.capitalize}Translation")
         options[:class_name] = options[:class_name].constantize if options[:class_name].is_a?(String)
         options[:association_name] ||= :"#{options[:type]}_translations"
         %i[type association_name].each { |key| options[key] = options[key].to_sym }
@@ -93,7 +93,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
             def after_destroy
               super
               [:string, :text].freeze.each do |type|
-                Mobility::Sequel.const_get("#{type.capitalize}Translation".freeze).
+                Mobility::Sequel.const_get("#{type.capitalize}Translation").
                   where(translatable_id: id, translatable_type: self.class.name).destroy
               end
             end

--- a/lib/mobility/backends/sequel/key_value/query_methods.rb
+++ b/lib/mobility/backends/sequel/key_value/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/sequel/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/sequel/pg_hash.rb
+++ b/lib/mobility/backends/sequel/pg_hash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/util"
 require "mobility/backends/sequel"
 require "mobility/backends/hash_valued"

--- a/lib/mobility/backends/sequel/query_methods.rb
+++ b/lib/mobility/backends/sequel/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/util"
 
 module Mobility

--- a/lib/mobility/backends/sequel/serialized.rb
+++ b/lib/mobility/backends/sequel/serialized.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/sequel"
 require "mobility/backends/hash_valued"
 require "mobility/backends/serialized"

--- a/lib/mobility/backends/sequel/serialized/query_methods.rb
+++ b/lib/mobility/backends/sequel/serialized/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/sequel/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/util"
 require "mobility/backends/sequel"
 require "mobility/backends/key_value"

--- a/lib/mobility/backends/sequel/table/query_methods.rb
+++ b/lib/mobility/backends/sequel/table/query_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backends/sequel/query_methods"
 
 module Mobility

--- a/lib/mobility/backends/serialized.rb
+++ b/lib/mobility/backends/serialized.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/util"
 
 module Mobility

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/plugins/cache"
 
 module Mobility

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
 =begin
 

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -45,21 +45,21 @@ value of the translated attribute if passed to it.
           def initialize(*attribute_names)
             attribute_names.each do |name|
               method_suffixes.each do |suffix|
-                define_method "#{name}#{suffix}".freeze do
-                  __send__("attribute#{suffix}".freeze, Mobility.normalize_locale_accessor(name))
+                define_method "#{name}#{suffix}" do
+                  __send__("attribute#{suffix}", Mobility.normalize_locale_accessor(name))
                 end
               end
 
-              define_method "restore_#{name}!".freeze do
+              define_method "restore_#{name}!" do
                 locale_accessor = Mobility.normalize_locale_accessor(name)
                 if attribute_changed?(locale_accessor)
-                  __send__("#{name}=".freeze, changed_attributes[locale_accessor])
+                  __send__("#{name}=", changed_attributes[locale_accessor])
                 end
               end
             end
 
             define_method :restore_attribute! do |attr|
-              attribute_names.include?(attr.to_s) ? send("restore_#{attr}!".freeze) : super(attr)
+              attribute_names.include?(attr.to_s) ? send("restore_#{attr}!") : super(attr)
             end
             private :restore_attribute!
           end

--- a/lib/mobility/plugins/active_record/dirty.rb
+++ b/lib/mobility/plugins/active_record/dirty.rb
@@ -46,7 +46,7 @@ AR::Dirty plugin adds support for the following persistence-specific methods
 
             if ::ActiveRecord::VERSION::MAJOR == 5 && ::ActiveRecord::VERSION::MINOR == 1
               names = @attribute_names
-              method_name_regex = /\A(#{names.join('|'.freeze)})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
+              method_name_regex = /\A(#{names.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
               has_attribute = Module.new do
                 define_method :has_attribute? do |attr_name|
                   super(attr_name) || !!method_name_regex.match(attr_name)

--- a/lib/mobility/plugins/cache.rb
+++ b/lib/mobility/plugins/cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/plugins/cache/translation_cacher"
 
 module Mobility

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
   module Plugins
 =begin

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/backend_resetter"
 require "mobility/plugins/fallthrough_accessors"
 

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/util"
 
 module Mobility

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -44,14 +44,14 @@ model class is generated.
 
       # @param [String] One or more attributes
       def initialize(*attributes)
-        method_name_regex = /\A(#{attributes.join('|'.freeze)})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
+        method_name_regex = /\A(#{attributes.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
 
         define_method :method_missing do |method_name, *arguments, **options, &block|
           if method_name =~ method_name_regex
             attribute = $1.to_sym
-            locale, suffix = $2.split('_'.freeze)
-            locale = "#{locale}-#{suffix.upcase}".freeze if suffix
-            public_send("#{attribute}#{$4}".freeze, *arguments, **options, locale: locale.to_sym)
+            locale, suffix = $2.split('_')
+            locale = "#{locale}-#{suffix.upcase}" if suffix
+            public_send("#{attribute}#{$4}", *arguments, **options, locale: locale.to_sym)
           else
             super(method_name, *arguments, &block)
           end

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -53,7 +53,7 @@ If no locales are passed as an option to the initializer,
       private
 
       def define_reader(name, locale)
-        warning_message = "locale passed as option to locale accessor will be ignored".freeze
+        warning_message = "locale passed as option to locale accessor will be ignored"
         normalized_locale = Mobility.normalize_locale(locale)
 
         define_method "#{name}_#{normalized_locale}" do |**options|
@@ -70,7 +70,7 @@ If no locales are passed as an option to the initializer,
       end
 
       def define_writer(name, locale)
-        warning_message = "locale passed as option to locale accessor will be ignored".freeze
+        warning_message = "locale passed as option to locale accessor will be ignored"
         normalized_locale = Mobility.normalize_locale(locale)
 
         define_method "#{name}_#{normalized_locale}=" do |value, **options|

--- a/lib/mobility/plugins/presence.rb
+++ b/lib/mobility/plugins/presence.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/util"
 
 module Mobility

--- a/lib/mobility/sequel/column_changes.rb
+++ b/lib/mobility/sequel/column_changes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
   module Sequel
 =begin
@@ -10,7 +12,7 @@ setter method is called.
       # @param [Array<String>] attributes Backend attributes
       def initialize(*attributes)
         attributes.each do |attribute|
-          define_method "#{attribute}=".freeze do |value, **options|
+          define_method "#{attribute}=" do |value, **options|
             if !options[:super] && send(attribute) != value
               locale = options[:locale] || Mobility.locale
               column = attribute.to_sym

--- a/lib/mobility/sequel/hash_initializer.rb
+++ b/lib/mobility/sequel/hash_initializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
   module Sequel
 =begin

--- a/lib/mobility/sequel/string_translation.rb
+++ b/lib/mobility/sequel/string_translation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/sequel/translation"
 
 module Mobility

--- a/lib/mobility/sequel/text_translation.rb
+++ b/lib/mobility/sequel/text_translation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mobility/sequel/translation"
 
 module Mobility

--- a/lib/mobility/translates.rb
+++ b/lib/mobility/translates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
 =begin
 

--- a/lib/mobility/util.rb
+++ b/lib/mobility/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
 =begin
 
@@ -40,7 +42,7 @@ Some useful methods on strings, borrowed in parts from Sequel and ActiveSupport.
     # @return [String]
     def camelize(str)
       call_or_yield str do
-        str.to_s.sub(/^[a-z\d]*/) { $&.capitalize }.gsub(/(?:_|(\/))([a-z\d]*)/) { "#{$1}#{$2.capitalize}" }.gsub('/'.freeze, '::'.freeze)
+        str.to_s.sub(/^[a-z\d]*/) { $&.capitalize }.gsub(/(?:_|(\/))([a-z\d]*)/) { "#{$1}#{$2.capitalize}" }.gsub('/', '::')
       end
     end
 

--- a/lib/mobility/version.rb
+++ b/lib/mobility/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mobility
   VERSION = "0.4.3"
 end

--- a/lib/rails/generators/mobility/active_record_migration_compatibility.rb
+++ b/lib/rails/generators/mobility/active_record_migration_compatibility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails/generators/active_record"
 require "active_record/migration"
 

--- a/lib/rails/generators/mobility/backend_generators/base.rb
+++ b/lib/rails/generators/mobility/backend_generators/base.rb
@@ -53,15 +53,15 @@ module Mobility
       end
 
       def template
-        "#{backend}_translations".freeze
+        "#{backend}_translations"
       end
 
       def migration_dir
-        File.expand_path("db/migrate".freeze)
+        File.expand_path("db/migrate")
       end
 
       def migration_file
-        "create_#{file_name}_#{attributes.map(&:name).join('_and_')}_translations_for_mobility_#{backend}_backend".freeze
+        "create_#{file_name}_#{attributes.map(&:name).join('_and_')}_translations_for_mobility_#{backend}_backend"
       end
     end
 

--- a/lib/rails/generators/mobility/generators.rb
+++ b/lib/rails/generators/mobility/generators.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails/generators"
 
 require_relative "./active_record_migration_compatibility"

--- a/lib/rails/generators/mobility/install_generator.rb
+++ b/lib/rails/generators/mobility/install_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails/generators"
 require "rails/generators/active_record"
 require_relative "./active_record_migration_compatibility"

--- a/lib/rails/generators/mobility/translations_generator.rb
+++ b/lib/rails/generators/mobility/translations_generator.rb
@@ -35,7 +35,7 @@ Other backends are not supported, for obvious reasons:
 =end
   class TranslationsGenerator < ::Rails::Generators::NamedBase
     SUPPORTED_BACKENDS = %w[column table]
-    BACKEND_OPTIONS = { type: :string, desc: "Backend to use for translations (defaults to Mobility.default_backend)".freeze }
+    BACKEND_OPTIONS = { type: :string, desc: "Backend to use for translations (defaults to Mobility.default_backend)" }
     argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
 
     class_option(:backend, BACKEND_OPTIONS)
@@ -50,7 +50,7 @@ Other backends are not supported, for obvious reasons:
     def self.prepare_for_invocation(name, value)
       if name == :backend
         if SUPPORTED_BACKENDS.include?(value)
-          require_relative "./backend_generators/#{value}_backend".freeze
+          require_relative "./backend_generators/#{value}_backend"
           Mobility::BackendGenerators.const_get("#{value}_backend".camelcase.freeze)
         else
           begin
@@ -70,7 +70,7 @@ Other backends are not supported, for obvious reasons:
 
     def say_status(status, message, *args)
       if status == :invoke && SUPPORTED_BACKENDS.include?(message)
-        super(status, "#{message}_backend".freeze, *args)
+        super(status, "#{message}_backend", *args)
       else
         super
       end


### PR DESCRIPTION
Cleans up a lot of inconsistent `freeze`-ing.

Inspired by: https://www.mikeperham.com/2018/02/28/ruby-optimization-with-one-magic-comment/