### PR TITLE
Revert unscoping in uniqueness validator

### DIFF
--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -49,7 +49,7 @@ To use the validator, you must +extend Mobility+ before calling +validates+
       private
 
       def mobility_scope_relation(record, relation)
-        [*options[:scope]].inject(relation.unscoped) do |scoped_relation, scope_item|
+        [*options[:scope]].inject(relation) do |scoped_relation, scope_item|
           scoped_relation.__mobility_query_scope__ do |m|
             m.__send__(scope_item).eq(record.send(scope_item))
           end

--- a/spec/support/shared_examples/validation_examples.rb
+++ b/spec/support/shared_examples/validation_examples.rb
@@ -19,14 +19,6 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
         model_class.create(attribute1 => "foo")
         expect(model_class.new(attribute1 => "foo")).not_to be_valid
       end
-
-      context "with default_scope defined" do
-        it "removes default_scope" do
-          model_class.class_eval { default_scope { none } }
-          model_class.create(attribute1 => "foo")
-          expect(model_class.new(attribute1 => "foo")).not_to be_valid
-        end
-      end
     end
 
     context "with untranslated scope on translated attribute" do


### PR DESCRIPTION
This reverts #237, which seemed to cause issues in SpinaCMS. Will investigate further later.