### PR TITLE
Enforce null: false constraint on columns consistently

### DIFF
--- a/lib/rails/generators/mobility/templates/create_string_translations.rb
+++ b/lib/rails/generators/mobility/templates/create_string_translations.rb
@@ -2,12 +2,12 @@ class CreateStringTranslations < <%= activerecord_migration_class %>
 
   def change
     create_table :mobility_string_translations do |t|
-      t.string  :locale
-      t.string  :key
+      t.string  :locale,            null: false
+      t.string  :key,               null: false
       t.string  :value
-      t.integer :translatable_id
-      t.string  :translatable_type
-      t.timestamps
+      t.integer :translatable_id,   null: false
+      t.string  :translatable_type, null: false
+      t.timestamps                  null: false
     end
     add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
     add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute

--- a/lib/rails/generators/mobility/templates/create_text_translations.rb
+++ b/lib/rails/generators/mobility/templates/create_text_translations.rb
@@ -2,12 +2,12 @@ class CreateTextTranslations < <%= activerecord_migration_class %>
 
   def change
     create_table :mobility_text_translations do |t|
-      t.string  :locale
-      t.string  :key
+      t.string  :locale,            null: false
+      t.string  :key,               null: false
       t.text    :value
-      t.integer :translatable_id
-      t.string  :translatable_type
-      t.timestamps
+      t.integer :translatable_id,   null: false
+      t.string  :translatable_type, null: false
+      t.timestamps                  null: false
     end
     add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
     add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -10,13 +10,13 @@ module Mobility
         def up
           create_table "posts" do |t|
             t.boolean :published
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table "articles" do |t|
             t.string :slug
             t.boolean :published
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table "article_translations" do |t|
@@ -24,27 +24,27 @@ module Mobility
             t.integer :article_id
             t.string :title
             t.text :content
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table "multitable_posts" do |t|
             t.string :slug
             t.boolean :published
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table "multitable_post_translations" do |t|
             t.string :locale
             t.integer :multitable_post_id
             t.string :title
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table "multitable_post_foo_translations" do |t|
             t.string :locale
             t.integer :multitable_post_id
             t.string :foo
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table "mobility_string_translations" do |t|
@@ -53,7 +53,7 @@ module Mobility
             t.string  :value,             null: false
             t.integer :translatable_id,   null: false
             t.string  :translatable_type, null: false
-            t.timestamps
+            t.timestamps                  null: false
           end
           add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
           add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
@@ -65,7 +65,7 @@ module Mobility
             t.text    :value,             null: false
             t.integer :translatable_id,   null: false
             t.string  :translatable_type, null: false
-            t.timestamps
+            t.timestamps                  null: false
           end
           add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
           add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
@@ -80,14 +80,14 @@ module Mobility
             t.text :author_pt_br
             t.text :author_ru
             t.boolean :published
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table "serialized_posts" do |t|
             t.text :my_title_i18n
             t.text :my_content_i18n
             t.boolean :published
-            t.timestamps
+            t.timestamps null: false
           end
 
           if ENV['DB'] == 'postgres'
@@ -95,20 +95,20 @@ module Mobility
               t.jsonb :my_title_i18n, default: {}
               t.jsonb :my_content_i18n, default: {}
               t.boolean :published
-              t.timestamps
+              t.timestamps null: false
             end
 
             create_table "json_posts" do |t|
               t.json :my_title_i18n, default: {}
               t.json :my_content_i18n, default: {}
               t.boolean :published
-              t.timestamps
+              t.timestamps null: false
             end
 
             create_table "container_posts" do |t|
               t.jsonb :translations, default: {}
               t.boolean :published
-              t.timestamps
+              t.timestamps null: false
             end
 
             execute "CREATE EXTENSION IF NOT EXISTS hstore"
@@ -117,7 +117,7 @@ module Mobility
               t.hstore :my_title_i18n, default: ''
               t.hstore :my_content_i18n, default: ''
               t.boolean :published
-              t.timestamps
+              t.timestamps null: false
             end
           end
         end

--- a/spec/generators/rails/mobility/translations_generator_spec.rb
+++ b/spec/generators/rails/mobility/translations_generator_spec.rb
@@ -88,8 +88,8 @@ describe Mobility::TranslationsGenerator, type: :generator, orm: :active_record 
       before do
         connection.create_table :post_translations do |t|
           t.string :locale
-          t.integer :post_id
-          t.timestamps
+          t.integer :post_id, null: false
+          t.timestamps null: false
         end
       end
 

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -68,9 +68,9 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
       m = ActiveRecord::Migration.new
       m.verbose = false
       m.create_table :json_container_posts do |t|
-        t.json :json_translations, default: {}
+        t.json :json_translations, default: {}, null: false
         t.boolean :published
-        t.timestamps
+        t.timestamps null: false
       end
     end
     before(:each) do
@@ -94,7 +94,7 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
       m.create_table :string_column_posts do |t|
         t.string :foo
         t.boolean :published
-        t.timestamps
+        t.timestamps null: false
       end
     end
     after(:all) do

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -16,7 +16,7 @@ module Mobility
           DB.create_table? :post_metadatas do
             primary_key :id
             String      :metadata
-            Integer     :post_id
+            Integer     :post_id,    allow_null: false
             DateTime    :created_at, allow_null: false
             DateTime    :updated_at, allow_null: false
           end
@@ -31,8 +31,8 @@ module Mobility
 
           DB.create_table? :article_translations do
             primary_key :id
-            Integer     :article_id
-            String      :locale
+            Integer     :article_id, allow_null: false
+            String      :locale,     allow_null: false
             String      :title
             String      :content, size: 65535
             DateTime    :created_at, allow_null: false
@@ -48,45 +48,45 @@ module Mobility
 
           DB.create_table? :multitable_post_translations do
             primary_key :id
-            Integer     :multitable_post_id
-            String      :locale
+            Integer     :multitable_post_id, allow_null: false
+            String      :locale,             allow_null: false
             String      :title
-            DateTime    :created_at, allow_null: false
-            DateTime    :updated_at, allow_null: false
+            DateTime    :created_at,         allow_null: false
+            DateTime    :updated_at,         allow_null: false
           end
 
 
           DB.create_table? :multitable_post_foo_translations do
             primary_key :id
-            Integer     :multitable_post_id
-            String      :locale
+            Integer     :multitable_post_id, allow_null: false
+            String      :locale,             allow_null: false
             String      :foo
-            DateTime    :created_at, allow_null: false
-            DateTime    :updated_at, allow_null: false
+            DateTime    :created_at,         allow_null: false
+            DateTime    :updated_at,         allow_null: false
           end
 
           DB.create_table? :mobility_text_translations do
             primary_key :id
-            String      :locale,            null: false
-            String      :key,               null: false
-            String      :value,             null: false, size: 65535
-            Integer     :translatable_id,   null: false
-            String      :translatable_type, null: false
-            DateTime    :created_at, allow_null: false
-            DateTime    :updated_at, allow_null: false
+            String      :locale,            allow_null: false
+            String      :key
+            String      :value
+            Integer     :translatable_id,   allow_null: false
+            String      :translatable_type, allow_null: false
+            DateTime    :created_at,        allow_null: false
+            DateTime    :updated_at,        allow_null: false
             index [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
             index [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
           end
 
           DB.create_table? :mobility_string_translations do
             primary_key :id
-            String      :locale,            null: false
-            String      :key,               null: false
-            String      :value,             null: false
-            Integer     :translatable_id,   null: false
-            String      :translatable_type, null: false
-            DateTime    :created_at, allow_null: false
-            DateTime    :updated_at, allow_null: false
+            String      :locale,            allow_null: false
+            String      :key,               allow_null: false
+            String      :value
+            Integer     :translatable_id,   allow_null: false
+            String      :translatable_type, allow_null: false
+            DateTime    :created_at,        allow_null: false
+            DateTime    :updated_at,        allow_null: false
             index [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
             index [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
             index [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
@@ -109,48 +109,48 @@ module Mobility
 
           DB.create_table? :serialized_posts do
             primary_key :id
-            String      :my_title_i18n,         size: 65535
-            String      :my_content_i18n,       size: 65535
+            String      :my_title_i18n,   size: 65535
+            String      :my_content_i18n, size: 65535
             TrueClass   :published
-            DateTime    :created_at, allow_null: false
-            DateTime    :updated_at, allow_null: false
+            DateTime    :created_at,                   allow_null: false
+            DateTime    :updated_at,                   allow_null: false
           end
 
           if ENV['DB'] == 'postgres'
             DB.create_table? :jsonb_posts do
               primary_key :id
-              jsonb       :my_title_i18n,      default: '{}'
-              jsonb       :my_content_i18n,    default: '{}'
+              jsonb       :my_title_i18n,   default: '{}', allow_null: false
+              jsonb       :my_content_i18n, default: '{}', allow_null: false
               TrueClass   :published
-              DateTime    :created_at, allow_null: false
-              DateTime    :updated_at, allow_null: false
+              DateTime    :created_at,                     allow_null: false
+              DateTime    :updated_at,                     allow_null: false
             end
 
             DB.create_table? :json_posts do
               primary_key :id
-              json        :my_title_i18n,      default: '{}'
-              json        :my_content_i18n,    default: '{}'
+              json        :my_title_i18n,   default: '{}', allow_null: false
+              json        :my_content_i18n, default: '{}', allow_null: false
               TrueClass   :published
-              DateTime    :created_at, allow_null: false
-              DateTime    :updated_at, allow_null: false
+              DateTime    :created_at,                     allow_null: false
+              DateTime    :updated_at,                     allow_null: false
             end
 
             DB.create_table? :container_posts do
               primary_key :id
-              jsonb       :translations, default: '{}'
+              jsonb       :translations, default: '{}',    allow_null: false
               TrueClass   :published
-              DateTime    :created_at, allow_null: false
-              DateTime    :updated_at, allow_null: false
+              DateTime    :created_at,                     allow_null: false
+              DateTime    :updated_at,                     allow_null: false
             end
 
             DB.run "CREATE EXTENSION IF NOT EXISTS hstore"
             DB.create_table? :hstore_posts do
               primary_key :id
-              hstore      :my_title_i18n,      default: ''
-              hstore      :my_content_i18n,    default: ''
+              hstore      :my_title_i18n, default: '',   allow_null: false
+              hstore      :my_content_i18n, default: '', allow_null: false
               TrueClass   :published
-              DateTime    :created_at, allow_null: false
-              DateTime    :updated_at, allow_null: false
+              DateTime    :created_at,                   allow_null: false
+              DateTime    :updated_at,                   allow_null: false
             end
           end
         end


### PR DESCRIPTION
I noticed there were warnings in the Rails 4.2 specs because `null: false` is not specified on `timestamps` in migrations. While fixing that, I've also enforced this constraint on KeyValue migrations for all columns other than `value`, which I think is a better default.

This will be released in 0.6.0 (should be the last release before 1.0).