### PR TITLE
Add inspect method to Attributes

### DIFF
--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -169,6 +169,10 @@ with other backends.
       names.each(&block)
     end
 
+    def inspect
+      "#<Attributes (#{backend_name}) @names=#{names.join(", ")}>"
+    end
+
     # Process options passed into accessor method before calling backend, and
     # return locale
     # @deprecated This method was mainly used internally but is no longer

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -251,4 +251,11 @@ describe Mobility::Attributes do
       expect(attributes.backend_name).to eq(:null)
     end
   end
+
+  describe "#inspect" do
+    it "returns backend name and attribute names" do
+      attributes = described_class.new("title", "content", backend: :null)
+      expect(attributes.inspect).to eq("#<Attributes (null) @names=title, content>")
+    end
+  end
 end


### PR DESCRIPTION
This makes it much easier to understand what's going on when inspecting a module's ancestors.