### PR TITLE
Only return unique names from mobility_attributes method

### DIFF
--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -268,7 +268,7 @@ EOL
       # Return translated attribute names on this model.
       # @return [Array<String>] Attribute names
       def mobility_attributes
-        mobility_modules.map(&:names).flatten
+        mobility_modules.map(&:names).flatten.uniq
       end
 
       # @!method translated_attribute_names

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -78,6 +78,13 @@ describe Mobility::Attributes do
 
             expect(Article.public_send(method_name)).to match_array(["title", "content", "foo"])
           end
+
+          it "only returns unique attributes" do
+            Article.include described_class.new("title", backend: :null)
+            Article.include described_class.new("title", backend: :null)
+
+            expect(Article.public_send(method_name)).to eq(["title"])
+          end
         end
       end
 


### PR DESCRIPTION
This is an edge case, but I noticed in a spec that the new way attributes are generated (from modules in ancestors) does not call `uniq` on the resulting array. This means if you call `translates` more than once with the same attribute name, you'll get duplicates in the array.

This shouldn't happen normally but I think it should be handled in a sensible way, which is to just call `uniq` on the array.