### PR TITLE
Remove block handling from with_options

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -168,12 +168,11 @@ On top of this, a backend will normally:
       #   being changed.
       # @param [Hash] options
       # @return [Class] backend subclass
-      def with_options(options = {}, &block)
+      def with_options(options = {})
         configure(options) if respond_to?(:configure)
         options.freeze
         Class.new(self) do
           @options = options
-          class_eval(&block) if block_given?
         end
       end
 

--- a/spec/mobility/plugins/default_spec.rb
+++ b/spec/mobility/plugins/default_spec.rb
@@ -8,7 +8,8 @@ describe Mobility::Plugins::Default do
     let(:backend) { backend_class.new("model", "title") }
     let(:backend_class) do
       backend_double_ = backend_double
-      backend_class = Mobility::Backends::Null.with_options(default: default) do
+      backend_class = Mobility::Backends::Null.with_options(default: default)
+      backend_class.class_eval do
         define_method :read do |*args|
           backend_double_.read(*args)
         end

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -6,7 +6,8 @@ describe Mobility::Plugins::Fallbacks do
     let(:backend_class) do
       backend_class = stub_const 'MyBackend', Class.new
       backend_class.include(Mobility::Backend)
-      backend_subclass = backend_class.with_options(fallbacks: fallbacks) do
+      backend_subclass = backend_class.with_options(fallbacks: fallbacks)
+      backend_subclass.class_eval do
         def read(locale, **options)
           Mobility.enforce_available_locales!(locale)
           return "bar" if options[:bar]


### PR DESCRIPTION
This isn't actually used anywhere except in specs.