### PR TITLE
Ensure that public/private scope of changes_applied, etc do not change

### DIFF
--- a/lib/mobility/plugins/active_record/dirty.rb
+++ b/lib/mobility/plugins/active_record/dirty.rb
@@ -49,8 +49,6 @@ locale suffix, so +title_en+, +title_pt_br+, etc.)
           end
 
           class << self
-            private
-
             def dirty_class
               @dirty_class ||= (Class.new do
                 # In earlier versions of Rails, these are needed to avoid an

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -324,6 +324,24 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
     end
   end
 
+  %w[changes_applied clear_attribute_changes clear_changes_information].each do |method_name|
+    it "does not change private status of #{method_name}" do
+      # Create a dummy AR model so we can inspect its dirty methods. This way
+      # test works for all versions of Rails (private/public status of these
+      # methods has changed between versions.)
+      klass = Class.new do
+        def self.after_create; end
+        def self.after_update; end
+
+        include ::ActiveRecord::AttributeMethods::Dirty
+      end
+      dirty = klass.new
+
+      expect(instance.respond_to?(method_name)).to eq(dirty.respond_to?(method_name))
+      expect(instance.respond_to?(method_name, true)).to eq(dirty.respond_to?(method_name, true))
+    end
+  end
+
   describe "restoring attributes" do
     it "defines restore_<attribute>! for translated attributes" do
       Mobility.locale = :'pt-BR'


### PR DESCRIPTION
Previously, we were looking at the Active*Model* methods to se if they were private or public, and defining overrides accordingly. However, in some versions of Rails, the methods can be private in one module, but public in the other... so we need to ensure that the code actually looks at the correct +dirty_class+ to determine if the methods should be
public or private.

I never thought this dirty fix would be so complex...