### PR TITLE
Move query_method from global configuration to plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ with the lines:
 Mobility.configure do |config|
   config.default_backend = :key_value
   config.accessor_method = :translates
-  config.query_method    = :i18n
 end
 ```
 
@@ -115,7 +114,6 @@ unnecessary and will be ignored if you are using a different backend).
  Mobility.configure do |config|
    config.default_backend = :key_value
    config.accessor_method = :translates
-   config.query_method    = :i18n
 +  config.default_options[:dirty] = true
 +  config.default_options[:type]  = :string
 end

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -158,9 +158,6 @@ module Mobility
     # (see Mobility::Configuration#accessor_method)
     # @!method accessor_method
     #
-    # (see Mobility::Configuration#query_method)
-    # @!method query_method
-
     # (see Mobility::Configuration#new_fallbacks)
     # @!method new_fallbacks
 
@@ -175,7 +172,7 @@ module Mobility
     #
     # (see Mobility::Configuration#default_accessor_locales)
     # @!method default_accessor_locales
-    %w[accessor_method query_method default_backend default_options plugins default_accessor_locales].each do |method_name|
+    %w[accessor_method default_backend default_options plugins default_accessor_locales].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -13,6 +13,26 @@ Stores shared Mobility configuration referenced by all backends.
     # @return [Symbol]
     attr_accessor :accessor_method
 
+    def query_method=(method_name)
+      error_msg = <<-EOL
+query_method is no longer a global configuration option. The value can now be
+set in the value of options[:query_method].
+EOL
+      if method_name == :i18n
+        raise ArgumentError, <<-EOL
+#{error_msg}
+
+You are currently passing :i18n which is the default, so simply removing the line:
+
+   config.query_method = :i18n
+
+from your configuration will fix this exception.
+EOL
+      else
+        raise ArgumentError, error_msg
+      end
+    end
+
     # Default set of options. These will be merged with any backend options
     # when defining translated attributes (with +translates+). Default options
     # may not include the keys 'backend' or 'model_class'.

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -13,10 +13,6 @@ Stores shared Mobility configuration referenced by all backends.
     # @return [Symbol]
     attr_accessor :accessor_method
 
-    # Name of query scope/dataset method (defaults to +i18n+)
-    # @return [Symbol]
-    attr_accessor :query_method
-
     # Default set of options. These will be merged with any backend options
     # when defining translated attributes (with +translates+). Default options
     # may not include the keys 'backend' or 'model_class'.
@@ -68,12 +64,12 @@ Stores shared Mobility configuration referenced by all backends.
 
     def initialize
       @accessor_method = :translates
-      @query_method = :i18n
       @fallbacks_generator = lambda { |fallbacks| Mobility::Fallbacks.build(fallbacks) }
       @default_accessor_locales = lambda { Mobility.available_locales }
       @default_options = Options[{
         cache:     true,
         presence:  true,
+        # Override with a symbol to define a different query method name.
         query:     true,
         # A nil key here includes the plugin so it can be optionally turned on
         # when reading an attribute using accessor options.

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -16,11 +16,11 @@ enabled for any one attribute on the model.
     module ActiveRecord
       module Query
         class << self
-          def apply(names, model_class, backend_class)
+          def apply(names, model_class, backend_class, query_method)
             model_class.class_eval do
               extend QueryMethod
               extend FindByMethods.new(*names)
-              singleton_class.send :alias_method, Mobility.query_method, :__mobility_query_scope__
+              singleton_class.send :alias_method, query_method, :__mobility_query_scope__
             end
             backend_class.include self
           end

--- a/lib/mobility/plugins/query.rb
+++ b/lib/mobility/plugins/query.rb
@@ -11,20 +11,21 @@ module Mobility
 
       # Applies query plugin to attributes.
       included_hook do |model_class, backend_class|
-        if options[:query]
-          include_query_module(model_class, backend_class)
+        if query_method = options[:query]
+          query_method = :i18n if query_method == true
+          include_query_module(model_class, backend_class, query_method)
         end
       end
 
       private
 
-      def include_query_module(model_class, backend_class)
+      def include_query_module(model_class, backend_class, query_method)
         if Loaded::ActiveRecord && model_class < ::ActiveRecord::Base
           require "mobility/plugins/active_record/query"
-          ActiveRecord::Query.apply(names, model_class, backend_class)
+          ActiveRecord::Query.apply(names, model_class, backend_class, query_method)
         elsif Loaded::Sequel && model_class < ::Sequel::Model
           require "mobility/plugins/sequel/query"
-          Sequel::Query.apply(model_class)
+          Sequel::Query.apply(model_class, query_method)
         end
       end
     end

--- a/lib/mobility/plugins/sequel/query.rb
+++ b/lib/mobility/plugins/sequel/query.rb
@@ -9,10 +9,10 @@ See ActiveRecord::Query plugin.
     module Sequel
       module Query
         class << self
-          def apply(model_class)
+          def apply(model_class, query_method)
             model_class.class_eval do
               extend QueryMethod
-              singleton_class.send :alias_method, Mobility.query_method, :__mobility_query_dataset__
+              singleton_class.send :alias_method, query_method, :__mobility_query_dataset__
             end
           end
         end

--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -9,11 +9,6 @@ Mobility.configure do |config|
   # translation gem which uses the same method name.
   config.accessor_method = :translates
 
-  # To query on translated attributes, you need to append a scope to your
-  # model. The name of this scope is +i18n+ by default, but this can be changed
-  # to something else.
-  config.query_method    = :i18n
-
   # Uncomment and remove (or add) items to (from) this list to completely
   # disable/enable plugins globally (so they cannot be used and are never even
   # loaded). Note that if you remove an item from the list, you will not be

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -23,7 +23,6 @@ describe Mobility::InstallGenerator, type: :generator, orm: :active_record do
               contains "Mobility.configure do |config|"
               contains "config.default_backend = :key_value"
               contains "config.accessor_method = :translates"
-              contains "config.query_method    = :i18n"
             end
           end
         end

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -29,7 +29,7 @@ describe "Mobility::Plugins::ActiveRecord::Query", orm: :active_record do
   describe "query method" do
     # NOTE: __mobility_query_scope__ is a public method for convenience, but is
     # intended for internal use. For application code, use i18n or whatever you
-    # define in Mobility.query_method instead.
+    # define in options[:query].
     it "creates a __mobility_query_scope__ method" do
       stub_const 'Article', Class.new(ActiveRecord::Base)
       Article.class_eval do


### PR DESCRIPTION
Aiming to remove all plugin stuff from `Mobility::Configuration` for release of 1.0.