### PR TITLE
Only apply plugins if options key is set

### DIFF
--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -156,8 +156,10 @@ with other backends.
       @backend_class = get_backend_class(backend_name).for(model_class).with_options(options)
 
       Mobility.plugins.each do |name|
-        plugin = get_plugin_class(name)
-        plugin.apply(self, options[name])
+        if options.has_key?(name)
+          plugin = get_plugin_class(name)
+          plugin.apply(self, options[name])
+        end
       end
 
       each do |name|

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -106,9 +106,12 @@ default_fallbacks= will be removed in the next major version of Mobility.
       @fallbacks_generator = lambda { |fallbacks| Mobility::Fallbacks.build(fallbacks) }
       @default_accessor_locales = lambda { Mobility.available_locales }
       @default_options = Options[{
-        cache:    true,
-        presence: true,
-        query:    true
+        cache:     true,
+        presence:  true,
+        query:     true,
+        # A nil key here includes the plugin so it can be optionally turned on
+        # when reading an attribute using accessor options.
+        fallbacks: nil
       }]
       @plugins = %i[
         query

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -108,8 +108,7 @@ default_fallbacks= will be removed in the next major version of Mobility.
       @default_options = Options[{
         cache:    true,
         presence: true,
-        query:    true,
-        default:  Plugins::OPTION_UNSET
+        query:    true
       }]
       @plugins = %i[
         query

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -31,6 +31,5 @@ option value. For examples, see classes under the {Mobility::Plugins} namespace.
 
 =end
   module Plugins
-    OPTION_UNSET = Object.new
   end
 end

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -6,8 +6,7 @@ module Mobility
 
 Defines value or proc to fall through to if return value from getter would
 otherwise be nil. This plugin is disabled by default but will be enabled if any
-value (other than +Mobility::Plugins::OPTION_UNSET+) is passed as the +default+
-option key.
+value is passed as the +default+ option key.
 
 If default is a +Proc+, it will be called with the context of the model, and
 passed arguments:
@@ -65,9 +64,9 @@ The proc can accept zero to three arguments (see examples below)
     module Default
       # Applies default plugin to attributes.
       # @param [Attributes] attributes
-      # @param [Object] option
-      def self.apply(attributes, option)
-        attributes.backend_class.include(self) unless option == Plugins::OPTION_UNSET
+      # @param [Object] _option Ignored and plugin always applied.
+      def self.apply(attributes, _option)
+        attributes.backend_class.include(self)
       end
 
       # Generate a default value for given parameters.


### PR DESCRIPTION
This is so much simpler than how it is currently done.

Have to give credit where credit is due:

http://www.virtuouscode.com/2011/05/30/null-objects-and-falsiness/

> If we’re trying to coerce a homemade object into acting falsey, we may be chasing a vain ideal. With a little thought, it is almost always possible to transform code from typecasing conditionals to duck-typed polymorphic method calls. All we have to do is remember to represent the special cases as objects in their own right, whether that be a Null Object or something else.

This made me realize we shouldn't be checking for special objects in the plugins, but instead simply checking if the key is present before even applying the plugins, which is much cleaner.