### PR TITLE
Remove unneeded anonymous module in backend resetters

### DIFF
--- a/lib/mobility/active_model/backend_resetter.rb
+++ b/lib/mobility/active_model/backend_resetter.rb
@@ -9,7 +9,7 @@ Backend resetter for ActiveModel models. Adds hook to reset backend when
     class BackendResetter < Mobility::BackendResetter
 
       # (see Mobility::BackendResetter#initialize)
-      def initialize(attribute_names)
+      def initialize(attribute_names, &block)
         super
 
         model_reset_method = @model_reset_method

--- a/lib/mobility/active_record/backend_resetter.rb
+++ b/lib/mobility/active_record/backend_resetter.rb
@@ -11,16 +11,15 @@ Backend resetter for ActiveRecord models. Adds hook on +reload+ event to
 =end
     class BackendResetter < Mobility::ActiveModel::BackendResetter
 
-      # @param [Class] model_class Class of model to which backend resetter will be applied
-      def included(model_class)
+      # (see Mobility::BackendResetter#initialize)
+      def initialize(attribute_names, &block)
+        super
+
         model_reset_method = @model_reset_method
 
-        mod = Module.new do
-          define_method :reload do |*args|
-            super(*args).tap { instance_eval(&model_reset_method) }
-          end
+        define_method :reload do |*args|
+          super(*args).tap { instance_eval(&model_reset_method) }
         end
-        model_class.include mod
       end
     end
   end

--- a/lib/mobility/sequel/backend_resetter.rb
+++ b/lib/mobility/sequel/backend_resetter.rb
@@ -8,16 +8,15 @@ method is called.
 =end
     class BackendResetter < Mobility::BackendResetter
 
-      # @param [Class] model_class Class of model to which backend resetter will be applied
-      def included(model_class)
+      # (see Mobility::BackendResetter#initialize)
+      def initialize(attribute_names, &block)
+        super
+
         model_reset_method = @model_reset_method
 
-        mod = Module.new do
-          define_method :refresh do
-            super().tap { instance_eval(&model_reset_method) }
-          end
+        define_method :refresh do
+          super().tap { instance_eval(&model_reset_method) }
         end
-        model_class.include mod
       end
     end
   end


### PR DESCRIPTION
These `Module.new`s are completely unnecessary since we can define the method directly on the module itself.