### PR TITLE
Fix issues with dirty plugin by dynamically defining dirty methods

### DIFF
--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -34,15 +34,11 @@ The following methods are also patched to work with translated attributes:
         # Builds module which adds suffix/prefix methods for translated
         # attributes so they act like normal dirty-tracked attributes.
         class MethodsBuilder < Module
+          delegate :method_patterns, :public_method_patterns, to: :class
+
           def initialize(*attribute_names)
             define_dirty_methods(attribute_names)
-
-            if ::ActiveModel::VERSION::STRING >= '5.0' # methods added in Rails 5.0
-              define_ar_5_0_dirty_methods(attribute_names)
-              if ::ActiveModel::VERSION::STRING >= '5.1' # methods added in Rails 5.1
-                define_ar_6_0_dirty_methods(attribute_names)
-              end
-            end
+            define_handler_methods
           end
 
           def included(model_class)
@@ -55,31 +51,38 @@ The following methods are also patched to work with translated attributes:
 
           private
 
+          def define_handler_methods
+            public_method_patterns.each do |pattern|
+              method_name = pattern % 'attribute'
+
+              module_eval <<-EOM, __FILE__, __LINE__ + 1
+              def #{method_name}(attr_name, *rest)
+                if (mutations_from_mobility.attribute_changed?(attr_name) ||
+                    mutations_from_mobility.attribute_previously_changed?(attr_name))
+                  mutations_from_mobility.send(#{method_name.inspect}, attr_name, *rest)
+                else
+                  super
+                end
+              end
+              EOM
+            end
+          end
+
           def define_dirty_methods(attribute_names)
             m = self
 
             attribute_names.each do |name|
-              define_method "#{name}_changed?" do |**options|
-                mutations_from_mobility.changed?(m.append_locale(name), **options)
-              end
-
-              define_method "#{name}_change" do
-                mutations_from_mobility.change_to_attribute(m.append_locale(name))
-              end
-
-              define_method "#{name}_will_change!" do
-                mutations_from_mobility.force_change(m.append_locale(name))
-              end
-
-              define_method "#{name}_was" do
-                mutations_from_mobility.original_value(m.append_locale(name))
+              method_patterns.each do |pattern|
+                define_method(pattern % name) do |*args|
+                  mutations_from_mobility.send(pattern % 'attribute', m.append_locale(name), *args)
+                end
               end
 
               define_method "restore_#{name}!" do
                 locale_accessor = m.append_locale(name)
-                if mutations_from_mobility.changed?(locale_accessor)
-                  __send__("#{name}=", mutations_from_mobility.original_value(locale_accessor))
-                  mutations_from_mobility.forget_change(locale_accessor)
+                if mutations_from_mobility.attribute_changed?(locale_accessor)
+                  __send__("#{name}=", mutations_from_mobility.attribute_was(locale_accessor))
+                  mutations_from_mobility.restore_attribute!(locale_accessor)
                 end
               end
             end
@@ -93,39 +96,39 @@ The following methods are also patched to work with translated attributes:
             private :restore_attribute!
           end
 
-          def define_ar_5_0_dirty_methods(attribute_names)
-            m = self
+          class << self
+            # Get method suffixes. Creating an object just to get the list of
+            # suffixes is simplest given they change from Rails version to version.
+            def method_patterns
+              @method_patterns ||=
+                (dirty_class.attribute_method_matchers.map { |p| "#{p.prefix}%s#{p.suffix}" } - excluded_method_patterns)
+            end
 
-            attribute_names.each do |name|
-              define_method "#{name}_previously_changed?" do
-                mutations_before_last_save_from_mobility.changed?(m.append_locale(name))
-              end
-
-              define_method "#{name}_previous_change" do
-                mutations_before_last_save_from_mobility.change_to_attribute(m.append_locale(name))
+            def public_method_patterns
+              @public_method_patterns ||= method_patterns.select do |p|
+                !dirty_class.private_instance_methods.include?(:"#{p % 'attribute'}")
               end
             end
-          end
 
-          def define_ar_6_0_dirty_methods(attribute_names)
-            m = self
+            private
 
-            attribute_names.each do |name|
-              define_method "#{name}_previously_was" do
-                mutations_before_last_save_from_mobility.original_value(m.append_locale(name))
-              end
+            def excluded_method_patterns
+              ['%s', 'restore_%s!']
+            end
+
+            def dirty_class
+              @dirty_class ||= Class.new { include ::ActiveModel::Dirty }
             end
           end
 
           module InstanceMethods
             def changed_attributes
-              super.merge(mutations_from_mobility.changed_values)
+              super.merge(mutations_from_mobility.changed_attributes)
             end
 
             def changes_applied
               super
-              @mutations_before_last_save_from_mobility = mutations_from_mobility
-              @mutations_from_mobility = nil
+              mutations_from_mobility.finalize_changes
             end
 
             def changes
@@ -134,20 +137,19 @@ The following methods are also patched to work with translated attributes:
 
             def changed
               # uniq is required for Rails < 6.0
-              (super + mutations_from_mobility.changed_attribute_names).uniq
+              (super + mutations_from_mobility.changed).uniq
             end
 
             def changed?
-              super || mutations_from_mobility.any_changes?
+              super || mutations_from_mobility.changed?
             end
 
             def previous_changes
-              super.merge(mutations_before_last_save_from_mobility.changes)
+              super.merge(mutations_from_mobility.previous_changes)
             end
 
             def clear_changes_information
               @mutations_from_mobility = nil
-              @mutations_before_last_save_from_mobility = nil
               super
             end
 
@@ -156,82 +158,106 @@ The following methods are also patched to work with translated attributes:
             def mutations_from_mobility
               @mutations_from_mobility ||= MobilityMutationTracker.new(self)
             end
-
-            def mutations_before_last_save_from_mobility
-              @mutations_before_last_save_from_mobility ||= ::ActiveModel::NullMutationTracker.new(self)
-            end
           end
         end
 
         class MobilityMutationTracker
           OPTION_NOT_GIVEN = Object.new
 
+          attr_reader :previous_changes
+
           def initialize(model)
             @model = model
-            @forced_changes = {}
+            @current_changes = {}.with_indifferent_access
+            @previous_changes = {}.with_indifferent_access
           end
 
-          def changed_attribute_names
-            attr_names.select { |attr_name| changed?(attr_name) }
+          def finalize_changes
+            @previous_changes = changes
+            @current_changes = {}.with_indifferent_access
           end
 
-          def changed_values
+          def changed
+            attr_names.select { |attr_name| attribute_changed?(attr_name) }
+          end
+
+          def changed_attributes
             attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
-              if changed?(attr_name)
-                result[attr_name] = original_value(attr_name)
+              if attribute_changed?(attr_name)
+                result[attr_name] = attribute_was(attr_name)
               end
             end
           end
 
           def changes
             attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
-              if change = change_to_attribute(attr_name)
+              if change = attribute_change(attr_name)
                 result.merge!(attr_name => change)
               end
             end
           end
 
-          def change_to_attribute(attr_name)
-            if changed?(attr_name)
-              [original_value(attr_name), fetch_value(attr_name)]
+          def changed?
+            attr_names.any? { |attr| attribute_changed?(attr) }
+          end
+
+          def attribute_change(attr_name)
+            if attribute_changed?(attr_name)
+              [attribute_was(attr_name), fetch_value(attr_name)]
             end
           end
 
-          def any_changes?
-            attr_names.any? { |attr| changed?(attr) }
+          def attribute_previous_change(attr_name)
+            previous_changes[attr_name]
           end
 
-          def changed?(attr_name, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN)
-            attribute_changed?(attr_name) &&
-              (OPTION_NOT_GIVEN == from || original_value(attr_name) == from) &&
+          def attribute_previously_was(attr_name)
+            if attribute_previously_changed?(attr_name)
+              # Calling +first+ here fetches the value before change from the
+              # hash.
+              previous_changes[attr_name].first
+            end
+          end
+
+          def attribute_changed?(attr_name, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN)
+            current_changes.include?(attr_name) &&
+              (OPTION_NOT_GIVEN == from || attribute_was(attr_name) == from) &&
               (OPTION_NOT_GIVEN == to || fetch_value(attr_name) == to)
           end
 
-          def forget_change(attr_name)
-            forced_changes.delete(attr_name)
+          def attribute_previously_changed?(attr_name)
+            previous_changes.include?(attr_name)
           end
 
-          def original_value(attr_name)
-            if changed?(attr_name)
-              forced_changes[attr_name]
+          def attribute_was(attr_name)
+            if attribute_changed?(attr_name)
+              current_changes[attr_name]
             else
               fetch_value(attr_name)
             end
           end
 
-          def force_change(attr_name)
-            forced_changes[attr_name] = fetch_value(attr_name) unless attribute_changed?(attr_name)
+          def attribute_will_change!(attr_name)
+            current_changes[attr_name] = fetch_value(attr_name) unless current_changes.include?(attr_name)
           end
+
+          def restore_attribute!(attr_name)
+            current_changes.delete(attr_name)
+          end
+
+          # These are for ActiveRecord, but we'll define them here.
+          alias_method :saved_change_to_attribute?,     :attribute_previously_changed?
+          alias_method :saved_change_to_attribute,      :attribute_previous_change
+          alias_method :attribute_before_last_save,     :attribute_previously_was
+          alias_method :will_save_change_to_attribute?, :attribute_changed?
+          alias_method :attribute_change_to_be_saved,   :attribute_change
+          alias_method :attribute_in_database,          :attribute_was
 
           private
-          attr_reader :model, :forced_changes
+          attr_reader :model, :current_changes
 
           def attr_names
-            forced_changes.keys
-          end
-
-          def attribute_changed?(attr_name)
-            forced_changes.include?(attr_name)
+            current_changes.keys
           end
 
           def fetch_value(attr_name)
@@ -246,9 +272,9 @@ The following methods are also patched to work with translated attributes:
           def write(locale, value, options = {})
             locale_accessor = Mobility.normalize_locale_accessor(attribute, locale)
             if model.changed_attributes.has_key?(locale_accessor) && model.changed_attributes[locale_accessor] == value
-              mutations_from_mobility.forget_change(locale_accessor)
+              mutations_from_mobility.restore_attribute!(locale_accessor)
             elsif read(locale, options.merge(locale: true)) != value
-              mutations_from_mobility.force_change(locale_accessor)
+              mutations_from_mobility.attribute_will_change!(locale_accessor)
             end
             super
           end


### PR DESCRIPTION
Resolving issues raised in #347, for master branch. For a summary see [here](https://github.com/shioyama/mobility/pull/347#issuecomment-544742401), and 011575d9859b086330197d50427773e79f29d94d.