### PR TITLE
Fix Dirty plugin with Rails 6 (0-8-stable branch)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,8 @@ checks:
   method-complexity:
     config:
       threshold: 6
+  method-lines:
+    enabled: false
 engines:
   duplication:
     enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.4.5
-  - 2.5.6
-  - 2.6.4
+  - 2.4
+  - 2.5
+  - 2.6
 env:
   - DB=postgres ORM=active_record RAILS_VERSION=4.2
   - DB=mysql ORM=active_record RAILS_VERSION=4.2
@@ -36,11 +36,11 @@ matrix:
     - env: DB=mysql ORM=active_record RAILS_VERSION=latest
     - env: DB=sqlite3 ORM=active_record RAILS_VERSION=latest
   exclude:
-    - rvm: 2.4.5
+    - rvm: 2.4
       env: DB=postgres ORM=active_record RAILS_VERSION=latest
-    - rvm: 2.4.5
+    - rvm: 2.4
       env: DB=mysql ORM=active_record RAILS_VERSION=latest
-    - rvm: 2.4.5
+    - rvm: 2.4
       env: DB=sqlite3 ORM=active_record RAILS_VERSION=latest
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ env:
   - DB=postgres ORM=active_record RAILS_VERSION=5.2
   - DB=mysql ORM=active_record RAILS_VERSION=5.2
   - DB=sqlite3 ORM=active_record RAILS_VERSION=5.2
-  - DB=postgres ORM=active_record RAILS_VERSION=latest
-  - DB=mysql ORM=active_record RAILS_VERSION=latest
-  - DB=sqlite3 ORM=active_record RAILS_VERSION=latest
+  - DB=postgres ORM=active_record RAILS_VERSION=6.0
+  - DB=mysql ORM=active_record RAILS_VERSION=6.0
+  - DB=sqlite3 ORM=active_record RAILS_VERSION=6.0
   - DB=postgres ORM=sequel SEQUEL_VERSION=4
   - DB=mysql ORM=sequel SEQUEL_VERSION=4
   - DB=sqlite3 ORM=sequel SEQUEL_VERSION=4
@@ -31,17 +31,13 @@ env:
   - DB=sqlite3 ORM= I18N_FALLBACKS=true
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: DB=postgres ORM=active_record RAILS_VERSION=latest
-    - env: DB=mysql ORM=active_record RAILS_VERSION=latest
-    - env: DB=sqlite3 ORM=active_record RAILS_VERSION=latest
   exclude:
     - rvm: 2.4
-      env: DB=postgres ORM=active_record RAILS_VERSION=latest
+      env: DB=postgres ORM=active_record RAILS_VERSION=6.0
     - rvm: 2.4
-      env: DB=mysql ORM=active_record RAILS_VERSION=latest
+      env: DB=mysql ORM=active_record RAILS_VERSION=6.0
     - rvm: 2.4
-      env: DB=sqlite3 ORM=active_record RAILS_VERSION=latest
+      env: DB=sqlite3 ORM=active_record RAILS_VERSION=6.0
 
 before_script:
   - bundle exec rake db:create db:up

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ group :development, :test do
       gem 'activerecord', '>= 4.2.6', '< 5.0'
     elsif ENV['RAILS_VERSION'] == '5.1'
       gem 'activerecord', '>= 5.1', '< 5.2'
-    elsif ENV['RAILS_VERSION'] == 'latest'
-      gem 'activerecord', '>= 6.0.0.beta1'
-    else # Default is Rails 5.2
+    elsif ENV['RAILS_VERSION'] == '5.2'
       gem 'activerecord', '>= 5.2.0', '< 5.3'
       gem 'railties', '>= 5.2.0.rc2', '< 5.3'
+    else # Default is Rails 6.0
+      gem 'activerecord', '>= 6.0.0', '< 6.1'
     end
     gem "generator_spec", '~> 0.9.4'
   elsif ENV['ORM'] == 'sequel'
@@ -31,7 +31,11 @@ group :development, :test do
   platforms :ruby do
     gem 'guard-rspec'
     gem 'pry-byebug'
-    gem 'sqlite3', '~> 1.3.6'
+    if ENV['ORM'] == 'active_record' && ENV['RAILS_VERSION'] < '5.2'
+      gem 'sqlite3', '~> 1.3.13'
+    else
+      gem 'sqlite3', '~> 1.4.1'
+    end
     gem 'mysql2', '~> 0.4.9'
     gem 'pg', '< 1.0'
   end

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -15,7 +15,6 @@ following methods:
 - +title_will_change!+
 - +title_previously_changed?+
 - +title_previous_change+
-- +title_previous_was+
 - +restore_title!+
 
 The following methods are also patched to work with translated attributes:
@@ -39,9 +38,6 @@ The following methods are also patched to work with translated attributes:
 
             if ::ActiveModel::VERSION::STRING >= '5.0' # methods added in Rails 5.0
               define_ar_5_0_dirty_methods(attribute_names)
-              if ::ActiveModel::VERSION::STRING >= '5.1' # methods added in Rails 5.1
-                define_ar_6_0_dirty_methods(attribute_names)
-              end
             end
           end
 
@@ -103,16 +99,6 @@ The following methods are also patched to work with translated attributes:
 
               define_method "#{name}_previous_change" do
                 mutations_before_last_save_from_mobility.change_to_attribute(m.append_locale(name))
-              end
-            end
-          end
-
-          def define_ar_6_0_dirty_methods(attribute_names)
-            m = self
-
-            attribute_names.each do |name|
-              define_method "#{name}_previously_was" do
-                mutations_before_last_save_from_mobility.original_value(m.append_locale(name))
               end
             end
           end

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -15,82 +15,249 @@ following methods:
 - +title_will_change!+
 - +title_previously_changed?+
 - +title_previous_change+
+- +title_previous_was+
 - +restore_title!+
 
-In addition, the private method +restore_attribute!+ will also restore the
-value of the translated attribute if passed to it.
+The following methods are also patched to work with translated attributes:
+- +changed_attributes+
+- +changes+
+- +changed+
+- +changed?+
+- +previous_changes+
+- +clear_attribute_changes+
+- +restore_attributes+
 
 @see http://api.rubyonrails.org/classes/ActiveModel/Dirty.html Rails documentation for Active Model Dirty module
 
 =end
       module Dirty
-        # @!group Backend Accessors
-        # @!macro backend_writer
-        # @param [Hash] options
-        def write(locale, value, options = {})
-          locale_accessor = Mobility.normalize_locale_accessor(attribute, locale)
-          if model.changed_attributes.has_key?(locale_accessor) && model.changed_attributes[locale_accessor] == value
-            model.send(:attributes_changed_by_setter).except!(locale_accessor)
-          elsif read(locale, options.merge(locale: true)) != value
-            model.send(:mobility_changed_attributes) << locale_accessor
-            model.send(:attribute_will_change!, locale_accessor)
-          end
-          super
-        end
-        # @!endgroup
-
         # Builds module which adds suffix/prefix methods for translated
         # attributes so they act like normal dirty-tracked attributes.
         class MethodsBuilder < Module
           def initialize(*attribute_names)
+            define_dirty_methods(attribute_names)
+
+            if ::ActiveModel::VERSION::STRING >= '5.0' # methods added in Rails 5.0
+              define_ar_5_0_dirty_methods(attribute_names)
+              if ::ActiveModel::VERSION::STRING >= '5.1' # methods added in Rails 5.1
+                define_ar_6_0_dirty_methods(attribute_names)
+              end
+            end
+          end
+
+          def included(model_class)
+            model_class.include InstanceMethods
+          end
+
+          def append_locale(attr_name)
+            Mobility.normalize_locale_accessor(attr_name)
+          end
+
+          private
+
+          def define_dirty_methods(attribute_names)
+            m = self
+
             attribute_names.each do |name|
-              method_suffixes.each do |suffix|
-                define_method "#{name}#{suffix}" do
-                  __send__("attribute#{suffix}", Mobility.normalize_locale_accessor(name))
-                end
+              define_method "#{name}_changed?" do |**options|
+                mutations_from_mobility.changed?(m.append_locale(name), **options)
+              end
+
+              define_method "#{name}_change" do
+                mutations_from_mobility.change_to_attribute(m.append_locale(name))
+              end
+
+              define_method "#{name}_will_change!" do
+                mutations_from_mobility.force_change(m.append_locale(name))
+              end
+
+              define_method "#{name}_was" do
+                mutations_from_mobility.original_value(m.append_locale(name))
               end
 
               define_method "restore_#{name}!" do
-                locale_accessor = Mobility.normalize_locale_accessor(name)
-                if attribute_changed?(locale_accessor)
-                  __send__("#{name}=", changed_attributes[locale_accessor])
+                locale_accessor = m.append_locale(name)
+                if mutations_from_mobility.changed?(locale_accessor)
+                  __send__("#{name}=", mutations_from_mobility.original_value(locale_accessor))
+                  mutations_from_mobility.forget_change(locale_accessor)
                 end
               end
             end
 
+            # This private method override is necessary to make
+            # +restore_attributes+ (which is public) work with translated
+            # attributes.
             define_method :restore_attribute! do |attr|
               attribute_names.include?(attr.to_s) ? send("restore_#{attr}!") : super(attr)
             end
             private :restore_attribute!
           end
 
-          def included(model_class)
-            model_class.include ChangedAttributes
+          def define_ar_5_0_dirty_methods(attribute_names)
+            m = self
+
+            attribute_names.each do |name|
+              define_method "#{name}_previously_changed?" do
+                mutations_before_last_save_from_mobility.changed?(m.append_locale(name))
+              end
+
+              define_method "#{name}_previous_change" do
+                mutations_before_last_save_from_mobility.change_to_attribute(m.append_locale(name))
+              end
+            end
+          end
+
+          def define_ar_6_0_dirty_methods(attribute_names)
+            m = self
+
+            attribute_names.each do |name|
+              define_method "#{name}_previously_was" do
+                mutations_before_last_save_from_mobility.original_value(m.append_locale(name))
+              end
+            end
+          end
+
+          module InstanceMethods
+            def changed_attributes
+              super.merge(mutations_from_mobility.changed_values)
+            end
+
+            def changes_applied
+              super
+              @mutations_before_last_save_from_mobility = mutations_from_mobility
+              @mutations_from_mobility = nil
+            end
+
+            def changes
+              super.merge(mutations_from_mobility.changes)
+            end
+
+            def changed
+              # uniq is required for Rails < 6.0
+              (super + mutations_from_mobility.changed_attribute_names).uniq
+            end
+
+            def changed?
+              super || mutations_from_mobility.any_changes?
+            end
+
+            def previous_changes
+              super.merge(mutations_before_last_save_from_mobility.changes)
+            end
+
+            def clear_changes_information
+              @mutations_from_mobility = nil
+              @mutations_before_last_save_from_mobility = nil
+              super
+            end
+
+            private
+
+            def mutations_from_mobility
+              @mutations_from_mobility ||= MobilityMutationTracker.new(self)
+            end
+
+            def mutations_before_last_save_from_mobility
+              @mutations_before_last_save_from_mobility ||= ::ActiveModel::NullMutationTracker.new(self)
+            end
+          end
+        end
+
+        class MobilityMutationTracker
+          OPTION_NOT_GIVEN = Object.new
+
+          def initialize(model)
+            @model = model
+            @forced_changes = {}
+          end
+
+          def changed_attribute_names
+            attr_names.select { |attr_name| changed?(attr_name) }
+          end
+
+          def changed_values
+            attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
+              if changed?(attr_name)
+                result[attr_name] = original_value(attr_name)
+              end
+            end
+          end
+
+          def changes
+            attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
+              if change = change_to_attribute(attr_name)
+                result.merge!(attr_name => change)
+              end
+            end
+          end
+
+          def change_to_attribute(attr_name)
+            if changed?(attr_name)
+              [original_value(attr_name), fetch_value(attr_name)]
+            end
+          end
+
+          def any_changes?
+            attr_names.any? { |attr| changed?(attr) }
+          end
+
+          def changed?(attr_name, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN)
+            attribute_changed?(attr_name) &&
+              (OPTION_NOT_GIVEN == from || original_value(attr_name) == from) &&
+              (OPTION_NOT_GIVEN == to || fetch_value(attr_name) == to)
+          end
+
+          def forget_change(attr_name)
+            forced_changes.delete(attr_name)
+          end
+
+          def original_value(attr_name)
+            if changed?(attr_name)
+              forced_changes[attr_name]
+            else
+              fetch_value(attr_name)
+            end
+          end
+
+          def force_change(attr_name)
+            forced_changes[attr_name] = fetch_value(attr_name) unless attribute_changed?(attr_name)
           end
 
           private
+          attr_reader :model, :forced_changes
 
-          # Get method suffixes. Creating an object just to get the list of
-          # suffixes is not very efficient, but the most reliable way given that
-          # they change from Rails version to version.
-          def method_suffixes
-            @method_suffixes ||=
-              Class.new do
-                include ::ActiveModel::Dirty
-              end.attribute_method_matchers.map(&:suffix).select { |m| m =~ /\A_/ }
+          def attr_names
+            forced_changes.keys
           end
 
-          # Tracks which translated attributes have been changed, separate from
-          # the default tracking of changes in ActiveModel/ActiveRecord Dirty.
-          # This is required in order for the Mobility ActiveRecord Dirty
-          # plugin to correctly read the value of locale accessors like
-          # +title_en+ in dirty tracking.
-          module ChangedAttributes
-            private
+          def attribute_changed?(attr_name)
+            forced_changes.include?(attr_name)
+          end
 
-            def mobility_changed_attributes
-              @mobility_changed_attributes ||= Set.new
+          def fetch_value(attr_name)
+            model.__send__(attr_name)
+          end
+        end
+
+        module BackendMethods
+          # @!group Backend Accessors
+          # @!macro backend_writer
+          # @param [Hash] options
+          def write(locale, value, options = {})
+            locale_accessor = Mobility.normalize_locale_accessor(attribute, locale)
+            if model.changed_attributes.has_key?(locale_accessor) && model.changed_attributes[locale_accessor] == value
+              mutations_from_mobility.forget_change(locale_accessor)
+            elsif read(locale, options.merge(locale: true)) != value
+              mutations_from_mobility.force_change(locale_accessor)
             end
+            super
+          end
+          # @!endgroup
+
+          private
+
+          def mutations_from_mobility
+            model.send(:mutations_from_mobility)
           end
         end
       end

--- a/lib/mobility/plugins/active_record/dirty.rb
+++ b/lib/mobility/plugins/active_record/dirty.rb
@@ -12,7 +12,6 @@ details on usage.
 In addition to methods added by {Mobility::Plugins::ActiveModel::Dirty}, the
 AR::Dirty plugin adds support for the following persistence-specific methods
 (for a model with a translated attribute +title+):
-- +saved_changes+
 - +saved_change_to_title?+
 - +saved_change_to_title+
 - +title_before_last_save+
@@ -20,128 +19,98 @@ AR::Dirty plugin adds support for the following persistence-specific methods
 - +title_change_to_be_saved+
 - +title_in_database+
 
+The following methods are also patched to include translated attribute changes:
+- +saved_changes+
+- +has_changes_to_save?+
+- +changes_to_save+
+- +changed_attribute_names_to_save+
+- +attributes_in_database+
+
 =end
       module Dirty
-        include ActiveModel::Dirty
-
-        # Builds module which patches a few AR methods to handle changes to
-        # translated attributes just like normal attributes.
         class MethodsBuilder < ActiveModel::Dirty::MethodsBuilder
-          def initialize(*attribute_names)
-            super
-            @attribute_names = attribute_names
-            define_method_overrides if ::ActiveRecord::VERSION::STRING < '5.2'
-            define_attribute_methods if ::ActiveRecord::VERSION::STRING >= '5.1'
+          if ::ActiveRecord::VERSION::STRING >= '5.1' # define patterns added in 5.1
+            def initialize(*attribute_names)
+              super
+
+              define_ar_dirty_methods(attribute_names)
+            end
           end
 
-          # Overrides +ActiveRecord::AttributeMethods::ClassMethods#has_attribute+ (in AR 5.1) and
-          # +ActiveModel::AttributeMethods#_read_attribute+ (in AR >= 5.2) to
-          # ensure that fallthrough attribute methods are treated like "real"
-          # attribute methods.
-          #
-          # @note Patching +has_attribute?+ is necessary in AR 5.1 due to this commit[https://github.com/rails/rails/commit/4fed08fa787a316fa51f14baca9eae11913f5050].
           # @param [Attributes] attributes
           def included(model_class)
             super
 
-            if ::ActiveRecord::VERSION::MAJOR == 5 && ::ActiveRecord::VERSION::MINOR == 1
-              names = @attribute_names
-              method_name_regex = /\A(#{names.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
-              has_attribute = Module.new do
-                define_method :has_attribute? do |attr_name|
-                  super(attr_name) || (String === attr_name && !!method_name_regex.match(attr_name))
-                end
-              end
-              model_class.extend has_attribute
-            elsif ::ActiveRecord::VERSION::STRING >= '5.2'
-              model_class.include ReadAttribute
-            end
+            model_class.include InstanceMethods
           end
 
           private
 
-          # @note These method overrides are needed for AR versions < 5.2,
-          #   since AR::Dirty overrides AM::Dirty, disabling previous_changes
-          #   from being set. Here we "undo" that.
-          def define_method_overrides
-            changes_applied_method = ::ActiveRecord::VERSION::STRING < '5.1' ? :changes_applied : :changes_internally_applied
-            define_method changes_applied_method do
-              @previously_changed = changes
-              super()
-            end
+          def define_ar_dirty_methods(attribute_names)
+            m = self
 
-            define_method :clear_changes_information do
-              @previously_changed = ActiveSupport::HashWithIndifferentAccess.new
-              super()
-            end
+            attribute_names.each do |name|
+              define_method "saved_change_to_#{name}?" do
+                mutations_before_last_save_from_mobility.changed?(m.append_locale(name))
+              end
 
-            define_method :previous_changes do
-              (@previously_changed ||= ActiveSupport::HashWithIndifferentAccess.new).merge(super())
+              define_method "saved_change_to_#{name}" do
+                mutations_before_last_save_from_mobility.change_to_attribute(m.append_locale(name))
+              end
+
+              define_method "#{name}_before_last_save" do
+                mutations_before_last_save_from_mobility.original_value(m.append_locale(name))
+              end
+
+              define_method "will_save_change_to_#{name}?" do
+                mutations_from_mobility.changed?(m.append_locale(name))
+              end
+
+              define_method "#{name}_change_to_be_saved" do
+                mutations_from_mobility.change_to_attribute(m.append_locale(name))
+              end
+
+              define_method "#{name}_in_database" do
+                mutations_from_mobility.original_value(m.append_locale(name))
+              end
             end
           end
 
-          # For AR >= 5.1 only
-          def define_attribute_methods
-            define_method :saved_changes do
-              (@previously_changed ||= ActiveSupport::HashWithIndifferentAccess.new).merge(super())
-            end
-
-            @attribute_names.each do |name|
-              define_method :"saved_change_to_#{name}?" do
-                previous_changes.include?(Mobility.normalize_locale_accessor(name))
+          module InstanceMethods
+            if ::ActiveRecord::VERSION::STRING >= '5.1' # define patterns added in 5.1
+              def saved_changes
+                mutations_before_last_save_from_mobility.changes
               end
 
-              define_method :"saved_change_to_#{name}" do
-                previous_changes[Mobility.normalize_locale_accessor(name)]
+              def changes_to_save
+                super.merge(mutations_from_mobility.changes)
               end
 
-              define_method :"#{name}_before_last_save" do
-                previous_changes[Mobility.normalize_locale_accessor(name)].first
+              def changed_attribute_names_to_save
+                super + mutations_from_mobility.changed_attribute_names
               end
 
-              alias_method :"will_save_change_to_#{name}?", :"#{name}_changed?"
-              alias_method :"#{name}_change_to_be_saved", :"#{name}_change"
-              alias_method :"#{name}_in_database", :"#{name}_was"
-            end
-          end
+              def attributes_in_database
+                super.merge(mutations_from_mobility.changed_values)
+              end
 
-          # Overrides _read_attribute to correctly dispatch reads on translated
-          # attributes to their respective setters, rather than to
-          # +@attributes+, which would otherwise return +nil+.
-          #
-          # For background on why this is necessary, see:
-          # https://github.com/shioyama/mobility/issues/115
-          module ReadAttribute
-            # @note We first check if attributes has the key +attr+ to avoid
-            #   doing any extra work in case this is a "normal"
-            #   (non-translated) attribute.
-            def _read_attribute(attr, *args)
-              if @attributes.key?(attr)
-                super
-              else
-                mobility_changed_attributes.include?(attr) ? __send__(attr) : super
+              if ::ActiveRecord::VERSION::STRING >= '6.0'
+                def has_changes_to_save?
+                  super || mutations_from_mobility.any_changes?
+                end
               end
             end
 
-            # @note This is necessary due to a performance fix in e12607
-            #   which skips setting @previously_changed if @attributes is
-            #   defined. For Mobility models using the Dirty plugin, there will
-            #   be cases where @attributes has been set, but there are *other*
-            #   changes on virtual translated attributes which need to also be
-            #   assigned. In this case, we use the presence of such changed
-            #   virtual attributes as an alternative trigger to set this variable.
-            #
-            #   See:
-            #   - https://github.com/rails/rails/commit/e126078a0e013acfe0a397a8dad33b2c9de78732
-            #   - https://github.com/shioyama/mobility/pull/166
-            def changes_applied
-              if defined?(@attributes) && mobility_changed_attributes.any?
-                @previously_changed = changes
+            def reload(*)
+              super.tap do
+                @mutations_from_mobility = nil
+                @mutations_before_last_save_from_mobility = nil
               end
-              super
             end
           end
         end
+
+        BackendMethods = ActiveModel::Dirty::BackendMethods
       end
     end
   end

--- a/lib/mobility/plugins/active_record/dirty.rb
+++ b/lib/mobility/plugins/active_record/dirty.rb
@@ -79,7 +79,7 @@ The following methods are also patched to include translated attribute changes:
           module InstanceMethods
             if ::ActiveRecord::VERSION::STRING >= '5.1' # define patterns added in 5.1
               def saved_changes
-                mutations_before_last_save_from_mobility.changes
+                super.merge(mutations_before_last_save_from_mobility.changes)
               end
 
               def changes_to_save

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -50,7 +50,7 @@ details.
             else
               raise ArgumentError, "#{model_class} does not support Dirty module."
             end
-          backend_class.include dirty_module
+          backend_class.include dirty_module.const_get(:BackendMethods)
           model_class.include dirty_module.const_get(:MethodsBuilder).new(*attribute_names)
         end
       end

--- a/lib/mobility/plugins/sequel/dirty.rb
+++ b/lib/mobility/plugins/sequel/dirty.rb
@@ -13,21 +13,6 @@ Automatically includes dirty plugin in model class when enabled.
 =end
     module Sequel
       module Dirty
-        # @!group Backend Accessors
-        # @!macro backend_writer
-        # @param [Hash] options
-        def write(locale, value, options = {})
-          locale_accessor = Mobility.normalize_locale_accessor(attribute, locale).to_sym
-          if model.column_changes.has_key?(locale_accessor) && model.initial_values[locale_accessor] == value
-            super
-            [model.changed_columns, model.initial_values].each { |h| h.delete(locale_accessor) }
-          elsif read(locale, options.merge(fallback: false)) != value
-            model.will_change_column(locale_accessor)
-            super
-          end
-        end
-        # @!endgroup
-
         # Builds module which overrides dirty methods to handle translated as
         # well as normal (untranslated) attributes.
         class MethodsBuilder < Module
@@ -52,6 +37,23 @@ Automatically includes dirty plugin in model class when enabled.
             # this just adds Sequel::Plugins::Dirty to @plugins
             model_class.plugin :dirty
           end
+        end
+
+        module BackendMethods
+          # @!group Backend Accessors
+          # @!macro backend_writer
+          # @param [Hash] options
+          def write(locale, value, options = {})
+            locale_accessor = Mobility.normalize_locale_accessor(attribute, locale).to_sym
+            if model.column_changes.has_key?(locale_accessor) && model.initial_values[locale_accessor] == value
+              super
+              [model.changed_columns, model.initial_values].each { |h| h.delete(locale_accessor) }
+            elsif read(locale, options.merge(fallback: false)) != value
+              model.will_change_column(locale_accessor)
+              super
+            end
+          end
+          # @!endgroup
         end
       end
     end

--- a/spec/mobility/plugins/active_model/dirty_spec.rb
+++ b/spec/mobility/plugins/active_model/dirty_spec.rb
@@ -156,10 +156,14 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
 
       aggregate_failures do
         expect(article.title_changed?).to eq(true)
+        expect(article.title_changed?(from: 'foo', to: 'bar')).to eq(true)
+        expect(article.title_changed?(from: 'foo', to: 'baz')).to eq(false)
         expect(article.title_change).to eq(["foo", "bar"])
         expect(article.title_was).to eq("foo")
 
         expect(article.attribute_changed?(:title)).to eq(true)
+        expect(article.attribute_changed?(:title, from: 'foo', to: 'bar')).to eq(true)
+        expect(article.attribute_changed?(:title, from: 'foo', to: 'baz')).to eq(false)
         expect(article.attribute_was(:title)).to eq("foo")
 
         article.save

--- a/spec/mobility/plugins/active_model/dirty_spec.rb
+++ b/spec/mobility/plugins/active_model/dirty_spec.rb
@@ -147,7 +147,7 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
   end
 
   describe "suffix methods" do
-    it "defines suffix methods on translated attribute", rails_version_geq: '5.0' do
+    it "defines suffix methods on translated attribute" do
       article = Article.new
       article.title = "foo"
       article.save
@@ -160,12 +160,15 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
         expect(article.title_was).to eq("foo")
 
         article.save
-        if ENV['RAILS_VERSION'].present? && ENV['RAILS_VERSION'] < '5.0'
-          expect(article.title_changed?).to eq(nil)
-        else
+        expect(article.title_changed?).to eq(false)
+        if ENV['RAILS_VERSION'].present? && ENV['RAILS_VERSION'] >= '5.0'
           expect(article.title_previously_changed?).to eq(true)
           expect(article.title_previous_change).to eq(["foo", "bar"])
           expect(article.title_changed?).to eq(false)
+
+          if ENV['RAILS_VERSION'].present? && ENV['RAILS_VERSION'] >= '6.0'
+            expect(article.title_previously_was).to eq('foo')
+          end
         end
 
         article.title_will_change!
@@ -186,11 +189,7 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
         expect(article.title_was).to eq("foo")
 
         Mobility.locale = :fr
-        if ENV['RAILS_VERSION'].present? && ENV['RAILS_VERSION'] < '5.0'
-          expect(article.title_changed?).to eq(nil)
-        else
-          expect(article.title_changed?).to eq(false)
-        end
+        expect(article.title_changed?).to eq(false)
         expect(article.title_change).to eq(nil)
         expect(article.title_was).to eq(nil)
       end

--- a/spec/mobility/plugins/active_model/dirty_spec.rb
+++ b/spec/mobility/plugins/active_model/dirty_spec.rb
@@ -159,12 +159,20 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
         expect(article.title_change).to eq(["foo", "bar"])
         expect(article.title_was).to eq("foo")
 
+        expect(article.attribute_changed?(:title)).to eq(true)
+        expect(article.attribute_was(:title)).to eq("foo")
+
         article.save
         expect(article.title_changed?).to eq(false)
+        expect(article.attribute_changed?(:title)).to eq(false)
+
         if ENV['RAILS_VERSION'].present? && ENV['RAILS_VERSION'] >= '5.0'
           expect(article.title_previously_changed?).to eq(true)
           expect(article.title_previous_change).to eq(["foo", "bar"])
           expect(article.title_changed?).to eq(false)
+
+          expect(article.attribute_previously_changed?(:title)).to eq(true)
+          expect(article.attribute_changed?(:title)).to eq(false)
         end
 
         article.title_will_change!
@@ -184,11 +192,23 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
         expect(article.title_change).to eq(["foo", "bar"])
         expect(article.title_was).to eq("foo")
 
+        expect(article.attribute_changed?(:title)).to eq(true)
+        expect(article.attribute_was(:title)).to eq('foo')
+
         Mobility.locale = :fr
         expect(article.title_changed?).to eq(false)
         expect(article.title_change).to eq(nil)
         expect(article.title_was).to eq(nil)
+
+        expect(article.attribute_changed?(:title)).to eq(false)
+        expect(article.attribute_was(:title)).to eq(nil)
       end
+    end
+
+    it 'does not make private methods public' do
+      article = Article.new
+      expect { article.attribute_change(:title) }.to raise_error(NoMethodError)
+      expect { article.send(:attribute_change, :title) }.not_to raise_error
     end
   end
 

--- a/spec/mobility/plugins/active_model/dirty_spec.rb
+++ b/spec/mobility/plugins/active_model/dirty_spec.rb
@@ -165,10 +165,6 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
           expect(article.title_previously_changed?).to eq(true)
           expect(article.title_previous_change).to eq(["foo", "bar"])
           expect(article.title_changed?).to eq(false)
-
-          if ENV['RAILS_VERSION'].present? && ENV['RAILS_VERSION'] >= '6.0'
-            expect(article.title_previously_was).to eq('foo')
-          end
         end
 
         article.title_will_change!

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -389,7 +389,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
         article = Article.new
 
         article.published = false
-        expect(article/has_changes_to_save?).to eq(true)
+        expect(article.has_changes_to_save?).to eq(true)
       end
     end
 

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -431,12 +431,4 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
       expect(article.changed_attribute_names_to_save).to match_array(%w[title_en title_ja published])
     end
   end
-
-  # Regression test for https://github.com/shioyama/mobility/issues/149
-  describe "#_read_attribute" do
-    it "is public" do
-      article = Article.create
-      expect { article._read_attribute("foo") }.not_to raise_error
-    end
-  end
 end if Mobility::Loaded::ActiveRecord

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -405,7 +405,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
         expect(article.attributes_in_database).to eq({ 'title_en' => nil, 'title_ja' => nil })
 
         article.published = false
-        expect(article.attributes_in_database).to eq({ 'title_en' => nil, 'title_ja' => nil, 'published' => false })
+        expect(article.attributes_in_database).to eq({ 'title_en' => nil, 'title_ja' => nil, 'published' => nil })
 
         article.save
         article.title_en = 'foo en 2'

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -361,16 +361,17 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
   end
 
   describe "#saved_changes", rails_version_geq: '5.1' do
-    it "includes translated attributes" do
+    it "includes translated attributes and untranslated attributes" do
       article = Article.create
 
-      article.title = "foo en"
-      Mobility.with_locale(:ja) { article.title = "foo ja" }
+      article.title_en = "foo en"
+      article.title_ja = "foo ja"
+      article.published = false
       article.save
 
       aggregate_failures do
         saved_changes = article.saved_changes
-        expect(saved_changes).to include("title_en", "title_ja")
+        expect(saved_changes).to include("title_en", 'title_ja', 'published')
         expect(saved_changes["title_en"]).to eq([nil, "foo en"])
         expect(saved_changes["title_ja"]).to eq([nil, "foo ja"])
       end

--- a/spec/mobility/plugins/dirty_spec.rb
+++ b/spec/mobility/plugins/dirty_spec.rb
@@ -17,7 +17,7 @@ describe Mobility::Plugins::Dirty do
           let(:model_class) { Class.new(ActiveRecord::Base) }
 
           it "includes dirty modules into backend class and model class" do
-            expect(backend_class).to receive(:include).with(Mobility::Plugins::ActiveRecord::Dirty)
+            expect(backend_class).to receive(:include).with(Mobility::Plugins::ActiveRecord::Dirty::BackendMethods)
             methods = instance_double(Mobility::Plugins::ActiveRecord::Dirty::MethodsBuilder)
             expect(Mobility::Plugins::ActiveRecord::Dirty::MethodsBuilder).to receive(:new).with("title").and_return(methods)
             expect(model_class).to receive(:include).with(methods)
@@ -33,7 +33,7 @@ describe Mobility::Plugins::Dirty do
           end
 
           it "includes dirty modules into backend class and model class" do
-            expect(backend_class).to receive(:include).with(Mobility::Plugins::ActiveModel::Dirty)
+            expect(backend_class).to receive(:include).with(Mobility::Plugins::ActiveModel::Dirty::BackendMethods)
             methods = instance_double(Mobility::Plugins::ActiveModel::Dirty::MethodsBuilder)
             expect(Mobility::Plugins::ActiveModel::Dirty::MethodsBuilder).to receive(:new).with("title").and_return(methods)
             expect(model_class).to receive(:include).with(methods)
@@ -46,7 +46,7 @@ describe Mobility::Plugins::Dirty do
         let(:model_class) { Class.new(Sequel::Model) }
 
         it "includes dirty modules into backend class and model class" do
-          expect(backend_class).to receive(:include).with(Mobility::Plugins::Sequel::Dirty)
+          expect(backend_class).to receive(:include).with(Mobility::Plugins::Sequel::Dirty::BackendMethods)
           methods = instance_double(Mobility::Plugins::Sequel::Dirty::MethodsBuilder)
           expect(Mobility::Plugins::Sequel::Dirty::MethodsBuilder).to receive(:new).with("title").and_return(methods)
           expect(model_class).to receive(:include).with(methods)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-ENV['RAILS_VERSION']  ||= "5.2"
+ENV['RAILS_VERSION']  ||= "6.0"
 ENV['SEQUEL_VERSION'] ||= "4"
 
 if !ENV['ORM'].nil? && !ENV['ORM'].empty?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,6 @@ unless orm == 'none'
   require "#{orm}/models"
 end
 
-
 RSpec.configure do |config|
   config.include Helpers
   config.include Mobility::Util


### PR DESCRIPTION
This is a patch to the 0-8-stable branch of #343. The branches are far apart now, so this really has to be the last major change to 0.8.x.