### PR TITLE
Refactor Container backend query methods

### DIFF
--- a/lib/mobility/backends/active_record/container/jsonb_query_methods.rb
+++ b/lib/mobility/backends/active_record/container/jsonb_query_methods.rb
@@ -19,14 +19,11 @@ module Mobility
       def matches(key, value, locale)
         build_infix(:'->',
                     build_infix(:'->', column, quote(locale)),
-                    quote(key)).eq(quote(value.to_json))
+                    quote(key)).eq(value && quote(value.to_json))
       end
 
       def has_locale(key, locale)
-        build_infix(:'?', column, quote(locale)).and(
-          build_infix(:'?',
-                      build_infix(:'->', column, quote(locale)),
-                      quote(key)))
+        matches(key, nil, locale).not
       end
     end
   end

--- a/lib/mobility/backends/sequel/container/jsonb_query_methods.rb
+++ b/lib/mobility/backends/sequel/container/jsonb_query_methods.rb
@@ -23,7 +23,7 @@ module Mobility
       end
 
       def has_locale(key, locale)
-        build_op(column_name).has_key?(locale) & build_op(column_name)[locale].has_key?(key.to_s)
+        build_op(column_name)[locale][key.to_s] !~ nil
       end
 
       def build_op(key)


### PR DESCRIPTION
This changes the queries to use `IS NOT NULL` instead of using the jsonb-specific existence (`?`) operator. But I believe existence may be preferable for performance reasons. Need to research before merging this (or not merging) - if anyone has any info please let me know.