### PR TITLE
Yield to block (super) if query map is the identity function

### DIFF
--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -138,7 +138,7 @@ enabled for any one attribute on the model.
                   ->(r) { mod.backend_class.apply_scope(qm[r], mod_predicates, locale, invert: invert) }
                 end
 
-                return yield unless query_map
+                return yield if query_map == IDENTITY
 
                 relation = opts.empty? ? scope : yield(opts)
                 query_map[relation.where(predicates.inject(&:and))]


### PR DESCRIPTION
This kind of subtle, but basically if the query map here is the identity function, it means we did not match *any* keys to module keys, so there is nothing to do here. Checking if it is nil is meaningless since inject in this case will always return something.