### PR TITLE
Add json column support to container backend

### DIFF
--- a/lib/mobility/backends/active_record/container/json_query_methods.rb
+++ b/lib/mobility/backends/active_record/container/json_query_methods.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
-require "mobility/backends/active_record/jsonb"
+require 'mobility/backends/active_record/pg_query_methods'
+require "mobility/backends/active_record/query_methods"
 
 module Mobility
   module Backends
-    class ActiveRecord::Container::QueryMethods < ActiveRecord::QueryMethods
+    class ActiveRecord::Container::JsonQueryMethods < ActiveRecord::QueryMethods
       include ActiveRecord::PgQueryMethods
       attr_reader :column_name, :column
 
@@ -16,16 +17,13 @@ module Mobility
       private
 
       def matches(key, value, locale)
-        build_infix(:'->',
+        build_infix(:'->>',
                     build_infix(:'->', column, quote(locale)),
-                    quote(key)).eq(quote(value.to_json))
+                    quote(key)).eq(value && value.to_s)
       end
 
       def has_locale(key, locale)
-        build_infix(:'?', column, quote(locale)).and(
-          build_infix(:'?',
-                      build_infix(:'->', column, quote(locale)),
-                      quote(key)))
+        matches(key, nil, locale).not
       end
     end
   end

--- a/lib/mobility/backends/active_record/container/jsonb_query_methods.rb
+++ b/lib/mobility/backends/active_record/container/jsonb_query_methods.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'mobility/backends/active_record/pg_query_methods'
+require "mobility/backends/active_record/query_methods"
+
+module Mobility
+  module Backends
+    class ActiveRecord::Container::JsonbQueryMethods < ActiveRecord::QueryMethods
+      include ActiveRecord::PgQueryMethods
+      attr_reader :column_name, :column
+
+      def initialize(_attributes, options)
+        super
+        @column_name = options[:column_name]
+        @column      = arel_table[@column_name]
+      end
+
+      private
+
+      def matches(key, value, locale)
+        build_infix(:'->',
+                    build_infix(:'->', column, quote(locale)),
+                    quote(key)).eq(quote(value.to_json))
+      end
+
+      def has_locale(key, locale)
+        build_infix(:'?', column, quote(locale)).and(
+          build_infix(:'?',
+                      build_infix(:'->', column, quote(locale)),
+                      quote(key)))
+      end
+    end
+  end
+end

--- a/lib/mobility/backends/active_record/json/query_methods.rb
+++ b/lib/mobility/backends/active_record/json/query_methods.rb
@@ -18,7 +18,7 @@ module Mobility
       end
 
       def build_locale_infix(key, locale)
-        arel_table.grouping(build_infix(:'->>', arel_table[key], quote(locale)))
+        build_infix(:'->>', arel_table[key], quote(locale))
       end
     end
   end

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -103,7 +103,7 @@ code.
         end
 
         def build_infix(*args)
-          Arel::Nodes::InfixOperation.new(*args)
+          arel_table.grouping(Arel::Nodes::InfixOperation.new(*args))
         end
 
         def quote(value)

--- a/lib/mobility/backends/sequel/container/json_query_methods.rb
+++ b/lib/mobility/backends/sequel/container/json_query_methods.rb
@@ -6,7 +6,7 @@ Sequel.extension :pg_json, :pg_json_ops
 
 module Mobility
   module Backends
-    class Sequel::Container::QueryMethods < Sequel::QueryMethods
+    class Sequel::Container::JsonQueryMethods < Sequel::QueryMethods
       include Sequel::PgQueryMethods
       attr_reader :column_name
 
@@ -19,15 +19,15 @@ module Mobility
       private
 
       def matches(key, value, locale)
-        build_op(column_name)[locale][key.to_s] =~ value.to_json
+        build_op(column_name)[locale].get_text(key.to_s) =~ value.to_s
       end
 
       def has_locale(key, locale)
-        build_op(column_name).has_key?(locale) & build_op(column_name)[locale].has_key?(key.to_s)
+        build_op(column_name)[locale].get_text(key.to_s) !~ nil
       end
 
       def build_op(key)
-        ::Sequel.pg_jsonb_op(key)
+        ::Sequel.pg_json_op(key)
       end
     end
   end

--- a/lib/mobility/backends/sequel/container/jsonb_query_methods.rb
+++ b/lib/mobility/backends/sequel/container/jsonb_query_methods.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require "mobility/backends/sequel/pg_query_methods"
+require "mobility/backends/sequel/query_methods"
+
+Sequel.extension :pg_json, :pg_json_ops
+
+module Mobility
+  module Backends
+    class Sequel::Container::JsonbQueryMethods < Sequel::QueryMethods
+      include Sequel::PgQueryMethods
+      attr_reader :column_name
+
+      def initialize(attributes, options)
+        super
+        @column_name = options[:column_name]
+        define_query_methods
+      end
+
+      private
+
+      def matches(key, value, locale)
+        build_op(column_name)[locale][key.to_s] =~ value.to_json
+      end
+
+      def has_locale(key, locale)
+        build_op(column_name).has_key?(locale) & build_op(column_name)[locale].has_key?(key.to_s)
+      end
+
+      def build_op(key)
+        ::Sequel.pg_jsonb_op(key)
+      end
+    end
+  end
+end

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -108,7 +108,8 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
       StringColumnPost.extend Mobility
       expect {
         StringColumnPost.translates :title, backend: :container, column_name: :foo
-      }.to raise_error(Mobility::Backends::ActiveRecord::Container::InvalidColumnType)
+      }.to raise_error(Mobility::Backends::ActiveRecord::Container::InvalidColumnType,
+                       "foo must be a column of type json or jsonb")
     end
   end
 end if Mobility::Loaded::ActiveRecord


### PR DESCRIPTION
Currently, the Container backend requires a `jsonb` column. With this change, we check the column type and correctly handle translations on a `json` column in the same way, and raise if the column type is neither `json` nor `jsonb`.