### PR TITLE
Define default backend and options on Attributes class

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -169,15 +169,12 @@ module Mobility
     # (see Mobility::Configuration#default_backend)
     # @!method default_backend
 
-    # (see Mobility::Configuration#default_options)
-    # @!method default_options
-    #
     # (see Mobility::Configuration#plugins)
     # @!method plugins
     #
     # (see Mobility::Configuration#default_accessor_locales)
     # @!method default_accessor_locales
-    %w[accessor_method query_method default_backend default_options plugins default_accessor_locales].each do |method_name|
+    %w[accessor_method query_method default_backend plugins default_accessor_locales].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -108,8 +108,23 @@ with other backends.
 
 =end
   class Attributes < Module
-    def self.plugin(name)
-      include Plugins.load_plugin(name)
+    class << self
+      def plugin(plugin_name)
+        include Plugins.load_plugin(plugin_name)
+      end
+
+      def backend(backend_name)
+        @default_backend = backend_name
+      end
+      attr_reader :default_backend
+
+      def options(options)
+        @default_options = options
+      end
+
+      def default_options
+        @default_options ||= Configuration::DEFAULT_OPTIONS
+      end
     end
 
     # Attribute names for which accessors will be defined
@@ -133,9 +148,9 @@ with other backends.
     # @param [Symbol,Class] backend Backend to use
     # @param [Hash] backend_options Backend options hash
     # @raise [ArgumentError] if method is not reader, writer or accessor
-    def initialize(*attribute_names, method: :accessor, backend: Mobility.default_backend, **backend_options)
+    def initialize(*attribute_names, method: :accessor, backend: self.class.default_backend, **backend_options)
       raise ArgumentError, "method must be one of: reader, writer, accessor" unless %i[reader writer accessor].include?(method)
-      @options = Mobility.default_options.to_h.merge(backend_options)
+      @options = self.class.default_options.merge(backend_options)
       @names = attribute_names.map(&:to_s).freeze
 
       @backend_name = backend

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -71,14 +71,6 @@ Stores shared Mobility configuration referenced by all backends.
       @query_method = :i18n
       @fallbacks_generator = lambda { |fallbacks| Mobility::Fallbacks.build(fallbacks) }
       @default_accessor_locales = lambda { Mobility.available_locales }
-      @default_options = Options[{
-        cache:     true,
-        presence:  true,
-        query:     true,
-        # A nil key here includes the plugin so it can be optionally turned on
-        # when reading an attribute using accessor options.
-        fallbacks: nil
-      }]
     end
 
     def attributes_class
@@ -95,5 +87,14 @@ Stores shared Mobility configuration referenced by all backends.
         super
       end
     end
+
+    DEFAULT_OPTIONS = Options[{
+      cache:     true,
+      presence:  true,
+      query:     true,
+      # A nil key here includes the plugin so it can be optionally turned on
+      # when reading an attribute using accessor options.
+      fallbacks: nil
+    }]
   end
 end

--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -32,11 +32,6 @@ Mobility.configure do |config|
   #   locale_accessors
   # ]
 
-  # The translation cache is on by default, but you can turn it off by
-  # uncommenting this line. (This may be helpful in debugging.)
-  #
-  # config.default_options[:cache] = false
-
   # Dirty tracking is disabled by default. Uncomment this line to enable it.
   # If you enable this, you should also enable +locale_accessors+ by default
   # (see below).

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -24,7 +24,7 @@ describe Mobility::Attributes do
   end
 
   describe "including Attributes in a model" do
-    let(:expected_options) { { foo: "bar", **Mobility.default_options, model_class: model_class } }
+    let(:expected_options) { { foo: "bar", **Mobility::Attributes.default_options, model_class: model_class } }
 
     it "calls with_options on backend class with options merged with default options" do
       expect(backend_class).to receive(:with_options).with(expected_options).and_return(Class.new(backend_class))
@@ -36,7 +36,7 @@ describe Mobility::Attributes do
       attributes = described_class.new("title", backend: backend_class, foo: "bar")
       model_class.include attributes
       expect(attributes.options.merge(model_class: model_class)).to eq(attributes.backend_class.options)
-      expect(attributes.backend_class.options).to eq(Mobility.default_options.merge(model_class: model_class, foo: "bar"))
+      expect(attributes.backend_class.options).to eq(Mobility::Attributes.default_options.merge(model_class: model_class, foo: "bar"))
     end
 
     it "freezes backend options after inclusion into model class" do
@@ -187,7 +187,7 @@ describe Mobility::Attributes do
         model_class.include described_class.new("title", backend: backend_class, foo: "bar")
       end
       let(:article) { model_class.new }
-      let(:expected_options) { { foo: "bar", **Mobility.default_options, model_class: model_class } }
+      let(:expected_options) { { foo: "bar", **Mobility::Attributes.default_options, model_class: model_class } }
 
       it "defines <attribute_name>_backend method which returns backend instance" do
         expect(backend_class).to receive(:new).once.with(article, "title").and_call_original

--- a/spec/mobility/configuration_spec.rb
+++ b/spec/mobility/configuration_spec.rb
@@ -29,16 +29,4 @@ describe Mobility::Configuration do
       expect(subject.default_accessor_locales).to eq([:en, :de])
     end
   end
-
-  describe "#default_options" do
-    it "raises exception when reserved option keys are set" do
-      aggregate_failures do
-        %i[backend model_class].each do |reserved_key|
-          expect {
-            subject.default_options[reserved_key] = "value"
-          }.to raise_error(Mobility::Configuration::ReservedOptionKey)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
The objective here is to remove `Mobility::Configuration` and instead define defaults in a subclass of `Mobility::Attributes`. This is more transparent and allows further nesting of configuration through inheritance.

Usage:

```ruby
class TranslatedAttributes < Mobility::Attributes
  backend :key_value
  options cache: true, presence: false, query: true, fallbacks: false
end
```

The options and backend can still be overridden in each instance:

```ruby
class Post
  include TranslatedAttributes.new(:title, backend: :table, fallbacks: true)
end
```