### PR TITLE
Improve use of INNER/OUTER joins with AR Table backend

### DIFF
--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -263,7 +263,11 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
     describe "joins" do
       it "uses inner join for WHERE queries if query has at least one non-null attribute" do
         expect(Article.i18n.where(title: "foo", content: nil).to_sql).not_to match(/OUTER/)
+        expect(Article.i18n.where(title: "foo").where(content: nil).to_sql).not_to match(/OUTER/)
+        expect(Article.i18n.where(content: nil).where(title: "foo").to_sql).not_to match(/OUTER/)
         expect(Article.i18n.where(title: "foo", content: [nil, "bar"]).to_sql).not_to match(/OUTER/)
+        expect(Article.i18n.where(title: "foo").where(content: [nil, "bar"]).to_sql).not_to match(/OUTER/)
+        expect(Article.i18n.where(content: [nil, "bar"]).where(title: "foo").to_sql).not_to match(/OUTER/)
       end
 
       it "does not use OUTER JOIN with .not" do


### PR DESCRIPTION
Currently with the Table backend, depending on what you query on, Mobility will use an `INNER` or `OUTER` join depending on the query values. This works well unless you split your query across multiple `where`s, like this:

```ruby
Post.i18n.where(title: nil).where(content: "foo")
```

If both `title` and `content` are translated on a translation table, in this case we should use an `INNER` join since we will only match posts which have a translation with content "foo". However, currently Mobility sees `title: nil` and uses an `OUTER` join.

This PR fixes this so that this query will correctly use an `INNER` join in this case as well.