### PR TITLE
Ignore non-arel nodes in joins_values

### DIFF
--- a/lib/mobility/backends/active_record/table/query_methods.rb
+++ b/lib/mobility/backends/active_record/table/query_methods.rb
@@ -38,7 +38,7 @@ module Mobility
 
       def define_join_method(association_name, translation_class, foreign_key: nil, table_name: nil, **)
         define_method :"join_#{association_name}" do |**options|
-          return self if joins_values.any? { |v| v.left.name == table_name.to_s }
+          return self if joins_values.any? { |v| v.is_a?(Arel::Nodes::Join) && (v.left.name == table_name.to_s) }
           t = translation_class.arel_table
           m = arel_table
           join_type = options[:outer_join] ? Arel::Nodes::OuterJoin : Arel::Nodes::InnerJoin

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -271,6 +271,11 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
         # we're searching for negative matches
         expect(Article.i18n.where.not(title: nil).to_sql).not_to match /OUTER/
       end
+
+      it "works with other joins" do
+        article = Article.create(title: "foo")
+        expect(Article.i18n.joins(:translations).find_by(title: "foo")).to eq(article)
+      end
     end
   end
 


### PR DESCRIPTION
This is a bug with the table backend:

```ruby
Post.i18n.joins(:translations).where(title: "foo")
#=> NoMethodError: undefined method `left' for :translations:Symbol#=> NoMethodError: undefined method `left' for :translations:Symbol
```

The `joins` here is redundant, but the exception is unexpected. We need to filter out non-arel nodes when checking to see if we have already joined translations.