### PR TITLE
Add specs to Sequel querying examples for querying on locale

### DIFF
--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -570,6 +570,19 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
             expect(query_scope.where(a1 => "foo").select_all(table_name).all).to eq([@ja_instance2])
           end
         end
+
+        it "returns correct result when querying with locale option" do
+          expect(query_scope.where(a1 => "foo", locale: :en).select_all(table_name).all).to match_array([@instance1, @instance5])
+          expect(query_scope.where(a1 => "foo ja", locale: :ja).select_all(table_name).all).to eq([@ja_instance1])
+          expect(query_scope.where(a1 => "foo", locale: :ja).select_all(table_name).all).to eq([@ja_instance2])
+        end
+
+        it "returns correct result when querying with locale option twice in separate clauses" do
+          @ja_instance1.update(a1 => "foo en")
+          @ja_instance1.reload
+          expect(query_scope.where(a1 => "foo ja", locale: :ja).where(a1 => "foo en", locale: :en).select_all(table_name).all).to eq([@ja_instance1])
+          expect(query_scope.where(a1 => "foo", locale: :ja).where(a1 => nil, locale: :en).select_all(table_name).all).to eq([@ja_instance2])
+        end
       end
     end
 


### PR DESCRIPTION
We now support querying with a locale option in Sequel, like this:

```ruby
Post.i18n.where(title: "foo", locale: :ja).select_all("posts").all
#=> SELECT * FROM posts ...
```

so we should have tests to ensure this is working. Note that like with ActiveRecord, the `locale` value here cannot be an array (but this will be supported in the future).