### PR TITLE
Do not include Default plugin by default

### DIFF
--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -106,9 +106,10 @@ default_fallbacks= will be removed in the next major version of Mobility.
       @fallbacks_generator = lambda { |fallbacks| Mobility::Fallbacks.build(fallbacks) }
       @default_accessor_locales = lambda { I18n.available_locales }
       @default_options = Options[{
-        cache: true,
+        cache:    true,
         presence: true,
-        query: true
+        query:    true,
+        default:  Plugins::OPTION_UNSET
       }]
       @plugins = %i[
         query

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -31,5 +31,6 @@ option value. For examples, see classes under the {Mobility::Plugins} namespace.
 
 =end
   module Plugins
+    OPTION_UNSET = Object.new
   end
 end

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -65,7 +65,7 @@ The proc can accept zero to three arguments (see examples below)
       # @param [Attributes] attributes
       # @param [Object] option
       def self.apply(attributes, option)
-        attributes.backend_class.include(new(option))
+        attributes.backend_class.include(new(option)) unless option == Plugins::OPTION_UNSET
       end
 
       def initialize(default_option)

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -5,7 +5,9 @@ module Mobility
 =begin
 
 Defines value or proc to fall through to if return value from getter would
-otherwise be nil.
+otherwise be nil. This plugin is disabled by default but will be enabled if any
+value (other than +Mobility::Plugins::OPTION_UNSET+) is passed as the +default+
+option key.
 
 If default is a +Proc+, it will be called with the context of the model, and
 passed arguments:

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -18,7 +18,7 @@ created for the model with the hash defining additional fallbacks. To set a
 default value for this hash, use set the value of `default_options[:fallbacks]`
 in your Mobility configuration (see below).
 
-In addition, fallbacks are disabled in certain situation. To explicitly disable
+In addition, fallbacks are disabled in certain situations. To explicitly disable
 fallbacks when reading and writing, you can pass the <tt>fallback: false</tt>
 option to the reader method. This can be useful to determine the actual
 value of the translated attribute, including a possible +nil+ value.

--- a/lib/mobility/plugins/presence.rb
+++ b/lib/mobility/plugins/presence.rb
@@ -20,7 +20,7 @@ backend. Included by default, but can be disabled with +presence: false+ option.
         attributes.backend_class.include(self) if option
       end
 
-      # @group Backend Accessors
+      # @!group Backend Accessors
       # @!macro backend_reader
       # @option options [Boolean] presence
       #   *false* to disable presence filter.
@@ -28,7 +28,6 @@ backend. Included by default, but can be disabled with +presence: false+ option.
         options.delete(:presence) == false ? super : Presence[super]
       end
 
-      # @group Backend Accessors
       # @!macro backend_writer
       # @option options [Boolean] presence
       #   *false* to disable presence filter.
@@ -39,6 +38,7 @@ backend. Included by default, but can be disabled with +presence: false+ option.
           super(locale, Presence[value], options)
         end
       end
+      # @!endgroup
 
       def self.[](value)
         (value == "") ? nil : value

--- a/spec/mobility/plugins/default_spec.rb
+++ b/spec/mobility/plugins/default_spec.rb
@@ -17,7 +17,7 @@ describe Mobility::Plugins::Default do
           backend_double_.write(*args)
         end
       end
-      Class.new(backend_class).include(described_class.new(default))
+      Class.new(backend_class).include(described_class)
     end
 
     describe "#read" do
@@ -95,10 +95,8 @@ describe Mobility::Plugins::Default do
     it "includes instance of default into backend class" do
       backend_class = double("backend class")
       attributes = instance_double(Mobility::Attributes, backend_class: backend_class)
-      default = instance_double(described_class)
 
-      expect(described_class).to receive(:new).with("default").and_return(default)
-      expect(backend_class).to receive(:include).with(default)
+      expect(backend_class).to receive(:include).with(described_class)
       described_class.apply(attributes, "default")
     end
   end


### PR DESCRIPTION
Currently, the Default plugin is included in every backend. We can avoid this using the trick of a constant pointing to `Object.new` to signify an unset option key.

Also, I converted the plugin into a normal module rather than a module builder. Doesn't seem to affect performance but all else equal, normal modules are preferred.