### PR TITLE
Mention required ruby version change in 0.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   [#268](https://github.com/shioyama/mobility/pull/267))
 * Default locale to Mobility.locale in apply_scope
   ([#263](https://github.com/shioyama/mobility/pull/263))
+* Require Ruby version 2.3.7 or greater
+  ([#242](https://github.com/shioyama/mobility/pull/242))
 
 ### 0.7.6 (July 6, 2018)
 * Sequel pg_hash require hash_initializer


### PR DESCRIPTION
We're still running on a bit outdated Ruby version, so the required ruby version change in https://github.com/shioyama/mobility/pull/242 was an unfortunate surprise to us given that it was not mentioned in the changelog.

So here's an update to the changelog so others won't get bitten by the same change :smile:

Looks like we should upgrade Ruby quite soon 😅 