### PR TITLE
Default locale to Mobility.locale in apply_scope

### DIFF
--- a/lib/mobility/backends/active_record.rb
+++ b/lib/mobility/backends/active_record.rb
@@ -25,7 +25,7 @@ module Mobility
         # @param [Symbol] locale Locale
         # @option [Boolean] invert
         # @return [ActiveRecord::Relation] Relation with scope added
-        def apply_scope(relation, _predicate, _locale, invert: false)
+        def apply_scope(relation, _predicate, _locale = Mobility.locale, invert: false)
           relation
         end
 

--- a/lib/mobility/backends/active_record.rb
+++ b/lib/mobility/backends/active_record.rb
@@ -22,7 +22,7 @@ module Mobility
 
         # @param [ActiveRecord::Relation] relation Relation to scope
         # @param [Object] predicate Arel predicate
-        # @param [Symbol] locale Locale
+        # @param [Symbol] locale (Mobility.locale) Locale
         # @option [Boolean] invert
         # @return [ActiveRecord::Relation] Relation with scope added
         def apply_scope(relation, _predicate, _locale = Mobility.locale, invert: false)

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -59,7 +59,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
         # Joins translations using either INNER/OUTER join appropriate to the query.
         # @param [ActiveRecord::Relation] relation Relation to scope
         # @param [Object] predicate Arel predicate
-        # @param [Symbol] locale Locale
+        # @param [Symbol] locale (Mobility.locale) Locale
         # @option [Boolean] invert
         # @return [ActiveRecord::Relation] relation Relation with joins applied (if needed)
         def apply_scope(relation, predicate, locale = Mobility.locale, invert: false)

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -62,7 +62,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
         # @param [Symbol] locale Locale
         # @option [Boolean] invert
         # @return [ActiveRecord::Relation] relation Relation with joins applied (if needed)
-        def apply_scope(relation, predicate, locale, invert: false)
+        def apply_scope(relation, predicate, locale = Mobility.locale, invert: false)
           visitor = Visitor.new(self, locale)
           visitor.accept(predicate).inject(relation) do |rel, (attr, join_type)|
             join_type &&= ::Arel::Nodes::InnerJoin if invert

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -129,7 +129,7 @@ columns to that table.
         # @param [Symbol] locale Locale
         # @option [Boolean] invert
         # @return [ActiveRecord::Relation] relation Relation with joins applied (if needed)
-        def apply_scope(relation, predicate, locale, invert: false)
+        def apply_scope(relation, predicate, locale = Mobility.locale, invert: false)
           visitor = Visitor.new(self, locale)
           if join_type = visitor.accept(predicate)
             join_type &&= Visitor::INNER_JOIN if invert

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -126,7 +126,7 @@ columns to that table.
         # query.
         # @param [ActiveRecord::Relation] relation Relation to scope
         # @param [Object] predicate Arel predicate
-        # @param [Symbol] locale Locale
+        # @param [Symbol] locale (Mobility.locale) Locale
         # @option [Boolean] invert
         # @return [ActiveRecord::Relation] relation Relation with joins applied (if needed)
         def apply_scope(relation, predicate, locale = Mobility.locale, invert: false)


### PR DESCRIPTION
Whenever possible, we should always default to `Mobility.locale`.