### PR TITLE
Fix destroying empty translations in AR table backend

### DIFF
--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -299,7 +299,8 @@ columns to that table.
 
         # Destroys translations with all empty values
         def destroy_empty_translations(required_attributes)
-          each { |t| destroy(t) if required_attributes.map(&t.method(:send)).none? }
+          empty_translations = select{ |t| required_attributes.map(&t.method(:send)).none? }
+          destroy(empty_translations) if empty_translations.any?
         end
       end
     end

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -87,8 +87,11 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
         Mobility.locale = :ja
         article.title
 
+        Mobility.locale = :fr
+        article.title
+
         aggregate_failures do
-          expect(article.send(association_name).size).to eq(2)
+          expect(article.send(association_name).size).to eq(3)
           article.save
           expect(article.title).to be_nil
           expect(article.reload.send(association_name).size).to eq(1)


### PR DESCRIPTION
Destroying records during `each` messes up the loop internal pointer, so when there is more than one empty translation some of them are not destroyed.