### PR TITLE
Add virtual (unpersisted) Hash backend

### DIFF
--- a/lib/mobility/arel/nodes/pg_ops.rb
+++ b/lib/mobility/arel/nodes/pg_ops.rb
@@ -49,7 +49,7 @@ module Mobility
           case other
           when NilClass
             to_question.not
-          when Integer, Array, Hash
+          when Integer, Array, ::Hash
             to_dash_arrow.eq other.to_json
           when Jsonb
             to_dash_arrow.eq other.to_dash_arrow

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -255,7 +255,7 @@ EOL
       # @return [Hash] Hash of attribute names and backend instances
       # @api private
       def mobility_backends
-        @mobility_backends ||= Hash.new do |hash, name|
+        @mobility_backends ||= ::Hash.new do |hash, name|
           next hash[name.to_sym] if String === name
           hash[name] = self.class.mobility_backend_class(name).new(self, name.to_s)
         end
@@ -300,7 +300,7 @@ EOL
         @backends[name.to_sym]
       end
 
-      class BackendsCache < Hash
+      class BackendsCache < ::Hash
         def initialize(klass)
           # Preload backend mapping
           klass.mobility_modules.each do |mod|

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -66,9 +66,9 @@ On top of this, a backend will normally:
     # @!macro [new] backend_constructor
     #   @param model Model on which backend is defined
     #   @param [String] attribute Backend attribute
-    def initialize(model, attribute)
-      @model = model
-      @attribute = attribute
+    def initialize(*args)
+      @model = args[0]
+      @attribute = args[1]
     end
 
     # @!macro [new] backend_reader

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -114,7 +114,7 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
 
       class Coder
         def self.dump(obj)
-          if obj.is_a? Hash
+          if obj.is_a? ::Hash
             obj.inject({}) do |translations, (locale, value)|
               value.each do |k, v|
                 (translations[locale] ||= {})[k] = v if v.present?

--- a/lib/mobility/backends/active_record/pg_hash.rb
+++ b/lib/mobility/backends/active_record/pg_hash.rb
@@ -30,7 +30,7 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
 
         class Coder
           def self.dump(obj)
-            if obj.is_a? Hash
+            if obj.is_a? ::Hash
               obj.inject({}) do |translations, (locale, value)|
                 translations[locale] = value if value.present?
                 translations

--- a/lib/mobility/backends/hash.rb
+++ b/lib/mobility/backends/hash.rb
@@ -1,0 +1,37 @@
+module Mobility
+  module Backends
+=begin
+
+Backend which stores translations in an in-memory hash.
+
+=end
+    class Hash
+      include Backend
+
+      # @!group Backend Accessors
+      # @!macro backend_reader
+      # @return [Object]
+      def read(locale, _ = {})
+        translations[locale]
+      end
+
+      # @!macro backend_writer
+      # @return [Object]
+      def write(locale, value, _ = {})
+        translations[locale] = value
+      end
+      # @!endgroup
+
+      # @!macro backend_iterator
+      def each_locale
+        translations.each { |l, _| yield l }
+      end
+
+      private
+
+      def translations
+        @translations ||= {}
+      end
+    end
+  end
+end

--- a/lib/mobility/backends/sequel/jsonb.rb
+++ b/lib/mobility/backends/sequel/jsonb.rb
@@ -55,7 +55,7 @@ Implements the {Mobility::Backends::Jsonb} backend for Sequel models.
 
           def =~(other)
             case other
-            when Integer, Hash
+            when Integer, ::Hash
               to_dash_arrow =~ other.to_json
             when NilClass
               ~to_question

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -93,7 +93,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
               join_type = nils.empty? ? :inner : :left_outer
               # TODO: simplify to hash.transform_values { join_type } when
               #   support for Ruby 2.3 is deprecated
-              Hash[hash.keys.map { |key| [key, join_type] }]
+              ::Hash[hash.keys.map { |key| [key, join_type] }]
             else
               {}
             end
@@ -101,13 +101,13 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
             hash = visit(boolean.args, locale)
             # TODO: simplify to hash.transform_values { :inner } when
             #   support for Ruby 2.3 is deprecated
-            Hash[hash.keys.map { |key| [key, :inner] }]
+            ::Hash[hash.keys.map { |key| [key, :inner] }]
           elsif boolean.op == :OR
             hash = boolean.args.map { |op| visit(op, locale) }.
               compact.inject(&:merge)
             # TODO: simplify to hash.transform_values { :left_outer } when
             #   support for Ruby 2.3 is deprecated
-            Hash[hash.keys.map { |key| [key, :left_outer] }]
+            ::Hash[hash.keys.map { |key| [key, :left_outer] }]
           else
             visit(boolean.args, locale)
           end

--- a/lib/mobility/backends/serialized.rb
+++ b/lib/mobility/backends/serialized.rb
@@ -40,7 +40,7 @@ Format for serialization. Either +:yaml+ (default) or +:json+.
         def serializer_for(format)
           lambda do |obj|
             return if obj.nil?
-            if obj.is_a? Hash
+            if obj.is_a? ::Hash
               obj = obj.inject({}) do |translations, (locale, value)|
                 translations[locale] = value.to_s if Util.present?(value)
                 translations

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -126,7 +126,7 @@ default_fallbacks= will be removed in the next major version of Mobility.
 
     class ReservedOptionKey < Exception; end
 
-    class Options < Hash
+    class Options < ::Hash
       def []=(key, _)
         if RESERVED_OPTION_KEYS.include?(key)
           raise Configuration::ReservedOptionKey, "Default options may not contain the following reserved key: #{key}"

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -121,7 +121,7 @@ enabled for any one attribute on the model.
             case opts
             when Symbol, String
               @klass.mobility_attribute?(opts) ? order({ opts => :asc }, *rest) : super
-            when Hash
+            when ::Hash
               i18n_keys, keys = opts.keys.partition(&@klass.method(:mobility_attribute?))
               return super if i18n_keys.empty?
 
@@ -180,7 +180,7 @@ enabled for any one attribute on the model.
 
             class << self
               def build(scope, where_opts, invert: false, &block)
-                return yield unless Hash === where_opts
+                return yield unless ::Hash === where_opts
 
                 opts = where_opts.with_indifferent_access
                 locale = opts.delete(:locale) || Mobility.locale

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -152,12 +152,12 @@ the current locale was +nil+.
       end
 
       def convert_option_to_fallbacks(option)
-        if option.is_a?(Hash)
+        if option.is_a?(::Hash)
           Mobility.new_fallbacks(option)
         elsif option == true
           Mobility.new_fallbacks
         else
-          Hash.new { [] }
+          ::Hash.new { [] }
         end
       end
     end

--- a/lib/mobility/plugins/sequel/query.rb
+++ b/lib/mobility/plugins/sequel/query.rb
@@ -95,7 +95,7 @@ See ActiveRecord::Query plugin.
 
           class << self
             def build(dataset, query_method, query_conds, &block)
-              return yield unless Hash === query_conds.first
+              return yield unless ::Hash === query_conds.first
 
               cond = query_conds.first.dup
               locale = cond.delete(:locale) || Mobility.locale

--- a/spec/mobility/backends/hash_spec.rb
+++ b/spec/mobility/backends/hash_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+require "mobility/backends/hash"
+
+describe Mobility::Backends::Hash do
+  describe "#read/#write" do
+    it "returns value for locale key" do
+      backend = described_class.new
+      expect(backend.read(:ja)).to eq(nil)
+      expect(backend.read(:en)).to eq(nil)
+      backend.write(:ja, "アアア")
+      expect(backend.read(:ja)).to eq("アアア")
+      expect(backend.read(:en)).to eq(nil)
+      backend.write(:en, "foo")
+      expect(backend.read(:ja)).to eq("アアア")
+      expect(backend.read(:en)).to eq("foo")
+    end
+  end
+
+  describe "#each_locale" do
+    it "returns keys of hash to block" do
+      backend = described_class.new
+      backend.write(:ja, "アアア")
+      backend.write(:en, "aaa")
+      expect { |b| backend.each_locale(&b) }.to yield_successive_args(:ja, :en)
+    end
+  end
+
+  context "included in model" do
+    let(:model_class) do
+      klass = Class.new
+      klass.extend Mobility
+      klass.translates :name, backend: :hash
+      klass
+    end
+
+    it "defines reader and writer methods" do
+      instance = model_class.new
+      Mobility.with_locale(:en) { instance.name = "foo" }
+      Mobility.with_locale(:ja) { instance.name = "アアア" }
+      expect(instance.name(locale: :en)).to eq("foo")
+      expect(instance.name(locale: :ja)).to eq("アアア")
+
+      expect(instance.name_backend.locales).to match_array([:en, :ja])
+    end
+  end
+end


### PR DESCRIPTION
I had a need for a non-persisted translated model and realized there was no backend for this use case, although many of Mobility's plugins (e.g. fallbacks) work with unpersisted models. So I created a minimal one called the Hash backend, which as its name implies just uses a hash for translations (similar to JSON backends).