### PR TITLE
Support equality predicates between jsonb nodes

### DIFF
--- a/lib/mobility/arel/nodes/pg_ops.rb
+++ b/lib/mobility/arel/nodes/pg_ops.rb
@@ -30,9 +30,13 @@ module Mobility
       end
 
       # Needed for AR 4.2, can be removed when support is deprecated
-      HstoreDashArrow.class_eval do
-        def quoted_node other
-          other && super
+      if ::ActiveRecord::VERSION::STRING < '5.0'
+        [JsonbDashDoubleArrow, HstoreDashArrow].each do |klass|
+          klass.class_eval do
+            def quoted_node other
+              other && super
+            end
+          end
         end
       end
 

--- a/lib/mobility/arel/nodes/pg_ops.rb
+++ b/lib/mobility/arel/nodes/pg_ops.rb
@@ -75,15 +75,14 @@ module Mobility
 
       class JsonContainer < Json
         def initialize column, locale, attr
-          left = Arel::Nodes::JsonDashArrow.new column, locale
-          super left, attr
+          super(Arel::Nodes::JsonDashArrow.new(column, locale), attr)
         end
       end
 
       class JsonbContainer < Jsonb
         def initialize column, locale, attr
           @column, @locale = column, locale
-          super JsonbDashArrow.new(column, locale), attr
+          super(JsonbDashArrow.new(column, locale), attr)
         end
 
         def eq other

--- a/lib/mobility/arel/nodes/pg_ops.rb
+++ b/lib/mobility/arel/nodes/pg_ops.rb
@@ -19,7 +19,7 @@ module Mobility
           include ::Arel::OrderPredications
           include ::Arel::AliasPredication
 
-          def eq(other)
+          def eq other
             Equality.new self, quoted_node(other)
           end
 
@@ -31,18 +31,18 @@ module Mobility
 
       # Needed for AR 4.2, can be removed when support is deprecated
       HstoreDashArrow.class_eval do
-        def quoted_node(other)
+        def quoted_node other
           other && super
         end
       end
 
       class Jsonb  < JsonbDashDoubleArrow
         def to_dash_arrow
-          JsonbDashArrow.new(left, right)
+          JsonbDashArrow.new left, right
         end
 
         def to_question
-          JsonbQuestion.new(left, right)
+          JsonbQuestion.new left, right
         end
 
         def eq other
@@ -50,7 +50,7 @@ module Mobility
           when NilClass
             to_question.not
           when Integer, Array, Hash
-            to_dash_arrow.eq(other.to_json)
+            to_dash_arrow.eq other.to_json
           else
             super
           end
@@ -59,7 +59,7 @@ module Mobility
 
       class Hstore < HstoreDashArrow
         def to_question
-          HstoreQuestion.new(left, right)
+          HstoreQuestion.new left, right
         end
 
         def eq other
@@ -70,16 +70,16 @@ module Mobility
       class Json < JsonDashDoubleArrow; end
 
       class JsonContainer < Json
-        def initialize(column, locale, attr)
-          left = Arel::Nodes::JsonDashArrow.new(column, locale)
-          super(left, attr)
+        def initialize column, locale, attr
+          left = Arel::Nodes::JsonDashArrow.new column, locale
+          super left, attr
         end
       end
 
       class JsonbContainer < Jsonb
-        def initialize(column, locale, attr)
+        def initialize column, locale, attr
           @column, @locale = column, locale
-          super(JsonbDashArrow.new(column, locale), attr)
+          super JsonbDashArrow.new(column, locale), attr
         end
 
         def eq other
@@ -119,7 +119,7 @@ module Mobility
 
       private
 
-      def json_infix(o, a, opr)
+      def json_infix o, a, opr
         visit(Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right)), a)
       end
     end

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -63,13 +63,11 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
       #   node for attribute on json or jsonb column
       def self.build_node(attr, locale)
         column        = model_class.arel_table[column_name]
-        quoted_locale = build_quoted(locale)
-        quoted_attr   = build_quoted(attr)
         case column_type
         when :json
-          Arel::Nodes::Json.new(Arel::Nodes::JsonDashArrow.new(column, quoted_locale), quoted_attr)
+          Arel::Nodes::JsonContainer.new(column, build_quoted(locale), build_quoted(attr))
         when :jsonb
-          Arel::Nodes::Jsonb.new(Arel::Nodes::Jsonb.new(column, quoted_locale), quoted_attr)
+          Arel::Nodes::JsonbContainer.new(column, build_quoted(locale), build_quoted(attr))
         end
       end
 

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -62,7 +62,7 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
       # @return [Mobility::Arel::Nodes::Json,Mobility::Arel::Nodes::Jsonb] Arel
       #   node for attribute on json or jsonb column
       def self.build_node(attr, locale)
-        column        = model_class.arel_table[column_name]
+        column = model_class.arel_table[column_name]
         case column_type
         when :json
           Arel::Nodes::JsonContainer.new(column, build_quoted(locale), build_quoted(attr))

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -270,7 +270,6 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, a1=:t
 
         # TODO: support equality across columns with JSONB/CONTAINER backends
         it "handles (a EQ b)" do
-          skip "Not yet supported by #{backend_name}" if [:jsonb, :container].include?(backend_name)
           matching = [
             model_class.create(a1 => "foo", a2 => "foo"),
             model_class.create(a1 => "bar", a2 => "bar")


### PR DESCRIPTION
Previously it was not possible to create equality predicates between jsonb nodes. This fixes the issue, so you can do:

```ruby
Post.i18n { title.eq(content) }
```

... and Mobility will return all posts whose `title` and `content` are the same, for Jsonb (and Container) backends (already worked for other backends). I think this is the last issue to fix before releasing 0.7.0 :tada: