### PR TITLE
Check rails i18n locales when enforcing available locales

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -228,7 +228,7 @@ module Mobility
     def enforce_available_locales!(locale)
       # TODO: Remove conditional in v1.0
       if I18n.enforce_available_locales
-        raise Mobility::InvalidLocale.new(locale) unless (I18n.locale_available?(locale) || locale.nil?)
+        raise Mobility::InvalidLocale.new(locale) unless (locale.nil? || available_locales.include?(locale.to_sym))
       else
         warn <<-EOL
 WARNING: You called Mobility.enforce_available_locales! in a situation where


### PR DESCRIPTION
This is a subtle edge-case, but I18n.locale_available? will not actually check that the current locale is included in *rails-defined* locales.  This may cause problems, for example, if you set available locales in Rails and then try to use Mobility in an initializer, since Rails may not yet have set I18n.available_locales.

Anybody else notice this issue?