### PR TITLE
Add specific attribute types to basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ of options, like this:
 ```ruby
 class Word < ApplicationRecord
   extend Mobility
-  translates :name, :meaning
+  translates :name,    type: :string
+  translates :meaning, type: :text
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -162,10 +162,21 @@ of options, like this:
 ```ruby
 class Word < ApplicationRecord
   extend Mobility
+  translates :name, :meaning
+end
+```
+
+Note: When using the KeyValue backend, use the options hash to pass each attribute's type:
+
+```ruby
+class Word < ApplicationRecord
+  extend Mobility
   translates :name,    type: :string
   translates :meaning, type: :text
 end
 ```
+
+This is important because this is how Mobility knows to which of the [two translation tables](https://github.com/shioyama/mobility/wiki/KeyValue-Backend) it should save your translation.
 
 You now have translated attributes `name` and `meaning` on the model `Word`.
 You can set their values like you would any other attribute:


### PR DESCRIPTION
Hi!
When following the installation steps for the first time, the following warning is shown:
```
WARNING: In previous versions, the Mobility KeyValue backend defaulted to a
text type column, but this behavior is now deprecated and will be removed in
the next release. Either explicitly specify the type by passing type: :text in
each translated model, or set a default option in your configuration.
```
That's because the auto-generated initializer has `default_options[:type]` commented out by default and the basic example of defining attributes doesn't define their types explicitly:
```ruby
class Word < ApplicationRecord
  extend Mobility
  translates :name, :meaning
end
```
This PR simply adds the `type` option to the basic example to avoid the confusing warning for newcomers like myself.