### PR TITLE
Prefer Rails available_locales if loaded

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -117,7 +117,7 @@ module Mobility
     # Sets Mobility locale
     # @param [Symbol] locale Locale to set
     # @raise [InvalidLocale] if locale is nil or not in
-    #   +I18n.available_locales+ (if +I18n.enforce_available_locales+ is +true+)
+    #   +Mobility.available_locales+ (if +I18n.enforce_available_locales+ is +true+)
     # @return [Symbol] Locale
     def locale=(locale)
       set_locale(locale)
@@ -236,6 +236,22 @@ I18n.enforce_available_locales is false. In the past, Mobility would do nothing
 in this case, but as of the next major release Mobility will ignore the I18n
 setting and enforce available locales whenever this method is called.
 EOL
+      end
+    end
+
+    # Returns available locales. Defaults to I18n.available_locales, but will
+    # use Rails.application.config.i18n.available_locales if Rails is loaded
+    # and config is non-nil.
+    # @return [Array<Symbol>] Available locales
+    # @note The special case for Rails is necessary due to the fact that Rails
+    #   may load the model before setting +I18n.available_locales+. If we
+    #   simply default to +I18n.available_locales+, we may define many more
+    #   methods (in LocaleAccessors) than is really necessary.
+    def available_locales
+      if Loaded::Rails && Rails.application
+        Rails.application.config.i18n.available_locales || I18n.available_locales
+      else
+        I18n.available_locales
       end
     end
 

--- a/lib/mobility/backends/active_record/column.rb
+++ b/lib/mobility/backends/active_record/column.rb
@@ -14,8 +14,8 @@ translatable columns to the model table with:
   rails generate mobility:translations post title:string
 
 The generated migration will add columns +title_<locale>+ for every locale in
-+I18n.available_locales+. (The generator can be run again to add new attributes
-or locales.)
++Mobility.available_locales+ (i.e. +I18n.available_locales+). (The generator
+can be run again to add new attributes or locales.)
 
 @example
   class Post < ActiveRecord::Base

--- a/lib/mobility/backends/column.rb
+++ b/lib/mobility/backends/column.rb
@@ -6,7 +6,7 @@ module Mobility
 
 Stores translated attribute as a column on the model table. To use this
 backend, ensure that the model table has columns named +<attribute>_<locale>+
-for every locale in +I18n.available_locales+.
+for every locale in +Mobility.available_locales+ (i.e. +I18n.available_locales+).
 
 If you are using Rails, you can use the +mobility:translations+ generator to
 create a migration adding these columns to the model table with:
@@ -14,7 +14,7 @@ create a migration adding these columns to the model table with:
   rails generate mobility:translations post title:string
 
 The generated migration will add columns +title_<locale>+ for every locale in
-+I18n.available_locales+. (The generator can be run again to add new attributes
++Mobility.available_locales+. (The generator can be run again to add new attributes
 or locales.)
 
 ==Backend Options

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -104,7 +104,7 @@ default_fallbacks= will be removed in the next major version of Mobility.
       @accessor_method = :translates
       @query_method = :i18n
       @fallbacks_generator = lambda { |fallbacks| Mobility::Fallbacks.build(fallbacks) }
-      @default_accessor_locales = lambda { I18n.available_locales }
+      @default_accessor_locales = lambda { Mobility.available_locales }
       @default_options = Options[{
         cache:    true,
         presence: true,

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -10,7 +10,8 @@ locales directly with a method call, using a suffix including the locale:
   article.title_pt_br
 
 If no locales are passed as an option to the initializer,
-+I18n.available_locales+ will be used by default.
++Mobility.available_locales+ (i.e. +I18n.available_locales+, or Rails-set
+available locales for a Rails application) will be used by default.
 
 @example
   class Post

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -41,7 +41,7 @@ If no locales are passed as an option to the initializer,
 
       # @param [String] One or more attribute names
       # @param [Array<Symbol>] Locales
-      def initialize(*attribute_names, locales: I18n.available_locales)
+      def initialize(*attribute_names, locales:)
         attribute_names.each do |name|
           locales.each do |locale|
             define_reader(name, locale)

--- a/lib/rails/generators/mobility/templates/column_translations.rb
+++ b/lib/rails/generators/mobility/templates/column_translations.rb
@@ -1,7 +1,7 @@
 class <%= migration_class_name %> < <%= activerecord_migration_class %>
   def change
 <% attributes.each do |attribute| -%>
-<% I18n.available_locales.each do |locale| -%>
+<% Mobility.available_locales.each do |locale| -%>
 <% column_name = Mobility.normalize_locale_accessor(attribute.name, locale) -%>
 <% if connection.column_exists?(table_name, column_name) -%>
 <% warn "#{column_name} already exists, skipping." -%>

--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -62,8 +62,9 @@ Mobility.configure do |config|
   # config.default_options[:default] = ...
 
   # Uncomment to enable locale_accessors by default on models. A true value
-  # will use the locales defined in I18n.available_locales. If you want
-  # something else, pass an array of locales instead.
+  # will use the locales defined either in
+  # Rails.application.config.i18n.available_locales or I18n.available_locales.
+  # If you want something else, pass an array of locales instead.
   #
   # config.default_options[:locale_accessors] = true
 

--- a/lib/rails/generators/mobility/translations_generator.rb
+++ b/lib/rails/generators/mobility/translations_generator.rb
@@ -23,7 +23,7 @@ For the +table+ backend, the generator will either create a translation table
 exists.
 
 For the +column+ backend, the generator will add columns for all locales in
-+I18n.available_locales+. If some columns already exist, they will simply be
++Mobility.available_locales+. If some columns already exist, they will simply be
 skipped.
 
 Other backends are not supported, for obvious reasons:

--- a/spec/mobility/plugins/locale_accessors_spec.rb
+++ b/spec/mobility/plugins/locale_accessors_spec.rb
@@ -11,45 +11,7 @@ describe Mobility::Plugins::LocaleAccessors do
       end
     end
 
-    context "locales unset, uses I18n.available_locales" do
-      before do
-        @available_locales = I18n.available_locales
-        I18n.available_locales = [:en, :pt]
-      end
-      after do
-        I18n.available_locales = @available_locales
-      end
-      let(:model_class) do
-        base_model_class.include described_class.new(:title)
-        base_model_class
-      end
-
-      it_behaves_like "locale accessor", :title, :pt
-
-      it "raises NoMethodError if locale not in I18n.available_locales" do
-        model_class.include(described_class.new(:title))
-        instance = model_class.new
-        aggregate_failures do
-          expect { instance.title_de }.to raise_error(NoMethodError)
-          expect { instance.title_de? }.to raise_error(NoMethodError)
-          expect { instance.send(:title_de=, "value", {}) }.to raise_error(NoMethodError)
-        end
-      end
-
-      it "warns locale option will be ignored if called with locale" do
-        model_class.include(described_class.new(:title))
-        instance = model_class.new
-        warning_message = /locale passed as option to locale accessor will be ignored/
-        expect(instance).to receive(:title).with(locale: :pt).and_return("foo")
-        expect { expect(instance.title_pt(locale: :en)).to eq("foo") }.to output(warning_message).to_stderr
-        expect(instance).to receive(:title?).with(locale: :pt).and_return(true)
-        expect { expect(instance.title_pt?(locale: :en)).to eq(true) }.to output(warning_message).to_stderr
-        expect(instance).to receive(:title=).with("new foo", locale: :pt)
-        expect { instance.send(:title_pt=, "new foo", locale: :en)}.to output(warning_message).to_stderr
-      end
-    end
-
-    context "locales set" do
+    context "with locales set" do
       let(:model_class) do
         base_model_class.include described_class.new(:title, locales: [:cz, :de, :'pt-BR'])
       end
@@ -65,6 +27,17 @@ describe Mobility::Plugins::LocaleAccessors do
           expect { instance.title_en? }.to raise_error(NoMethodError)
           expect { instance.send(:title_en=, "value", {}) }.to raise_error(NoMethodError)
         end
+      end
+
+      it "warns locale option will be ignored if called with locale" do
+        instance = model_class.new
+        warning_message = /locale passed as option to locale accessor will be ignored/
+        expect(instance).to receive(:title).with(locale: :cz).and_return("foo")
+        expect { expect(instance.title_cz(locale: :en)).to eq("foo") }.to output(warning_message).to_stderr
+        expect(instance).to receive(:title?).with(locale: :cz).and_return(true)
+        expect { expect(instance.title_cz?(locale: :en)).to eq(true) }.to output(warning_message).to_stderr
+        expect(instance).to receive(:title=).with("new foo", locale: :cz)
+        expect { instance.send(:title_cz=, "new foo", locale: :en)}.to output(warning_message).to_stderr
       end
     end
 
@@ -83,7 +56,7 @@ describe Mobility::Plugins::LocaleAccessors do
           end
         end
         base_model_class.include mod
-        base_model_class.include described_class.new(:title)
+        base_model_class.include described_class.new(:title, locales: [:en])
 
         instance = base_model_class.new
 

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -149,6 +149,28 @@ describe Mobility do
     end
   end
 
+  describe ".available_locales" do
+    around do |example|
+      @available_locales = I18n.available_locales
+      I18n.available_locales = [:en, :pt]
+      example.run
+      I18n.available_locales = @available_locales
+    end
+
+    it "defaults to I18n.available_locales" do
+      expect(described_class.available_locales).to eq([:en, :pt])
+    end
+
+    # @note Required since model may be loaded in initializer before Rails has
+    #   updated I18n.available_locales.
+    it "uses Rails i18n locales if Rails application is loaded" do
+      stub_const("Rails", double.as_null_object)
+      allow(Rails).to receive_message_chain(:application, :config, :i18n, :available_locales).
+        and_return([:ru, :cn])
+      expect(described_class.available_locales).to eq([:ru, :cn])
+    end
+  end
+
   describe '.normalize_locale' do
     it "normalizes locale to lowercase string underscores" do
       expect(described_class.normalize_locale(:"pt-BR")).to eq("pt_br")

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -164,11 +164,10 @@ describe Mobility do
     # @note Required since model may be loaded in initializer before Rails has
     #   updated I18n.available_locales.
     it "uses Rails i18n locales if Rails application is loaded" do
-      stub_const("Rails", double.as_null_object)
       allow(Rails).to receive_message_chain(:application, :config, :i18n, :available_locales).
         and_return([:ru, :cn])
       expect(described_class.available_locales).to eq([:ru, :cn])
-    end
+    end if Mobility::Loaded::Rails
   end
 
   describe '.normalize_locale' do


### PR DESCRIPTION
For background, see: https://github.com/shioyama/mobility/issues/243#issuecomment-395302188

I don't like having Rails-specific code sprinkled around, but this seems fairly minimal and probably will avoid weird issues in Rails applications.