### PR TITLE
Correctly unscope in uniqueness validator and fix specs

### DIFF
--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -27,7 +27,7 @@ To use the validator, you must +extend Mobility+ before calling +validates+
 
         if (([*options[:scope]] + [attribute]).map(&:to_s) & klass.mobility_attributes).present?
           return unless value.present?
-          relation = klass.__mobility_query_scope__ do |m|
+          relation = klass.unscoped.__mobility_query_scope__ do |m|
             node = m.__send__(attribute)
             options[:case_sensitive] == false ? node.lower.eq(value.downcase) : node.eq(value)
           end

--- a/spec/support/shared_examples/validation_examples.rb
+++ b/spec/support/shared_examples/validation_examples.rb
@@ -16,6 +16,14 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
         model_class.create(attribute1 => "foo")
         expect(model_class.new(attribute1 => "foo")).not_to be_valid
       end
+
+      context "with default_scope defined" do
+        it "removes default_scope" do
+          model_class.class_eval { default_scope { none } }
+          model_class.create(attribute1 => "foo")
+          expect(model_class.new(attribute1 => "foo")).not_to be_valid
+        end
+      end
     end
 
     context "with untranslated scope on translated attribute" do

--- a/spec/support/shared_examples/validation_examples.rb
+++ b/spec/support/shared_examples/validation_examples.rb
@@ -7,15 +7,12 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
         end
       end
 
-      it "is valid if no other record has same attribute value in same locale" do
-        model_class.create(attribute1 => "foo")
-        instance = Mobility.with_locale(:ja) do
-          model_class.new(attribute1 => "foo")
-        end
-        expect(instance).to be_valid
+      it "is valid if no other record has same attribute value in this locale" do
+        Mobility.with_locale(:ja) { model_class.create(attribute1 => "foo") }
+        expect(model_class.new(attribute1 => "foo")).to be_valid
       end
 
-      it "is invalid if other record has same attribute value in same locale" do
+      it "is invalid if other record has same attribute value in this locale" do
         model_class.create(attribute1 => "foo")
         expect(model_class.new(attribute1 => "foo")).not_to be_valid
       end
@@ -28,12 +25,12 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
         end
       end
 
-      it "is valid if no other record has same attribute value in same locale, for the same scope" do
+      it "is valid if no other record has same attribute value in this locale, for the same scope" do
         model_class.create(attribute1 => "foo", published: true)
         expect(model_class.new(attribute1 => "foo", published: false)).to be_valid
       end
 
-      it "is invalid if other record has same attribute value in same locale, for the same scope" do
+      it "is invalid if other record has same attribute value in this locale, for the same scope" do
         model_class.create(attribute1 => "foo", published: true)
         instance1 = model_class.new(attribute1 => "foo", published: true)
         instance2 = Mobility.with_locale(:ja) { model_class.new(attribute1  => "foo", published: true) }
@@ -49,17 +46,21 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
         end
       end
 
-      it "is valid if no other record has same attribute value in same locale, for the same scope" do
+      it "is valid if no other record has same attribute value in this locale, for the same scope" do
         model_class.create(attribute1 => "foo", attribute2 => "bar")
         expect(model_class.new(attribute1 => "foo", attribute2 => "baz")).to be_valid
       end
 
-      it "is invalid if other record has same attribute value in same locale, for the same scope" do
+      it "is invalid if other record has same attribute value in this locale, for the same scope" do
         model_class.create(attribute1 => "foo", attribute2 => "bar")
-        instance1 = model_class.new(attribute1 => "foo", attribute2 => "bar")
-        instance2 = Mobility.with_locale(:ja) { model_class.new(attribute1  => "foo", attribute2 => "bar") }
-        expect(instance1).not_to be_valid
-        expect(instance2).to be_valid
+        expect(model_class.new(attribute1 => "foo", attribute2 => "bar")).not_to be_valid
+
+        Mobility.with_locale(:ja) do
+          expect(model_class.new(attribute1 => "foo", attribute2 => "bar")).to be_valid
+
+          model_class.create(attribute1 => "foo", attribute2 => "bar")
+          expect(model_class.new(attribute1 => "foo", attribute2 => "bar")).not_to be_valid
+        end
       end
     end
 
@@ -70,12 +71,12 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
         end
       end
 
-      it "is valid if no other record has same attribute value, for the same scope in same locale" do
+      it "is valid if no other record has same attribute value, for the same scope in this locale" do
         model_class.create(published: true, attribute1 => "foo")
         expect(model_class.new(published: true, attribute1 => "baz")).to be_valid
       end
 
-      it "is invalid if other record has same attribute value in same locale, for the same scope" do
+      it "is invalid if other record has same attribute value in this locale, for the same scope" do
         model_class.create(published: true, attribute1 => "foo")
         instance1 = model_class.new(published: true, attribute1 => "foo")
         instance2 = Mobility.with_locale(:ja) { model_class.new(published:  true, attribute1 => "foo") }
@@ -109,12 +110,13 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
         expect(model_class.new(published: false)).to be_valid
       end
 
-      it "is invalid if other record has same attribute value in same locale" do
+      it "is invalid if other record has same attribute value in this locale" do
         model_class.create(published: true)
-        instance1 = model_class.new(published: true)
-        instance2 = Mobility.with_locale(:ja) { model_class.new(published: true) }
-        expect(instance1).not_to be_valid
-        expect(instance2).not_to be_valid
+        expect(model_class.new(published: true)).not_to be_valid
+
+        Mobility.with_locale(:ja) do
+          expect(model_class.new(published: true)).not_to be_valid
+        end
       end
     end
   end


### PR DESCRIPTION
I'll merge this once specs pass, but we can release in the next minor instead of 0.7.x.