### PR TITLE
Default to OUTER JOIN for Table, KeyValue backends

### DIFF
--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -143,7 +143,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
 
         def visit_Mobility_Arel_Attribute(object)
           if object.backend_class == backend_class && object.locale == locale
-            { object.attribute_name => INNER_JOIN }
+            { object.attribute_name => OUTER_JOIN }
           end
         end
 

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -233,7 +233,7 @@ columns to that table.
           # join when required. Use options[:table_name] here since we don't
           # know if the other backend has a +table_name+ option accessor.
           (backend_class.table_name == object.backend_class.options[:table_name]) &&
-            (locale == object.locale) && INNER_JOIN
+            (locale == object.locale) && OUTER_JOIN || nil
         end
       end
 

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -439,6 +439,15 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
           end
         end
       end
+
+      describe ".order" do
+        it "users OUTER JOIN" do
+          article1 = Article.create(title: "foo")
+          article2 = Article.create
+
+          expect(Article.i18n.order(:title)).to match_array([article1, article2])
+        end
+      end
     end
 
     describe "Model.i18n.find_by_<translated attribute>" do

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -362,6 +362,15 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
         end
       end
     end
+
+    describe ".order" do
+      it "users OUTER JOIN" do
+        article1 = Article.create(title: "foo")
+        article2 = Article.create
+
+        expect(Article.i18n.order(:title)).to match_array([article1, article2])
+      end
+    end
   end
 
   describe "Model.i18n.find_by_<translated attribute>" do


### PR DESCRIPTION
Currently we default to an INNER join for the Table and KeyValue backends, although this never has any impact when using `where` since we always have equality predicates which don't fall through to the default. But for `order`, we currently use INNER join, which means that:

```ruby
Post.i18n.order(:title)
```

will only return posts that have a non-NULL `title` column. This seems counter-intuitive to me, so I'm changing the behaviour to use an OUTER join here so that all posts will be returned, even if they do not have a translation (in this case `title` will be ordered as if it was `nil`).

I also found a small bug where `&&` was returning `false` instead of `nil`, fixed here.