### PR TITLE
Use IN when querying on array values with PG backends

### DIFF
--- a/lib/mobility/backends/active_record/container/json_query_methods.rb
+++ b/lib/mobility/backends/active_record/container/json_query_methods.rb
@@ -10,18 +10,23 @@ module Mobility
 
       def initialize(_attributes, options)
         super
-        @column_name = options[:column_name]
-        @column      = arel_table[@column_name]
+        @column = arel_table[options[:column_name]]
       end
 
-      def matches(key, value, locale)
-        build_infix(:'->>',
-                    build_infix(:'->', column, quote(locale)),
-                    quote(key)).eq(value && value.to_s)
+      def matches(key, locale)
+        build_infix(:'->>', build_infix(:'->', column, build_quoted(locale)), build_quoted(key))
       end
 
-      def has_locale(key, locale)
-        matches(key, nil, locale).not
+      def exists(key, locale)
+        matches(key, locale).eq(nil).not
+      end
+
+      def absent(key, locale)
+        matches(key, locale).eq(nil)
+      end
+
+      def quote(value)
+        value.to_s
       end
     end
   end

--- a/lib/mobility/backends/active_record/container/jsonb_query_methods.rb
+++ b/lib/mobility/backends/active_record/container/jsonb_query_methods.rb
@@ -6,25 +6,24 @@ module Mobility
   module Backends
     class ActiveRecord::Container::JsonbQueryMethods < ActiveRecord::QueryMethods
       include ActiveRecord::PgQueryMethods
-      attr_reader :column_name, :column
+      attr_reader :column
 
       def initialize(_attributes, options)
         super
-        @column_name = options[:column_name]
-        @column      = arel_table[@column_name]
+        @column = arel_table[options[:column_name]]
       end
 
-      def matches(key, value, locale)
-        build_infix(:'->',
-                    build_infix(:'->', column, quote(locale)),
-                    quote(key)).eq(quote(value.to_json))
+      def matches(key, locale)
+        build_infix(:'->', build_infix(:'->', column, build_quoted(locale)), build_quoted(key))
       end
 
-      def has_locale(key, locale)
-        build_infix(:'?', column, quote(locale)).and(
-          build_infix(:'?',
-                      build_infix(:'->', column, quote(locale)),
-                      quote(key)))
+      def exists(key, locale)
+        build_infix(:'?', column, build_quoted(locale)).and(
+          build_infix(:'?', build_infix(:'->', column, build_quoted(locale)), build_quoted(key)))
+      end
+
+      def quote(value)
+        build_quoted(value.to_json)
       end
     end
   end

--- a/lib/mobility/backends/active_record/hstore/query_methods.rb
+++ b/lib/mobility/backends/active_record/hstore/query_methods.rb
@@ -6,12 +6,16 @@ module Mobility
     class ActiveRecord::Hstore::QueryMethods < ActiveRecord::QueryMethods
       include ActiveRecord::PgQueryMethods
 
-      def matches(key, value, locale)
-        build_infix(:'->', arel_table[column_name(key)], quote(locale)).eq(quote(value.to_s))
+      def matches(key, locale)
+        build_infix(:'->', arel_table[column_name(key)], build_quoted(locale))
       end
 
-      def has_locale(key, locale)
-        build_infix(:'?', arel_table[column_name(key)], quote(locale))
+      def exists(key, locale)
+        build_infix(:'?', arel_table[column_name(key)], build_quoted(locale))
+      end
+
+      def quote(value)
+        build_quoted(value)
       end
     end
   end

--- a/lib/mobility/backends/active_record/json/query_methods.rb
+++ b/lib/mobility/backends/active_record/json/query_methods.rb
@@ -7,18 +7,20 @@ module Mobility
     class ActiveRecord::Json::QueryMethods < ActiveRecord::QueryMethods
       include ActiveRecord::PgQueryMethods
 
-      def matches(key, value, locale)
-        build_locale_infix(key, locale).eq(value.to_s)
+      def matches(key, locale)
+        build_infix(:'->>', arel_table[column_name(key)], build_quoted(locale))
       end
 
-      def has_locale(key, locale)
-        build_locale_infix(key, locale).eq(nil).not
+      def exists(key, locale)
+        absent(key, locale).not
       end
 
-      private
+      def absent(key, locale)
+        matches(key, locale).eq(nil)
+      end
 
-      def build_locale_infix(key, locale)
-        build_infix(:'->>', arel_table[column_name(key)], quote(locale))
+      def quote(value)
+        value.to_s
       end
     end
   end

--- a/lib/mobility/backends/active_record/jsonb/query_methods.rb
+++ b/lib/mobility/backends/active_record/jsonb/query_methods.rb
@@ -7,12 +7,16 @@ module Mobility
     class ActiveRecord::Jsonb::QueryMethods < ActiveRecord::QueryMethods
       include ActiveRecord::PgQueryMethods
 
-      def matches(key, value, locale)
-        build_infix(:'->', arel_table[column_name(key)], quote(locale)).eq(quote(value.to_json))
+      def matches(key, locale)
+        build_infix(:'->', arel_table[column_name(key)], build_quoted(locale))
       end
 
-      def has_locale(key, locale)
-        build_infix(:'?', arel_table[column_name(key)], quote(locale))
+      def exists(key, locale)
+        build_infix(:'?', arel_table[column_name(key)], build_quoted(locale))
+      end
+
+      def quote(value)
+        build_quoted(value.to_json)
       end
     end
   end

--- a/lib/mobility/backends/sequel/container/json_query_methods.rb
+++ b/lib/mobility/backends/sequel/container/json_query_methods.rb
@@ -16,12 +16,16 @@ module Mobility
         define_query_methods
       end
 
-      def matches(key, value, locale)
-        build_op(column_name)[locale].get_text(key.to_s) =~ value.to_s
+      def matches(key, locale)
+        build_op(column_name)[locale].get_text(key.to_s)
       end
 
-      def has_locale(key, locale)
-        build_op(column_name)[locale].get_text(key.to_s) !~ nil
+      def exists(key, locale)
+        matches(key, locale) !~ nil
+      end
+
+      def quote(value)
+        value && value.to_s
       end
 
       private

--- a/lib/mobility/backends/sequel/container/jsonb_query_methods.rb
+++ b/lib/mobility/backends/sequel/container/jsonb_query_methods.rb
@@ -16,12 +16,16 @@ module Mobility
         define_query_methods
       end
 
-      def matches(key, value, locale)
-        build_op(column_name)[locale][key.to_s] =~ value.to_json
+      def matches(key, locale)
+        build_op(column_name)[locale][key.to_s]
       end
 
-      def has_locale(key, locale)
+      def exists(key, locale)
         build_op(column_name).has_key?(locale) & build_op(column_name)[locale].has_key?(key.to_s)
+      end
+
+      def quote(value)
+        value && value.to_json
       end
 
       private

--- a/lib/mobility/backends/sequel/hstore/query_methods.rb
+++ b/lib/mobility/backends/sequel/hstore/query_methods.rb
@@ -9,12 +9,16 @@ module Mobility
     class Sequel::Hstore::QueryMethods < Sequel::QueryMethods
       include Sequel::PgQueryMethods
 
-      def matches(key, value, locale)
-        build_op(key)[locale] =~ value.to_s
+      def matches(key, locale)
+        build_op(key)[locale]
       end
 
-      def has_locale(key, locale)
+      def exists(key, locale)
         build_op(key).has_key?(locale)
+      end
+
+      def quote(value)
+        value && value.to_s
       end
 
       private

--- a/lib/mobility/backends/sequel/json/query_methods.rb
+++ b/lib/mobility/backends/sequel/json/query_methods.rb
@@ -9,12 +9,16 @@ module Mobility
     class Sequel::Json::QueryMethods < Sequel::QueryMethods
       include Sequel::PgQueryMethods
 
-      def matches(key, value, locale)
-        build_op(key).get_text(locale) =~ value.to_s
+      def matches(key, locale)
+        build_op(key).get_text(locale)
       end
 
-      def has_locale(key, locale)
-        build_op(key).get_text(locale) !~ nil
+      def exists(key, locale)
+        matches(key, locale) !~ nil
+      end
+
+      def quote(value)
+        value && value.to_s
       end
 
       private

--- a/lib/mobility/backends/sequel/jsonb/query_methods.rb
+++ b/lib/mobility/backends/sequel/jsonb/query_methods.rb
@@ -9,12 +9,16 @@ module Mobility
     class Sequel::Jsonb::QueryMethods < Sequel::QueryMethods
       include Sequel::PgQueryMethods
 
-      def matches(key, value, locale)
-        build_op(key)[locale] =~ value.to_json
+      def matches(key, locale)
+        build_op(key)[locale]
       end
 
-      def has_locale(key, locale)
+      def exists(key, locale)
         build_op(key).has_key?(locale)
+      end
+
+      def quote(value)
+        value && value.to_json
       end
 
       private

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -27,6 +27,19 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
     include_dup_examples 'ContainerPost'
     include_cache_key_examples 'ContainerPost'
 
+    it "uses existence operator instead of NULL match" do
+      aggregate_failures do
+        expect(ContainerPost.i18n.where(title: nil).to_sql).to match /\?/
+        expect(ContainerPost.i18n.where(title: nil).to_sql).not_to match /NULL/
+        expect(ContainerPost.i18n.where.not(title: "foo").to_sql).to match /\?/
+        expect(ContainerPost.i18n.where.not(title: "foo").to_sql).not_to match /NULL/
+      end
+    end
+
+    it "treats array of nils like nil" do
+      expect(ContainerPost.i18n.where(title: nil).to_sql).to eq(ContainerPost.i18n.where(title: [nil]).to_sql)
+    end
+
     describe "non-text values" do
       it "stores non-string types as-is when saving", rails_version_geq: '5.0' do
         backend = post.mobility.backend_for("title")

--- a/spec/mobility/backends/active_record/jsonb_spec.rb
+++ b/spec/mobility/backends/active_record/jsonb_spec.rb
@@ -32,6 +32,19 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
     include_dup_examples 'JsonbPost'
     include_cache_key_examples 'JsonbPost'
 
+    it "uses existence operator instead of NULL match" do
+      aggregate_failures do
+        expect(JsonbPost.i18n.where(title: nil).to_sql).to match /\?/
+        expect(JsonbPost.i18n.where(title: nil).to_sql).not_to match /NULL/
+        expect(JsonbPost.i18n.where.not(title: "foo").to_sql).to match /\?/
+        expect(JsonbPost.i18n.where.not(title: "foo").to_sql).not_to match /NULL/
+      end
+    end
+
+    it "treats array of nils like nil" do
+      expect(JsonbPost.i18n.where(title: nil).to_sql).to eq(JsonbPost.i18n.where(title: [nil]).to_sql)
+    end
+
     describe "non-text values" do
       it "stores non-string types as-is when saving", rails_version_geq: '5.0' do
         backend = post.mobility.backend_for("title")

--- a/spec/mobility/backends/sequel/container_spec.rb
+++ b/spec/mobility/backends/sequel/container_spec.rb
@@ -25,6 +25,19 @@ describe "Mobility::Backends::Sequel::Container", orm: :sequel, db: :postgres do
     include_querying_examples 'ContainerPost'
     include_dup_examples 'ContainerPost'
 
+    it "uses existence operator instead of NULL match" do
+      aggregate_failures do
+        expect(ContainerPost.i18n.where(title: nil).sql).to match /\?/
+        expect(ContainerPost.i18n.where(title: nil).sql).not_to match /NULL/
+        expect(ContainerPost.i18n.exclude(title: "foo").sql).to match /\?/
+        expect(ContainerPost.i18n.exclude(title: "foo").sql).not_to match /NULL/
+      end
+    end
+
+    it "treats array of nils like nil" do
+      expect(ContainerPost.i18n.where(title: nil).sql).to eq(ContainerPost.i18n.where(title: [nil]).sql)
+    end
+
     describe "non-text values" do
       it "stores non-string types as-is when saving" do
         backend = post.mobility.backend_for("title")

--- a/spec/mobility/backends/sequel/jsonb_spec.rb
+++ b/spec/mobility/backends/sequel/jsonb_spec.rb
@@ -30,6 +30,19 @@ describe "Mobility::Backends::Sequel::Jsonb", orm: :sequel, db: :postgres do
     include_querying_examples 'JsonbPost'
     include_dup_examples 'JsonbPost'
 
+    it "uses existence operator instead of NULL match" do
+      aggregate_failures do
+        expect(JsonbPost.i18n.where(title: nil).sql).to match /\?/
+        expect(JsonbPost.i18n.where(title: nil).sql).not_to match /NULL/
+        expect(JsonbPost.i18n.exclude(title: "foo").sql).to match /\?/
+        expect(JsonbPost.i18n.exclude(title: "foo").sql).not_to match /NULL/
+      end
+    end
+
+    it "treats array of nils like nil" do
+      expect(JsonbPost.i18n.where(title: nil).sql).to eq(JsonbPost.i18n.where(title: [nil]).sql)
+    end
+
     describe "non-text values" do
       it "stores non-string types as-is when saving" do
         backend = post.mobility.backend_for("title")

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -211,6 +211,24 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, attri
         expect(query_scope.where.not(attribute1 => ["foo", nil]).to_sql).to eq(query_scope.where.not(attribute1 => ["foo", "foo", nil]).to_sql)
       end
     end
+
+    it "uses IN when matching array of two or more non-nil values" do
+      aggregate_failures "where" do
+        expect(query_scope.where(attribute1 => ["foo", "bar"]).to_sql).to match /\sIN\s/
+        expect(query_scope.where(attribute1 => ["foo", "bar", nil]).to_sql).to match /\sIN\s/
+        expect(query_scope.where(attribute1 => ["foo", nil]).to_sql).not_to match /\sIN\s/
+        expect(query_scope.where(attribute1 => "foo").to_sql).not_to match /\sIN\s/
+        expect(query_scope.where(attribute1 => nil).to_sql).not_to match /\sIN\s/
+      end
+
+      aggregate_failures "where not" do
+        expect(query_scope.where.not(attribute1 => ["foo", "bar"]).to_sql).to match /\sIN\s/
+        expect(query_scope.where.not(attribute1 => ["foo", "bar", nil]).to_sql).to match /\sIN\s/
+#        expect(query_scope.where.not(attribute1 => ["foo", nil]).to_sql).not_to match /\sIN\s/
+        expect(query_scope.where.not(attribute1 => "foo").to_sql).not_to match /\sIN\s/
+        expect(query_scope.where.not(attribute1 => nil).to_sql).not_to match /\sIN\s/
+      end
+    end
   end
 end
 

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -288,7 +288,7 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
         @instance1 = model_class.create(attribute1 => "foo"                                               )
         @instance2 = model_class.create(attribute1 => "foo", attribute2 => "foo content"                  )
         @instance3 = model_class.create(attribute1 => "foo", attribute2 => "foo content", published: false)
-        @instance4 = model_class.create(                          attribute2 => "foo content"                  )
+        @instance4 = model_class.create(                     attribute2 => "foo content"                  )
         @instance5 = model_class.create(attribute1 => "bar", attribute2 => "bar content"                  )
         @instance6 = model_class.create(attribute1 => "bar",                              published: true )
       end
@@ -323,7 +323,7 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
             @ja_instance1 = model_class.create(attribute1 => "foo ja", attribute2 => "foo content ja")
             @ja_instance2 = model_class.create(attribute1 => "foo",    attribute2 => "foo content"   )
             @ja_instance3 = model_class.create(attribute1 => "foo"                                   )
-            @ja_instance4 = model_class.create(                             attribute2 => "foo"      )
+            @ja_instance4 = model_class.create(                        attribute2 => "foo"           )
           end
         end
 
@@ -360,6 +360,14 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
         aggregate_failures do
           expect(query_scope.where(attribute1 => ["foo", "foo", nil]).sql).to eq(query_scope.where(attribute1 => ["foo", nil]).sql)
           expect(query_scope.where(attribute1 => ["foo", nil, nil]).sql).to eq(query_scope.where(attribute1 => ["foo", nil]).sql)
+        end
+      end
+
+      it "uses IN when matching array of two or more non-nil values" do
+        aggregate_failures do
+          expect(query_scope.where(attribute1 => ["foo", "bar"]).sql).to match /\sIN\s/
+          expect(query_scope.where(attribute1 => "foo").sql).not_to match /\sIN\s/
+          expect(query_scope.where(attribute1 => nil).sql).not_to match /\sIN\s/
         end
       end
     end


### PR DESCRIPTION
Currently a query like `Post.i18n.where(title: ["foo", "bar"])` with a PostgreSQL backend will use `OR` on each match in the array, but really we should be using `IN` for this. This PR changes the logic of pg query method classes to make this possible.

I'll update Sequel as well once AR specs are green.