### PR TITLE
Remove table backend index on foreign key alone

### DIFF
--- a/lib/rails/generators/mobility/templates/table_translations.rb
+++ b/lib/rails/generators/mobility/templates/table_translations.rb
@@ -17,7 +17,6 @@ class <%= migration_class_name %> < <%= activerecord_migration_class %>
       t.timestamps null: false
     end
 
-    add_index :<%= table_name %>, :<%= foreign_key %>, name: :<%= translation_index_name(foreign_key) %>
     add_index :<%= table_name %>, :locale, name: :<%= translation_index_name("locale") %>
     add_index :<%= table_name %>, [:<%= foreign_key %>, :locale], name: :<%= translation_index_name(foreign_key, "locale") %>, unique: true
 

--- a/spec/generators/rails/mobility/translations_generator_spec.rb
+++ b/spec/generators/rails/mobility/translations_generator_spec.rb
@@ -70,7 +70,6 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
                 contains "t.string  :locale, null: false"
                 contains "t.integer :post_id, null: false"
                 contains "t.timestamps null: false"
-                contains "add_index :post_translations, :post_id, name: :index_post_translations_on_post_id"
                 contains "add_index :post_translations, :locale, name: :index_post_translations_on_locale"
                 contains "add_index :post_translations, [:post_id, :locale], name: :index_post_translations_on_post_id_and_locale, unique: true"
                 contains "add_index :post_translations, [:title, :locale], name: :index_post_translations_on_title_and_locale"


### PR DESCRIPTION
Since we already generate a unique index on the `[foreign_key, :locale]` pair, the index on `foreign_key` alone is unnecessary.

@pwim Curious about this, what indices do you have on your translation tables? See the change here. I don't think we need `:post_id` if we already have `[:post_id, :locale]`, and if we don't need an index better not to generate it.