### PR TITLE
Remove some deprecated methods

### DIFF
--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -173,20 +173,6 @@ with other backends.
       "#<Attributes (#{backend_name}) @names=#{names.join(", ")}>"
     end
 
-    # Process options passed into accessor method before calling backend, and
-    # return locale
-    # @deprecated This method was mainly used internally but is no longer
-    #   needed. It will be removed in the next major release.
-    # @param [Hash] options Options hash passed to accessor method
-    # @return [Symbol] locale
-    # TODO: Remove in v1.0
-    def self.process_options!(options)
-      (options[:locale] || Mobility.locale).tap { |locale|
-        Mobility.enforce_available_locales!(locale)
-        options[:locale] &&= !!locale
-      }.to_sym
-    end
-
     private
 
     def define_backend(attribute)

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -73,13 +73,6 @@ The proc can accept zero to three arguments (see examples below)
           default = options.has_key?(:default) ? options.delete(:default) : default_option
           if (value = super(locale, options)).nil?
             return default unless default.is_a?(Proc)
-            # TODO: Remove in v1.0
-            if default.parameters.any? { |n, v| [:keyreq, :keyopt].include?(n) && [:model, :attribute, :locale, :options].include?(v) }
-              warn %{
-WARNING: Passing keyword arguments to a Proc in the Default plugin is
-deprecated. See the API documentation for details.}
-              return default.call(model: model, attribute: attribute, locale: locale, options: options)
-            end
             args = [attribute, locale, options]
             args = args.first(default.arity) unless default.arity < 0
             model.instance_exec(*args, &default)

--- a/spec/mobility/plugins/default_spec.rb
+++ b/spec/mobility/plugins/default_spec.rb
@@ -87,17 +87,6 @@ describe Mobility::Plugins::Default do
             expect(backend.read(:fr, default: default_as_option, this: 'option')).to eq("default title")
           end
         end
-
-        # TODO: Remove in v1.0
-        it "emits warning if proc takes keyword arguments" do
-          expect(backend_double).to receive(:read).once.with(:fr, this: 'option').and_return(nil)
-          default_as_option = Proc.new { |model:, attribute:, locale:, options:|  "default #{model} #{attribute} #{locale} #{options[:this]}" }
-          expect {
-            expect(backend.read(:fr, default: default_as_option, this: 'option')).to eq("default model title fr option")
-          }.to output(/#{%{
-WARNING: Passing keyword arguments to a Proc in the Default plugin is
-deprecated. See the API documentation for details.}}/).to_stderr
-        end
       end
     end
   end


### PR DESCRIPTION
The inline comments say these will be removed in v1.0, but the deprecation messages just say the next version. Let's just get rid of them in 0.6.