### PR TITLE
[WIP] Add regression spec for issue #258

### DIFF
--- a/spec/mobility/active_record_spec.rb
+++ b/spec/mobility/active_record_spec.rb
@@ -15,4 +15,14 @@ describe Mobility::ActiveRecord, orm: :active_record do
       expect(Article.new.translated_attribute_names).to eq(["foo"])
     end
   end
+
+  # regression spec for https://github.com/shioyama/mobility/issues/258
+  describe "name error" do
+    it "resolves ActiveRecord to ::ActiveRecord in model class" do
+      aggregate_failures do
+        expect(Post.instance_eval("ActiveRecord")).to eq(::ActiveRecord)
+        expect(Post.class_eval("ActiveRecord")).to eq(::ActiveRecord)
+      end
+    end
+  end
 end if Mobility::Loaded::ActiveRecord


### PR DESCRIPTION
Test for #258. Demonstrates the issue.

It seems that the names for any constants under `Mobility` need to be chosen carefully to not potentially conflict with other gems, due to the fact that we `extend Mobility`.

I need to think about this a bit more, since it would mean a shake up in a lot of constants (although not the backends or plugins themselves I believe, since they are under `Mobility::Backends`, and `Mobility::Plugins`, unless we rename those constants too...).

If anyone has any experience with this kind of lookup issue I'd be keen to get suggestions on this.