### PR TITLE
Do not skip generator on :revoke behavior

### DIFF
--- a/lib/rails/generators/mobility/backend_generators/base.rb
+++ b/lib/rails/generators/mobility/backend_generators/base.rb
@@ -9,7 +9,7 @@ module Mobility
       include ::Mobility::ActiveRecordMigrationCompatibility
 
       def create_migration_file
-        if self.class.migration_exists?(migration_dir, migration_file)
+        if behavior == :invoke && self.class.migration_exists?(migration_dir, migration_file)
           ::Kernel.warn "Migration already exists: #{migration_file}"
         else
           migration_template "#{template}.rb", "db/migrate/#{migration_file}.rb"

--- a/lib/rails/generators/mobility/install_generator.rb
+++ b/lib/rails/generators/mobility/install_generator.rb
@@ -35,7 +35,7 @@ module Mobility
 
     def add_mobility_migration(template)
       migration_dir = File.expand_path("db/migrate")
-      if self.class.migration_exists?(migration_dir, template)
+      if behavior == :invoke && self.class.migration_exists?(migration_dir, template)
         ::Kernel.warn "Migration already exists: #{template}"
       else
         migration_template "#{template}.rb", "db/migrate/#{template}.rb"


### PR DESCRIPTION
This PR fixes the rails generators when run in reverse, that is with `rails destroy`, so they remove the corresponding generated migrations.

I didn't add tests because I'm not sure if this behavior is intented, maybe to be cautious about what you remove? Let me know if you want me to add them. Also, thanks for your amazing work with this gem and globalize ^^