### PR TITLE
Fix fallthrough accessor method_missing not passing all options to super

### DIFF
--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -53,7 +53,7 @@ model class is generated.
             locale = "#{locale}-#{suffix.upcase}" if suffix
             public_send("#{attribute}#{$4}", *arguments, **options, locale: locale.to_sym)
           else
-            super(method_name, *arguments, &block)
+            super(method_name, *arguments, **options, &block)
           end
         end
 

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -16,6 +16,23 @@ describe Mobility::Plugins::FallthroughAccessors do
     it_behaves_like "locale accessor", :title, :en
     it_behaves_like "locale accessor", :title, :de
     it_behaves_like "locale accessor", :title, :'pt-BR'
+
+    it 'passes arguments and options to super when method does not match' do
+      mod = Module.new do
+        def method_missing(method_name, *_args, **options, &block)
+          (method_name == :foo) ? options : super
+        end
+      end
+
+      klass = Class.new
+      klass.include mod
+      klass.include described_class.new(:title)
+
+      instance = klass.new
+
+      options = { some: 'params' }
+      expect(instance.foo(**options)).to eq(options)
+    end
   end
 
   describe ".apply" do


### PR DESCRIPTION
When mobility handled something it wasn't responsible for, it didn't pass all options to `super` and actually swallowed `options`. Other method missing handlers couldn't work as intended then.