### PR TITLE
Use backend visitors to fully support Arel queries

### DIFF
--- a/lib/mobility/arel.rb
+++ b/lib/mobility/arel.rb
@@ -1,1 +1,18 @@
+# frozen-string-literal: true
 require "mobility/arel/nodes"
+require "mobility/arel/visitor"
+
+module Mobility
+  module Arel
+    class Attribute < ::Arel::Attributes::Attribute
+      attr_reader :backend_class
+      attr_reader :attribute_name
+
+      def initialize(relation, column_name, backend_class, attribute_name = nil)
+        @backend_class = backend_class
+        @attribute_name = attribute_name || column_name
+        super(relation, column_name)
+      end
+    end
+  end
+end

--- a/lib/mobility/arel/nodes.rb
+++ b/lib/mobility/arel/nodes.rb
@@ -4,8 +4,8 @@ module Mobility
     module Nodes
       class Unary  < ::Arel::Nodes::Unary;  end
       class Binary < ::Arel::Nodes::Binary; end
-      class Grouping < Unary; end
-      class Equality < Binary; end
+      class Grouping < ::Arel::Nodes::Grouping; end
+      class Equality < ::Arel::Nodes::Equality; end
 
       ::Arel::Visitors::ToSql.class_eval do
         alias :visit_Mobility_Arel_Nodes_Equality :visit_Arel_Nodes_Equality

--- a/lib/mobility/arel/visitor.rb
+++ b/lib/mobility/arel/visitor.rb
@@ -1,0 +1,61 @@
+# frozen-string-literal: true
+module Mobility
+  module Arel
+    class Visitor < ::Arel::Visitors::Visitor
+      INNER_JOIN = ::Arel::Nodes::InnerJoin
+      OUTER_JOIN = ::Arel::Nodes::OuterJoin
+
+      attr_reader :backend_class
+
+      def initialize(backend_class = nil)
+        super()
+        @backend_class = backend_class
+      end
+
+      private
+
+      def visit(object)
+        super
+      rescue TypeError
+        visit_default(object)
+      end
+
+      def visit_collection(_objects)
+        raise NotImplementedError
+      end
+      alias :visit_Array :visit_collection
+
+      def visit_Arel_Nodes_Unary(object)
+        visit(object.expr)
+      end
+
+      def visit_Arel_Nodes_Binary(object)
+        visit_collection([object.left, object.right])
+      end
+
+      def visit_Arel_Nodes_Function(object)
+        visit_collection(object.expressions)
+      end
+
+      def visit_Arel_Nodes_Case(object)
+        visit_collection([object.case, object.conditions, object.default])
+      end
+
+      def visit_Arel_Nodes_And(object)
+        visit_Array(object.children)
+      end
+
+      def visit_Arel_Nodes_Node(object)
+        visit_default(object)
+      end
+
+      def visit_Arel_Attributes_Attribute(object)
+        visit_default(object)
+      end
+
+      def visit_default(_object)
+        nil
+      end
+    end
+  end
+end

--- a/lib/mobility/backends/active_record.rb
+++ b/lib/mobility/backends/active_record.rb
@@ -21,10 +21,11 @@ module Mobility
         end
 
         # @param [ActiveRecord::Relation] relation Relation to scope
+        # @param [Object] predicate Arel predicate
         # @param [Symbol] locale Locale
         # @option [Boolean] invert
         # @return [ActiveRecord::Relation] Relation with scope added
-        def add_translations(relation, _opts, _locale, invert: false)
+        def apply_scope(relation, _predicate, _locale, invert: false)
           relation
         end
 

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -11,7 +11,7 @@ module Mobility
 Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
 
 @example
-  class Post < ActiveRecord::Base
+  class Post < ApplicationRecord
     extend Mobility
     translates :title, backend: :key_value, association_name: :translations, type: :string
   end

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -19,7 +19,7 @@ If the translation table already exists, it will create a migration adding
 columns to that table.
 
 @example Model with table backend
-  class Post < ActiveRecord::Base
+  class Post < ApplicationRecord
     extend Mobility
     translates :title, backend: :table
   end

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -23,6 +23,7 @@ module Mobility
             t.string :locale
             t.integer :article_id
             t.string :title
+            t.string :subtitle
             t.text :content
             t.timestamps null: false
           end
@@ -80,6 +81,7 @@ module Mobility
             t.text :author_pt_br
             t.text :author_ru
             t.boolean :published
+            t.integer :article_id
             t.timestamps null: false
           end
 

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+# @note Although this plugin should probably really be tested against an
+#   abstract backend with +build_node+ and +apply_scope+ defined and tested,
+#   doing so would be quite involved, so instead this spec tests against a
+#   complex combination of existing backends, which is less precise but should
+#   be sufficient at this stage.
+#
+describe "Mobility::Plugins::ActiveRecord::Query", orm: :active_record do
+  require "mobility/plugins/active_record/query"
+
+  describe "virtual row handling" do
+    before do
+      stub_const 'Article', Class.new(ActiveRecord::Base)
+      Article.class_eval do
+        extend Mobility
+        translates :title, backend: :table
+        translates :subtitle, backend: :table
+        translates :content, type: :text, backend: :key_value
+        translates :author, type: :string, backend: :key_value
+        has_many :comments
+      end
+
+      stub_const 'Comment', Class.new(ActiveRecord::Base)
+      Comment.class_eval do
+        extend Mobility
+        belongs_to :article
+        translates :author, backend: :column
+      end
+    end
+
+    # TODO: Test more thoroughly
+    context "single-block querying" do
+      context "multiple backends" do
+        it "does not join translations table when backend node not included in predicate" do
+          Article.i18n { title; content.eq("bazcontent").or(author.eq("foobarauthor")) }.tap do |relation|
+            expect(relation.to_sql).not_to match /article_translations/
+          end
+        end
+      end
+    end
+
+    # TODO: Test more thoroughly
+    context "multiple-block querying" do
+      it "returns records matching predicate across models" do
+        article1 = Article.create(author: "foo")
+        article2 = Article.create(author: "foo")
+        comment1 = article1.comments.create(author: "foo")
+        comment2 = article2.comments.create(author: "baz")
+
+        expect(Article.i18n { |a| a.author.eq("foo") }).to match_array([article1, article2])
+        expect(Comment.i18n { |c| c.author.eq("foo") }).to eq([comment1])
+
+        expect(Article.joins(:comments).i18n { |a| Comment.i18n { |c| a.author.eq(c.author) } }).to eq([article1])
+      end
+    end
+  end
+end if Mobility::Loaded::ActiveRecord

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -34,6 +34,7 @@ module Mobility
             Integer     :article_id, allow_null: false
             String      :locale,     allow_null: false
             String      :title
+            String      :subtitle
             String      :content, size: 65535
             DateTime    :created_at, allow_null: false
             DateTime    :updated_at, allow_null: false
@@ -103,6 +104,7 @@ module Mobility
             String      :author_pt_br
             String      :author_ru
             TrueClass   :published
+            Integer     :post_id
             DateTime    :created_at, allow_null: false
             DateTime    :updated_at, allow_null: false
           end


### PR DESCRIPTION
(This is a follow-up to #216.)

This PR implements **full support** for querying using Arel translation nodes across all backends. It's taken a lot of thought to get here, but I think this will be a very important change for anyone using Mobility with querying, particularly complex querying.

In previous versions of Mobility, you could call `where` and `not` on a scoped relation on a translated model, and Mobility would convert translated attributes into their corresponding backend-specific nodes. However, this meant that you were limited to equality-type predicates, since that's all that `where` supports.

So I thought: what if you could just get an Arel node for a backend attribute? Then you could build your own queries with the node, e.g. `title.eq("foo")` but also `title.matches("foo")`, or anything else you could imagine.

The tricky part with this is that some backends (Table and KeyValue) have associations they depend on. A node on its own can't arbitrarily join another table, so the node would depend on backend-specific code (joining one or more tables). I want a truly backend-independent solution here, so this was not enough.

PR #216 added another method `add_translations` which had to be called on the backend to fully support querying on Arel nodes, but I didn't really like this implementation.

After digging further, I came to a better solution which instead adds visitor classes for Table and KeyValue bakends (like Arel uses internally). These visitors take a predicate, a relation and a locale, and return the relation with whatever the relation will need to support the predicate. The details are too complex here (I'll write about it in a blog post soon), but the result is that there is now a powerful interface to query on any backends with Arel nodes.

Here is an example with a deliberately complex model:

```ruby
class Post < ApplicationRecord
  extend Mobility
  translates :title, backend: :jsonb
  translates :subtitle, backend: :table
  translates :author, backend: :column
end
```

The interface uses the existing `i18n` scope, but you can now optionally pass attribute names and a block, and the block will be passed the nodes from which you can build a predicate:

```ruby
Post.i18n(:title, :subtitle, :author) do |title, subtitle, author|
  title.eq("Querying with Arel in Mobility").
    and(subtitle.eq("Feel the Power")).
    and(author.matches("Chris"))
```

This will generate the SQL:

```sql
SELECT "posts".* FROM "posts"
  INNER JOIN "post_translations" ON "post_translations"."post_id" = "posts"."id" AND "post_translations"."locale" = 'en'
  WHERE ("posts"."title" -> 'en') = '"Querying with Arel in Mobility"'
  AND "post_translations"."subtitle" = 'Feel the Power'
  AND "posts"."author_en" ILIKE 'Chris'
```

Note that each attribute is mapped to a different predicate depending on the backend, but the predicate you build in the block is completely independent of these details. Also, the `JOIN` is added because the `subtitle` attribute needs it, but again you don't need to worry about.

Not only that, but Mobility will detect whether you need an `INNER` or `OUTER` join, so if I change the query to this:


```ruby
Post.i18n(:title, :subtitle, :author) do |title, subtitle, author|
  title.eq("Querying with Arel in Mobility").
    and(subtitle.eq(nil)).
    and(author.matches("Chris"))
```

then the query becomes:

```sql
SELECT "posts".* FROM "posts"
  LEFT OUTER JOIN "post_translations" ON "post_translations"."post_id" = "posts"."id" AND "post_translations"."locale" = 'en'
  WHERE ("posts"."title" -> 'en') = '"Querying with Arel in Mobility"'
  AND "post_translations"."subtitle" IS NULL
  AND "posts"."author_en" ILIKE 'Chris'
```

Note here that since we're looking for a `NULL` value on `post_translations`, we need to `OUTER JOIN` the table because the translation may be missing (which means the value is treated as `nil`). Without an `OUTER JOIN` here, you could return a miss when in fact there was a post it should have matched.

Using the [Visitor Pattern](http://patshaughnessy.net/2014/9/23/how-arel-converts-ruby-queries-into-sql-statements) here makes this query interface very powerful, since Mobility will evaluate the entire tree of the predicate, so even if you create more complex nodes it will still find the translated node(s) and join the correct table in the correct way.