### PR TITLE
Support querying on multiple locales at once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_script:
 before_install: gem install bundler
 addons:
   postgresql: "9.4"
+  apt:
+    update: true
 services:
   - postgresql
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ addons:
   postgresql: "9.4"
 services:
   - postgresql
+  - mysql
 notifications:
   webhooks:
     urls:

--- a/lib/mobility/arel.rb
+++ b/lib/mobility/arel.rb
@@ -6,10 +6,12 @@ module Mobility
   module Arel
     class Attribute < ::Arel::Attributes::Attribute
       attr_reader :backend_class
+      attr_reader :locale
       attr_reader :attribute_name
 
-      def initialize(relation, column_name, backend_class, attribute_name = nil)
+      def initialize(relation, column_name, locale, backend_class, attribute_name: nil)
         @backend_class = backend_class
+        @locale = locale
         @attribute_name = attribute_name || column_name
         super(relation, column_name)
       end

--- a/lib/mobility/arel/visitor.rb
+++ b/lib/mobility/arel/visitor.rb
@@ -5,11 +5,11 @@ module Mobility
       INNER_JOIN = ::Arel::Nodes::InnerJoin
       OUTER_JOIN = ::Arel::Nodes::OuterJoin
 
-      attr_reader :backend_class
+      attr_reader :backend_class, :locale
 
-      def initialize(backend_class = nil)
+      def initialize(backend_class, locale)
         super()
-        @backend_class = backend_class
+        @backend_class, @locale = backend_class, locale
       end
 
       private

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -331,7 +331,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
     end
 
     describe ".configure" do
-      it "sets association_name, class_name and table_alias from string type" do
+      it "sets association_name, class_name and table_alias_affix from string type" do
         options = { type: :string, model_class: Post }
         described_class.configure(options)
         expect(options).to eq({
@@ -339,11 +339,11 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
           class_name: Mobility::ActiveRecord::StringTranslation,
           model_class: Post,
           association_name: :string_translations,
-          table_alias: "Post_%s_string_translations"
+          table_alias_affix: "Post_%s_string_translations"
         })
       end
 
-      it "sets association_name, class_name and table_alias from text type" do
+      it "sets association_name, class_name and table_alias_affix from text type" do
         options = { type: :text, model_class: Post }
         described_class.configure(options)
         expect(options).to eq({
@@ -351,7 +351,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
           class_name: Mobility::ActiveRecord::TextTranslation,
           model_class: Post,
           association_name: :text_translations,
-          table_alias: "Post_%s_text_translations"
+          table_alias_affix: "Post_%s_text_translations"
         })
       end
 
@@ -369,7 +369,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
           class_name: Mobility::ActiveRecord::TextTranslation,
           model_class: Post,
           association_name: :text_translations,
-          table_alias: "Post_%s_text_translations"
+          table_alias_affix: "Post_%s_text_translations"
         })
       end
     end


### PR DESCRIPTION
This is currently supported (although not tested) by all backends except KeyValue and Table. Should be straightforward to support universally.

The format looks like this:

```ruby
Post.i18n(locale: :en) do |en|
  Post.i18n(locale: :ja) do |ja|
    en.title.eq("Title").and(ja.title.eq("タイトル"))
  end
end
```

This queries for a post with an English title `Title` and a Japanese title `タイトル`, but obviously you could build much more complex logic.

Here is the resulting SQL for a Jsonb backend:

```sql
SELECT "posts".* FROM "posts"
WHERE ("posts"."title" -> 'en') = '"foo"' AND ("posts"."title" -> 'ja') = '"bar"'
```

The problem with KeyValue and Table backends is that their respective joins do not alias the table name with an alias that includes the locale.