### PR TITLE
Avoid making private methods accidentally public

### DIFF
--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -52,15 +52,11 @@ the ActiveRecord dirty plugin for more information.
           end
 
           def included(model_class)
+            private_methods = InstanceMethods.instance_methods & model_class.private_instance_methods
             model_class.include InstanceMethods
-            model_class.include handler_methods_module
+            model_class.class_eval { private(*private_methods) }
 
-            # In earlier versions of Rails, these methods are private
-            %i[clear_attribute_changes clear_changes_information changes_applied].each do |method_name|
-              if dirty_class.private_instance_methods.include?(method_name)
-                model_class.class_eval { private method_name }
-              end
-            end
+            model_class.include handler_methods_module
           end
 
           def append_locale(attr_name)

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -122,7 +122,7 @@ the ActiveRecord dirty plugin for more information.
 
             def public_method_patterns
               @public_method_patterns ||= method_patterns.select do |p|
-                !dirty_class.private_instance_methods.include?(:"#{p % 'attribute'}")
+                dirty_class.public_method_defined?(p % 'attribute')
               end
             end
 

--- a/lib/mobility/plugins/cache.rb
+++ b/lib/mobility/plugins/cache.rb
@@ -74,7 +74,7 @@ Values are added to the cache in two ways:
           names = @names
 
           method_names(klass).each do |method_name|
-            priv = klass.private_instance_methods.include?(method_name)
+            priv = klass.private_method_defined?(method_name)
             define_method method_name do |*args|
               super(*args).tap do
                 names.each { |name| mobility_backends[name].clear_cache }

--- a/spec/mobility/plugins/cache_spec.rb
+++ b/spec/mobility/plugins/cache_spec.rb
@@ -109,6 +109,24 @@ describe Mobility::Plugins::Cache do
         it_behaves_like "cache that resets on model action", :reload
         it_behaves_like "cache that resets on model action", :reload, { readonly: true, lock: true }
         it_behaves_like "cache that resets on model action", :save
+
+        # borrowed from dirty plugin specs
+        %w[changes_applied clear_changes_information].each do |method_name|
+          it "does not change private status of #{method_name}" do
+            # Create a dummy vanilla AR model so we can inspect its methods and
+            # ensure we haven't made anything that was private, public. By
+            # doing it like this, we ensure that the test works for all
+            # versions of Rails (private/public status of various methods has
+            # changed between versions.)
+            klass = Class.new(ActiveRecord::Base) do
+              self.table_name = 'articles'
+            end
+            ar = klass.new
+
+            expect(instance.respond_to?(method_name)).to eq(ar.respond_to?(method_name))
+            expect(instance.respond_to?(method_name, true)).to eq(ar.respond_to?(method_name, true))
+          end
+        end
       end
 
       context "with multiple backends" do


### PR DESCRIPTION
`changes_applied` is private in some versions of Rails, and we should not be changing that. To avoid this from happening, we can create a dummy class including the AR dirty module, check its methods and see if either `changes_applied` or `clear_changes_information` are private, and if so change the method visibility accordingly.

Note: I will only be applying this to the `master` branch, where I noticed ae06d748626771a5114506c6a4ec85a9359dfba7 had changed the cache code. I won't be back-porting this to the 0-8 branch unless anybody had any issues, but I think in versions of Rails <= 5.1, the cache plugin makes `changes_applied` public when it is actually private in AR models. This probably is not a problem for anybody which I guess is why I haven't heard about it, but Mobility should really not make private methods public...