### PR TITLE
Array.wrap -> Kernel::Array

### DIFF
--- a/lib/mobility/backends/active_record/key_value/query_methods.rb
+++ b/lib/mobility/backends/active_record/key_value/query_methods.rb
@@ -54,7 +54,7 @@ module Mobility
         define_method :where! do |opts, *rest|
           if i18n_keys = q.extract_attributes(opts)
             opts = opts.with_indifferent_access
-            i18n_nulls = i18n_keys.reject { |key| opts[key] && Array.wrap(opts[key]).all? }
+            i18n_nulls = i18n_keys.reject { |key| opts[key] && Array(opts[key]).all? }
             i18n_keys.each { |attr| opts["#{attr}_#{association_name}"] = { value: opts.delete(attr) }}
             super(opts, *rest).
               send("join_#{association_name}", *(i18n_keys - i18n_nulls)).

--- a/lib/mobility/backends/active_record/table/query_methods.rb
+++ b/lib/mobility/backends/active_record/table/query_methods.rb
@@ -92,7 +92,7 @@ module Mobility
             options = {
               # We only need an OUTER JOIN if every value is either nil, or an
               # array with at least one nil value.
-              outer_join: opts.values_at(*i18n_keys).compact.all? { |v| !Array.wrap(v).all? }
+              outer_join: opts.values_at(*i18n_keys).compact.all? { |v| !Array(v).all? }
             }
             i18n_keys.each { |attr| opts["#{translation_class.table_name}.#{attr}"] = opts.delete(attr) }
             super(opts, *rest).send("join_#{association_name}", options)


### PR DESCRIPTION
Why use ActiveSupport when you don't have to?