### PR TITLE
Deprecate Ruby 2.4, support Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
               name: 'active_record'
               version: '6.1'
             experimental: true
+        exclude:
+          - ruby: '2.7'
+            orm:
+              name: 'active_record'
+              version: '4.2'
+          - ruby: '2.7'
+            orm:
+              name: 'sequel'
+              version: '4'
     env:
       DB: ${{ matrix.database }}
       BUNDLE_JOBS: 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '2.7'
           - '2.6'
           - '2.5'
-          - '2.4'
         database:
           - 'sqlite3'
           - 'mysql'
@@ -44,40 +44,35 @@ jobs:
         experimental: [false]
         feature: ['unit']
         include:
-          - ruby: '2.6'
+          - ruby: '2.7'
             database: 'sqlite3'
             feature: 'performance'
             experimental: false
-          - ruby: '2.6'
+          - ruby: '2.7'
             database: 'sqlite3'
             feature: 'i18n_fallbacks'
             experimental: false
-          - ruby: '2.6'
+          - ruby: '2.7'
             database: 'sqlite3'
             feature: 'unit'
             orm:
               name: 'active_record'
               version: '6.1'
             experimental: true
-          - ruby: '2.6'
+          - ruby: '2.7'
             database: 'mysql'
             feature: 'unit'
             orm:
               name: 'active_record'
               version: '6.1'
             experimental: true
-          - ruby: '2.6'
+          - ruby: '2.7'
             database: 'postgres'
             feature: 'unit'
             orm:
               name: 'active_record'
               version: '6.1'
             experimental: true
-        exclude:
-          - ruby: '2.4'
-            orm:
-              name: 'active_record'
-              version: '6.0'
     env:
       DB: ${{ matrix.database }}
       BUNDLE_JOBS: 4

--- a/mobility.gemspec
+++ b/mobility.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Chris Salzberg"]
   spec.email         = ["chris@dejimata.com"]
 
-  spec.required_ruby_version = '>= 2.3.7'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.summary       = %q{Pluggable Ruby translation framework}
   spec.description   = %q{Stores and retrieves localized data through attributes on a Ruby class, with flexible support for different storage strategies.}

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -224,13 +224,13 @@ describe Mobility::Attributes do
       shared_examples_for "reader" do
         it "correctly maps getter method for translated attribute to backend" do
           expect(Mobility).to receive(:locale).and_return(:de)
-          expect(listener).to receive(:read).with(:de, {}).and_return("foo")
+          expect(listener).to receive(:read).with(:de, any_args).and_return("foo")
           expect(article.title).to eq("foo")
         end
 
         it "correctly maps presence method for translated attribute to backend" do
           expect(Mobility).to receive(:locale).and_return(:de)
-          expect(listener).to receive(:read).with(:de, {}).and_return("foo")
+          expect(listener).to receive(:read).with(:de, any_args).and_return("foo")
           expect(article.title?).to eq(true)
         end
 
@@ -263,7 +263,7 @@ describe Mobility::Attributes do
       shared_examples_for "writer" do
         it "correctly maps setter method for translated attribute to backend" do
           expect(Mobility).to receive(:locale).and_return(:de)
-          expect(listener).to receive(:write).with(:de, "foo", {})
+          expect(listener).to receive(:write).with(:de, "foo", any_args)
           article.title = "foo"
         end
 

--- a/spec/mobility/plugins/cache_spec.rb
+++ b/spec/mobility/plugins/cache_spec.rb
@@ -22,7 +22,7 @@ describe Mobility::Plugins::Cache do
       end
 
       it "does not modify options passed in" do
-        allow(listener).to receive(:read).with(locale, {}).and_return("foo")
+        allow(listener).to receive(:read).with(locale, any_args).and_return("foo")
         options = { cache: false }
         backend.read(locale, options)
         expect(options).to eq({ cache: false })
@@ -50,7 +50,7 @@ describe Mobility::Plugins::Cache do
       end
 
       it "does not modify options passed in" do
-        allow(listener).to receive(:write).with(locale, "foo", {})
+        allow(listener).to receive(:write).with(locale, "foo", any_args)
         options = { cache: false }
         backend.write(locale, "foo", options)
         expect(options).to eq({ cache: false })
@@ -62,14 +62,14 @@ describe Mobility::Plugins::Cache do
     shared_examples_for "cache that resets on model action" do |action, options = nil|
       it "updates backend cache on #{action}" do
         aggregate_failures "reading and writing" do
-          expect(listener).to receive(:write).with(:en, "foo", {}).and_return("foo set")
+          expect(listener).to receive(:write).with(:en, "foo", any_args).and_return("foo set")
           backend.write(:en, "foo")
           expect(backend.read(:en)).to eq("foo set")
         end
 
         aggregate_failures "resetting model" do
           options ? instance.send(action, options) : instance.send(action)
-          expect(listener).to receive(:read).with(:en, {}).and_return("from backend")
+          expect(listener).to receive(:read).with(:en, any_args).and_return("from backend")
           expect(backend.read(:en)).to eq("from backend")
         end
       end
@@ -78,8 +78,8 @@ describe Mobility::Plugins::Cache do
     shared_examples_for "cache that resets on model action with multiple backends" do |action, options = nil|
       it "updates cache on both backends on #{action}" do
         aggregate_failures "reading and writing" do
-          expect(listener).to receive(:write).with(:en, "foo", {}).and_return("foo set")
-          expect(content_listener).to receive(:write).with(:en, "bar", {}).and_return("bar set")
+          expect(listener).to receive(:write).with(:en, "foo", any_args).and_return("foo set")
+          expect(content_listener).to receive(:write).with(:en, "bar", any_args).and_return("bar set")
           backend.write(:en, "foo")
           instance.content_backend.write(:en, "bar")
           expect(backend.read(:en)).to eq("foo set")
@@ -88,9 +88,9 @@ describe Mobility::Plugins::Cache do
 
         aggregate_failures "resetting model" do
           options ? instance.send(action, options) : instance.send(action)
-          expect(listener).to receive(:read).with(:en, {}).and_return("from title backend")
+          expect(listener).to receive(:read).with(:en, any_args).and_return("from title backend")
           expect(backend.read(:en)).to eq("from title backend")
-          expect(content_listener).to receive(:read).with(:en, {}).and_return("from content backend")
+          expect(content_listener).to receive(:read).with(:en, any_args).and_return("from content backend")
           expect(instance.content_backend.read(:en)).to eq("from content backend")
         end
       end

--- a/spec/mobility/plugins/default_spec.rb
+++ b/spec/mobility/plugins/default_spec.rb
@@ -9,32 +9,32 @@ describe Mobility::Plugins::Default do
 
     describe "#read" do
       it "returns value if not nil" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return("foo")
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return("foo")
         expect(backend.read(:fr)).to eq("foo")
       end
 
       it "returns value if value is false" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return(false)
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return(false)
         expect(backend.read(:fr)).to eq(false)
       end
 
       it "returns default if backend return value is nil" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return(nil)
         expect(backend.read(:fr)).to eq("default foo")
       end
 
       it "returns value of default override if passed as option to reader" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return(nil)
         expect(backend.read(:fr, default: "default bar")).to eq("default bar")
       end
 
       it "returns nil if passed default: nil as option to reader" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return(nil)
         expect(backend.read(:fr, default: nil)).to eq(nil)
       end
 
       it "returns false if passed default: false as option to reader" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return(nil)
         expect(backend.read(:fr, default: false)).to eq(false)
       end
     end

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -8,7 +8,7 @@ describe Mobility::Plugins::Fallbacks do
     plugin_setup fallbacks: { :'en-US' => 'de-DE', :pt => 'de-DE' }
 
     it "returns value when value is not nil" do
-      allow(listener).to receive(:read).once.with(:ja, {}).and_return("ja val")
+      allow(listener).to receive(:read).once.with(:ja, any_args).and_return("ja val")
       expect(backend.read(:ja)).to eq("ja val")
     end
 
@@ -34,7 +34,7 @@ describe Mobility::Plugins::Fallbacks do
     end
 
     it "returns backend value when fallback: false option is passed" do
-      expect(listener).to receive(:read).once.with(:'en-US', {}).and_return('')
+      expect(listener).to receive(:read).once.with(:'en-US', any_args).and_return('')
       expect(backend.read(:'en-US', fallback: false)).to eq('')
     end
 
@@ -93,9 +93,9 @@ describe Mobility::Plugins::Fallbacks do
     plugin_setup fallbacks: nil
 
     it "does not use fallbacks when accessor fallback option is false or nil" do
-      expect(listener).to receive(:read).with(:'en-US', {}).once.and_return('')
+      expect(listener).to receive(:read).with(:'en-US', any_args).once.and_return('')
       expect(backend.read(:'en-US')).to eq('')
-      expect(listener).to receive(:read).with(:'en-US', {}).once.and_return('')
+      expect(listener).to receive(:read).with(:'en-US', any_args).once.and_return('')
       expect(backend.read(:'en-US', fallback: false)).to eq('')
     end
 
@@ -115,7 +115,7 @@ describe Mobility::Plugins::Fallbacks do
     end
 
     it "does not use fallbacks when fallback: true option is passed" do
-      expect(listener).to receive(:read).once.with(:'en-US', {}).and_return(nil)
+      expect(listener).to receive(:read).once.with(:'en-US', any_args).and_return(nil)
       expect(backend.read(:'en-US', fallback: true)).to eq(nil)
     end
   end

--- a/spec/mobility/plugins/presence_spec.rb
+++ b/spec/mobility/plugins/presence_spec.rb
@@ -9,33 +9,33 @@ describe Mobility::Plugins::Presence do
 
     describe "#read" do
       it "passes through present values unchanged" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return("foo")
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return("foo")
         expect(backend.read(:fr)).to eq("foo")
       end
 
       it "converts blank strings to nil" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return("")
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return("")
         expect(backend.read(:fr)).to eq(nil)
       end
 
       it "passes through nil values unchanged" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return(nil)
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return(nil)
         expect(backend.read(:fr)).to eq(nil)
       end
 
       it "passes through false values unchanged" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return(false)
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return(false)
         expect(backend.read(:fr)).to eq(false)
       end
 
       it "does not convert blank string to nil if presence: false passed as option" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return("")
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return("")
         expect(backend.read(:fr, presence: false)).to eq("")
       end
 
       it "does not modify options passed in" do
         options = { presence: false }
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return("")
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return("")
         backend.read(:fr, options)
         expect(options).to eq({ presence: false })
       end
@@ -43,33 +43,33 @@ describe Mobility::Plugins::Presence do
 
     describe "#write" do
       it "passes through present values unchanged" do
-        expect(listener).to receive(:write).once.with(:fr, "foo", {}).and_return("foo")
+        expect(listener).to receive(:write).once.with(:fr, "foo", any_args).and_return("foo")
         expect(backend.write(:fr, "foo")).to eq("foo")
       end
 
       it "converts blank strings to nil" do
-        expect(listener).to receive(:write).once.with(:fr, nil, {}).and_return(nil)
+        expect(listener).to receive(:write).once.with(:fr, nil, any_args).and_return(nil)
         expect(backend.write(:fr, "")).to eq(nil)
       end
 
       it "passes through nil values unchanged" do
-        expect(listener).to receive(:write).once.with(:fr, nil, {}).and_return(nil)
+        expect(listener).to receive(:write).once.with(:fr, nil, any_args).and_return(nil)
         expect(backend.write(:fr, nil)).to eq(nil)
       end
 
       it "passes through false values unchanged" do
-        expect(listener).to receive(:write).once.with(:fr, false, {}).and_return(false)
+        expect(listener).to receive(:write).once.with(:fr, false, any_args).and_return(false)
         expect(backend.write(:fr, false)).to eq(false)
       end
 
       it "does not convert blank string to nil if presence: false passed as option" do
-        expect(listener).to receive(:write).once.with(:fr, "", {}).and_return("")
+        expect(listener).to receive(:write).once.with(:fr, "", any_args).and_return("")
         expect(backend.write(:fr, "", presence: false)).to eq("")
       end
 
       it "does not modify options passed in" do
         options = { presence: false }
-        expect(listener).to receive(:write).once.with(:fr, "foo", {})
+        expect(listener).to receive(:write).once.with(:fr, "foo", any_args)
         backend.write(:fr, "foo", options)
         expect(options).to eq({ presence: false })
       end
@@ -81,14 +81,14 @@ describe Mobility::Plugins::Presence do
 
     describe "#read" do
       it "does not convert blank strings to nil" do
-        expect(listener).to receive(:read).once.with(:fr, {}).and_return("")
+        expect(listener).to receive(:read).once.with(:fr, any_args).and_return("")
         expect(backend.read(:fr)).to eq("")
       end
     end
 
     describe "#write" do
       it "does not convert blank strings to nil" do
-        expect(listener).to receive(:write).once.with(:fr, "", {}).and_return("")
+        expect(listener).to receive(:write).once.with(:fr, "", any_args).and_return("")
         expect(backend.write(:fr, "")).to eq("")
       end
     end


### PR DESCRIPTION
2.4 was EOLed on 2020-03-31.