### PR TITLE
Remove bundler development dependency

### DIFF
--- a/mobility.gemspec
+++ b/mobility.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'request_store', '~> 1.0'
   spec.add_dependency 'i18n', '>= 0.6.10', '< 1.1'
-  spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner", '~> 1.5', '>= 1.5.3'
   spec.add_development_dependency "rake", '~> 12', '>= 12.2.1'
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
This was added by bundler when originally creating the gem, but we don't need it.