### PR TITLE
Handle case when attribute name passed to `has_attribute` is not a string

### DIFF
--- a/lib/mobility/plugins/active_record/dirty.rb
+++ b/lib/mobility/plugins/active_record/dirty.rb
@@ -47,7 +47,7 @@ AR::Dirty plugin adds support for the following persistence-specific methods
               method_name_regex = /\A(#{names.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
               has_attribute = Module.new do
                 define_method :has_attribute? do |attr_name|
-                  super(attr_name) || !!method_name_regex.match(attr_name)
+                  super(attr_name) || (String === attr_name && !!method_name_regex.match(attr_name))
                 end
               end
               model_class.extend has_attribute

--- a/spec/mobility/backends/active_record/hstore_spec.rb
+++ b/spec/mobility/backends/active_record/hstore_spec.rb
@@ -46,7 +46,7 @@ describe "Mobility::Backends::ActiveRecord::Hstore", orm: :active_record, db: :p
   context "with dirty plugin applied" do
     let(:backend) { post.mobility_backends[:title] }
 
-    before { HstorePost.translates :title, :content, backend: :hstore, **default_options }
+    before { HstorePost.translates :title, :content, backend: :hstore, **default_options, dirty: true }
     let(:post) { HstorePost.new }
 
     include_accessor_examples 'HstorePost'

--- a/spec/mobility/backends/active_record/json_spec.rb
+++ b/spec/mobility/backends/active_record/json_spec.rb
@@ -45,7 +45,7 @@ describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: :pos
   context "with dirty plugin applied" do
     let(:backend) { post.mobility_backends[:title] }
 
-    before { JsonPost.translates :title, :content, backend: :json, **default_options }
+    before { JsonPost.translates :title, :content, backend: :json, **default_options, dirty: true }
     let(:post) { JsonPost.new }
 
     include_accessor_examples 'JsonPost'

--- a/spec/mobility/backends/active_record/jsonb_spec.rb
+++ b/spec/mobility/backends/active_record/jsonb_spec.rb
@@ -95,5 +95,8 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
 
     include_accessor_examples 'JsonbPost'
     include_serialization_examples 'JsonbPost', column_affix: column_affix
+
+    # regression for https://github.com/shioyama/mobility/issues/308
+    include_querying_examples 'JsonbPost' if ENV['RAILS_VERSION'] == '5.1'
   end
 end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/backends/active_record/jsonb_spec.rb
+++ b/spec/mobility/backends/active_record/jsonb_spec.rb
@@ -90,7 +90,7 @@ describe "Mobility::Backends::ActiveRecord::Jsonb", orm: :active_record, db: :po
   context "with dirty plugin applied" do
     let(:backend) { post.mobility_backends[:title] }
 
-    before { JsonbPost.translates :title, :content, backend: :jsonb, **default_options }
+    before { JsonbPost.translates :title, :content, backend: :jsonb, **default_options, dirty: true }
     let(:post) { JsonbPost.new }
 
     include_accessor_examples 'JsonbPost'


### PR DESCRIPTION
This only matters for ActiveRecord 5.1 with Dirty enabled.

Fixes #308.