### PR TITLE
[WIP] Allow passing locale to queries

### DIFF
--- a/lib/mobility/backends/active_record/column/query_methods.rb
+++ b/lib/mobility/backends/active_record/column/query_methods.rb
@@ -53,11 +53,17 @@ module Mobility
 
             next node.eq(nil) if vals.empty?
 
-            query = vals.size == 1 ? node.eq(vals.first) : node.in(vals)
+            query = node_in(node, vals)
             query = query.or(node.eq(nil)) unless nils.empty?
             query
           }.inject(&(inverse ? :and : :or))
         }.inject(&(inverse ? :or : :and))
+      end
+
+      private
+
+      def node_in(node, vals)
+        vals.size == 1 ? node.eq(vals.first) : node.in(vals)
       end
     end
   end

--- a/lib/mobility/backends/active_record/key_value/query_methods.rb
+++ b/lib/mobility/backends/active_record/key_value/query_methods.rb
@@ -21,10 +21,11 @@ module Mobility
           define_method :not do |opts, *rest|
             if i18n_keys = q.extract_attributes(opts)
               opts = opts.with_indifferent_access
+              locale = opts.delete(:locale) || Mobility.locale
               i18n_keys.each do |attr|
                 opts["#{attr}_#{association_name}"] = { value: q.collapse(opts.delete(attr)) }
               end
-              super(opts, *rest).send(:"join_#{association_name}", *i18n_keys)
+              super(opts, *rest).send(:"join_#{association_name}", *i18n_keys, locale: locale)
             else
               super(opts, *rest)
             end
@@ -36,16 +37,17 @@ module Mobility
       private
 
       def define_join_method(association_name, translation_class)
-        define_method :"join_#{association_name}" do |*attributes, **options|
+        define_method :"join_#{association_name}" do |*attributes, locale:, **options|
           attributes.inject(self) do |relation, attribute|
             t = translation_class.arel_table.alias("#{attribute}_#{association_name}")
             m = arel_table
             join_type = options[:outer_join] ? Arel::Nodes::OuterJoin : Arel::Nodes::InnerJoin
+            matches_locale = locale.is_a?(Array) ? t[:locale].in(locale) : t[:locale].eq(locale)
             relation.joins(m.join(t, join_type).
                            on(t[:key].eq(attribute).
-                              and(t[:locale].eq(Mobility.locale).
-                                  and(t[:translatable_type].eq(base_class.name).
-                                      and(t[:translatable_id].eq(m[:id]))))).join_sources)
+                              and(t[:translatable_type].eq(base_class.name).
+                                  and(t[:translatable_id].eq(m[:id]).
+                                      and(matches_locale)))).join_sources)
           end
         end
       end
@@ -56,13 +58,14 @@ module Mobility
         define_method :where! do |opts, *rest|
           if i18n_keys = q.extract_attributes(opts)
             opts = opts.with_indifferent_access
+            locale = opts.delete(:locale) || Mobility.locale
             i18n_nulls = i18n_keys.reject { |key| opts[key] && Array(opts[key]).all? }
             i18n_keys.each do |attr|
               opts["#{attr}_#{association_name}"] = { value: q.collapse(opts.delete(attr)) }
             end
             super(opts, *rest).
-              send("join_#{association_name}", *(i18n_keys - i18n_nulls)).
-              send("join_#{association_name}", *i18n_nulls, outer_join: true)
+              send("join_#{association_name}", *(i18n_keys - i18n_nulls), locale: locale).
+              send("join_#{association_name}", *i18n_nulls, outer_join: true, locale: locale)
           else
             super(opts, *rest)
           end

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -42,7 +42,7 @@ backend querying code.
           define_method :where! do |opts, *rest|
             if i18n_keys = q.extract_attributes(opts)
               opts = opts.with_indifferent_access
-              query = q.create_query!(opts, i18n_keys)
+              query = q.create_query!(opts, i18n_keys, locale: opts.delete(:locale))
 
               opts.empty? ? super(query) : super(opts, *rest).where(query)
             else
@@ -59,7 +59,7 @@ backend querying code.
             define_method :not do |opts, *rest|
               if i18n_keys = q.extract_attributes(opts)
                 opts = opts.with_indifferent_access
-                query = q.create_query!(opts, i18n_keys, inverse: true)
+                query = q.create_query!(opts, i18n_keys, inverse: true, locale: opts.delete(:locale))
 
                 super(opts, *rest).where(query)
               else
@@ -77,11 +77,12 @@ backend querying code.
         # @param [Array] keys Translated attribute names
         # @option [Boolean] inverse (false) If true, create a +not+ query
         #   instead of a +where+ query
+        # @option [Symbol, Array<Symbol>, NilClass] locale Locale or array of locales
         # @return [Arel::Node] Arel node to pass to +where+
-        def create_query!(opts, keys, inverse: false)
+        def create_query!(opts, keys, inverse: false, locale:)
           keys.map { |key|
             values = Array.wrap(opts.delete(key)).uniq
-            send(inverse ? :not_query : :where_query, key, values, Mobility.locale)
+            send(inverse ? :not_query : :where_query, key, values, Array.wrap(locale || Mobility.locale))
           }.inject(&:and)
         end
 
@@ -119,33 +120,38 @@ backend querying code.
         #
         # @param [String] key Translated attribute name
         # @param [Array] values Values to match
-        # @param [Symbol] locale Locale to query for
+        # @param [Symbol, Array<Symbol>] locales Locale or locales to query for
         # @return [Arel::Node] Arel node to pass to +where+
-        def where_query(key, values, locale)
+        def where_query(key, values, locales)
           nils, vals = values.partition(&:nil?)
-
-          return absent(key, locale) if vals.empty?
-
-          node = matches(key, locale)
           vals = vals.map(&method(:quote))
 
-          query = vals.size == 1 ? node.eq(vals.first) : node.in(vals)
-          query = query.or(absent(key, locale)) unless nils.empty?
-          query
+          locales.map { |locale|
+            next absent(key, locale) if vals.empty?
+
+            node = matches(key, locale)
+
+            query = vals.size == 1 ? node.eq(vals.first) : node.in(vals)
+            query = query.or(absent(key, locale)) unless nils.empty?
+            query
+          }.inject(&:or)
         end
 
         # Create +not+ query for specified key and values
         #
         # @param [String] key Translated attribute name
         # @param [Array] values Values to match
-        # @param [Symbol] locale Locale to query for
+        # @param [Symbol, Array<Symbol>] locales Locale or locales to query for
         # @return [Arel::Node] Arel node to pass to +where+
-        def not_query(key, values, locale)
+        def not_query(key, values, locales)
           vals = values.map(&method(:quote))
-          node = matches(key, locale)
 
-          query = vals.size == 1 ? node.eq(vals.first) : node.in(vals)
-          query.not.and(exists(key, locale))
+          locales.map { |locale|
+            node = matches(key, locale)
+
+            query = vals.size == 1 ? node.eq(vals.first) : node.in(vals)
+            query.not.and(exists(key, locale))
+          }.inject(&:or)
         end
       end
     end

--- a/lib/mobility/backends/active_record/pg_query_methods.rb
+++ b/lib/mobility/backends/active_record/pg_query_methods.rb
@@ -129,9 +129,7 @@ backend querying code.
           locales.map { |locale|
             next absent(key, locale) if vals.empty?
 
-            node = matches(key, locale)
-
-            query = vals.size == 1 ? node.eq(vals.first) : node.in(vals)
+            query = node_in(matches(key, locale), vals)
             query = query.or(absent(key, locale)) unless nils.empty?
             query
           }.inject(&:or)
@@ -147,11 +145,12 @@ backend querying code.
           vals = values.map(&method(:quote))
 
           locales.map { |locale|
-            node = matches(key, locale)
-
-            query = vals.size == 1 ? node.eq(vals.first) : node.in(vals)
-            query.not.and(exists(key, locale))
+            node_in(matches(key, locale), vals).not.and(exists(key, locale))
           }.inject(&:or)
+        end
+
+        def node_in(node, vals)
+          vals.size == 1 ? node.eq(vals.first) : node.in(vals)
         end
       end
     end

--- a/lib/mobility/backends/active_record/table/query_methods.rb
+++ b/lib/mobility/backends/active_record/table/query_methods.rb
@@ -40,7 +40,7 @@ module Mobility
       private
 
       def define_join_method(association_name, translation_class, foreign_key: nil, table_name: nil, **)
-        define_method :"join_#{association_name}" do |locale:, outer_join: false, **options|
+        define_method :"join_#{association_name}" do |locale:, outer_join: false|
           return self if joins_values.any? { |v| v.is_a?(Arel::Nodes::Join) && (v.left.name == table_name.to_s) }
           t = translation_class.arel_table
           m = arel_table

--- a/lib/mobility/backends/active_record/table/query_methods.rb
+++ b/lib/mobility/backends/active_record/table/query_methods.rb
@@ -24,10 +24,11 @@ module Mobility
           define_method :not do |opts, *rest|
             if i18n_keys = q.extract_attributes(opts)
               opts = opts.with_indifferent_access
+              locale = opts.delete(:locale) || Mobility.locale
               i18n_keys.each do |attr|
                 opts["#{translation_class.table_name}.#{attr}"] = q.collapse opts.delete(attr)
               end
-              super(opts, *rest).send("join_#{association_name}")
+              super(opts, *rest).send("join_#{association_name}", locale: locale)
             else
               super(opts, *rest)
             end
@@ -39,14 +40,13 @@ module Mobility
       private
 
       def define_join_method(association_name, translation_class, foreign_key: nil, table_name: nil, **)
-        define_method :"join_#{association_name}" do |**options|
+        define_method :"join_#{association_name}" do |locale:, outer_join: false, **options|
           return self if joins_values.any? { |v| v.is_a?(Arel::Nodes::Join) && (v.left.name == table_name.to_s) }
           t = translation_class.arel_table
           m = arel_table
-          join_type = options[:outer_join] ? Arel::Nodes::OuterJoin : Arel::Nodes::InnerJoin
-          joins(m.join(t, join_type).
-                on(t[foreign_key].eq(m[:id]).
-                   and(t[:locale].eq(Mobility.locale))).join_sources)
+          join_type = outer_join ? Arel::Nodes::OuterJoin : Arel::Nodes::InnerJoin
+          matches_locale = locale.is_a?(Array) ? t[:locale].in(locale) : t[:locale].eq(locale)
+          joins(m.join(t, join_type).on(t[foreign_key].eq(m[:id]).and(matches_locale)).join_sources)
         end
       end
 
@@ -94,7 +94,8 @@ module Mobility
             options = {
               # We only need an OUTER JOIN if every value is either nil, or an
               # array with at least one nil value.
-              outer_join: opts.values_at(*i18n_keys).compact.all? { |v| !Array(v).all? }
+              outer_join: opts.values_at(*i18n_keys).compact.all? { |v| !Array(v).all? },
+              locale: opts.delete(:locale) || Mobility.locale
             }
             i18n_keys.each do |attr|
               opts["#{translation_class.table_name}.#{attr}"] = q.collapse opts.delete(attr)


### PR DESCRIPTION
Fixes #51.

This PR works for all backends except column currently. Ironically, column is the simplest backend but supporting an array-valued `locale` option to queries (`Post.i18n.where(title: "foo", locale: [:en, :fr])`) is more complicated than I thought.

I'm going to try getting basic specs green first, then think about how this can be cleaned up. I have a rough plan to lean much more heavily on Arel and hopefully make the query interface more flexible.