### PR TITLE
Add support for pluck on translated attributes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,9 @@
 ---
+version: "2"
+checks:
+  method-complexity:
+    config:
+      threshold: 6
 engines:
   duplication:
     enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .ruby-version
 .byebug_history
 Guardfile
+*.gem

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -109,6 +109,22 @@ enabled for any one attribute on the model.
             end
           end
 
+          if ::ActiveRecord::VERSION::STRING >= '5.0'
+            def pluck(*attrs)
+              return super unless attrs.any?(&@klass.method(:mobility_attribute?))
+
+              keys = attrs.dup
+
+              base = keys.each_with_index.inject(self) do |query, (key, index)|
+                next query unless @klass.mobility_attribute?(key)
+                keys[index] = backend_node(key)
+                @klass.mobility_backend_class(key).apply_scope(query, backend_node(key))
+              end
+
+              base.pluck(*keys)
+            end
+          end
+
           # Return backend node for attribute name.
           # @param [Symbol,String] name Name of attribute
           # @param [Symbol] locale Locale


### PR DESCRIPTION
Ref: #275

@wenderjean This is an implementation of just `pluck`. As it turns out `select` is a little more tricky to do, so I'll leave that to do separately.

`group` should I think also be simple.