### PR TITLE
Support block query format with Sequel

### DIFF
--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -91,10 +91,18 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
             nils, ops = boolean.args.partition(&:nil?)
             if hash = visit(ops, locale)
               join_type = nils.empty? ? :inner : :left_outer
+              # TODO: simplify to hash.transform_values { join_type } when
+              #   support for Ruby 2.3 is deprecated
               Hash[hash.keys.map { |key| [key, join_type] }]
             else
               {}
             end
+          elsif boolean.op == :OR
+            hash = boolean.args.map { |op| visit(op, locale) }.
+              compact.inject(&:merge)
+            # TODO: simplify to hash.transform_values { :left_outer } when
+            #   support for Ruby 2.3 is deprecated
+            Hash[hash.keys.map { |key| [key, :left_outer] }]
           else
             visit(boolean.args, locale)
           end

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -110,6 +110,8 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
             boolean.args.any? { |op| visit(op, locale) } && :inner
           elsif boolean.op == :IS
             boolean.args.any?(&:nil?) && :left_outer
+          elsif boolean.op == :OR
+            boolean.args.any? { |op| visit(op, locale) } && :left_outer
           else
             visit(boolean.args, locale)
           end

--- a/lib/mobility/plugins/sequel/query.rb
+++ b/lib/mobility/plugins/sequel/query.rb
@@ -53,7 +53,12 @@ See ActiveRecord::Query plugin.
               row = new(klass, locale)
               query = block.arity.zero? ? row.instance_eval(&block) : block.call(row)
 
-              prepare_datasets(klass.dataset, row.__backends, locale, query).where(query)
+              if ::Sequel::Dataset === query
+                predicates = query.opts[:where]
+                prepare_datasets(query, row.__backends, locale, predicates)
+              else
+                prepare_datasets(klass.dataset, row.__backends, locale, query).where(query)
+              end
             end
 
             private

--- a/spec/sequel/schema.rb
+++ b/spec/sequel/schema.rb
@@ -104,7 +104,7 @@ module Mobility
             String      :author_pt_br
             String      :author_ru
             TrueClass   :published
-            Integer     :post_id
+            Integer     :article_id
             DateTime    :created_at, allow_null: false
             DateTime    :updated_at, allow_null: false
           end


### PR DESCRIPTION
This brings Sequel support almost up to the same level as ActiveRecord (except missing support for `order` in the Query plugin, which I may try to add before releasing 0.8.0).