### PR TITLE
Add missing documentation

### DIFF
--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -3,10 +3,20 @@ module Mobility
 =begin
 
 A backend-agnostic uniqueness validator for ActiveRecord translated attributes.
+To use the validator, you must +extend Mobility+ before calling +validates+
+(see example below).
 
 @note This validator does not support case sensitivity, since doing so would
   significantly complicate implementation.
 
+@example Validating uniqueness on translated model
+  class Post < ActiveRecord::Base
+    extend Mobility
+    translates :title
+
+    # This must come *after* extending Mobility.
+    validates :title, uniqueness: true
+  end
 =end
     class UniquenessValidator < ::ActiveRecord::Validations::UniquenessValidator
       # @param [ActiveRecord::Base] record Translated model

--- a/lib/mobility/backends/active_record/column.rb
+++ b/lib/mobility/backends/active_record/column.rb
@@ -19,6 +19,7 @@ or locales.)
 
 @example
   class Post < ActiveRecord::Base
+    extend Mobility
     translates :title, backend: :column
   end
 

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -12,6 +12,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
 
 @example
   class Post < ActiveRecord::Base
+    extend Mobility
     translates :title, backend: :key_value, association_name: :translations, type: :string
   end
 

--- a/lib/mobility/backends/active_record/serialized.rb
+++ b/lib/mobility/backends/active_record/serialized.rb
@@ -11,6 +11,7 @@ Implements {Mobility::Backends::Serialized} backend for ActiveRecord models.
 
 @example Define attribute with serialized backend
   class Post < ActiveRecord::Base
+    extend Mobility
     translates :title, backend: :serialized, format: :yaml
   end
 

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -20,6 +20,7 @@ columns to that table.
 
 @example Model with table backend
   class Post < ActiveRecord::Base
+    extend Mobility
     translates :title, backend: :table
   end
 
@@ -45,6 +46,7 @@ columns to that table.
 
 @example Model with multiple translation tables
   class Post < ActiveRecord::Base
+    extend Mobility
     translates :title,   backend: :table, table_name: :post_title_translations,   association_name: :title_translations
     translates :content, backend: :table, table_name: :post_content_translations, association_name: :content_translations
   end

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -37,6 +37,7 @@ the current locale was +nil+.
 
 @example With default fallbacks enabled (falls through to default locale)
   class Post
+    extend Mobility
     translates :title, fallbacks: true
   end
 
@@ -54,6 +55,7 @@ the current locale was +nil+.
 
 @example With additional fallbacks enabled
   class Post
+    extend Mobility
     translates :title, fallbacks: { :'en-US' => 'de-DE', :pt => 'de-DE' }
   end
 
@@ -70,6 +72,7 @@ the current locale was +nil+.
 
 @example Passing fallback option when reading value
   class Post
+    extend Mobility
     translates :title, fallbacks: true
   end
 
@@ -88,6 +91,7 @@ the current locale was +nil+.
 
 @example Fallbacks disabled
   class Post
+    extend Mobility
     translates :title, fallbacks: { :'fr' => 'en' }, locale_accessors: true
   end
 


### PR DESCRIPTION
- missing `extend Mobility` in many examples
- no mention that `validates` must be called after `extend Mobility` for uniqueness validator to work