### PR TITLE
Simplify Util module

### DIFF
--- a/lib/mobility/util.rb
+++ b/lib/mobility/util.rb
@@ -101,8 +101,7 @@ Some useful methods on strings, borrowed in parts from Sequel and ActiveSupport.
     end
 
     def blank?(object)
-      return true if object.nil?
-      object.respond_to?(:empty?) ? !!object.empty? : !object
+      object.nil? || object == ""
     end
 
     def presence(object)


### PR DESCRIPTION
We should only define the level of functionality that Mobility requires in this module, so e.g. presence should only check `nil` or `""`, etc.