### PR TITLE
Sequel pg_hash require hash_initializer

### DIFF
--- a/lib/mobility/backends/sequel/pg_hash.rb
+++ b/lib/mobility/backends/sequel/pg_hash.rb
@@ -3,6 +3,7 @@ require "mobility/util"
 require "mobility/backends/sequel"
 require "mobility/backends/hash_valued"
 require "mobility/sequel/column_changes"
+require "mobility/sequel/hash_initializer"
 
 module Mobility
   module Backends


### PR DESCRIPTION
Adding `require "mobility/sequel/hash_initializer"` to lib/mobility/backends/sequel/pg_hash.rb avoid `NameError: uninitialized constant Mobility::Sequel::HashInitializer` error when using json, jsonb or hstore backend with sequel

