### PR TITLE
Fix issue with method_missing in fallthrough_accessors

### DIFF
--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -49,14 +49,18 @@ model class is generated.
       def define_fallthrough_accessors(*names)
         method_name_regex = /\A(#{names.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
 
-        define_method :method_missing do |method_name, *arguments, **options, &block|
+        define_method :method_missing do |method_name, *args, &block|
           if method_name =~ method_name_regex
-            attribute = $1.to_sym
+            attribute_method = "#{$1}#{$4}"
             locale, suffix = $2.split('_')
             locale = "#{locale}-#{suffix.upcase}" if suffix
-            public_send("#{attribute}#{$4}", *arguments, **options, locale: locale.to_sym)
+            if $4 == '=' # writer
+              public_send(attribute_method, args[0], **(args[1] || {}), locale: locale.to_sym)
+            else         # reader
+              public_send(attribute_method, **(args[0] || {}), locale: locale.to_sym)
+            end
           else
-            super(method_name, *arguments, **options, &block)
+            super(method_name, *args, &block)
           end
         end
 

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -18,6 +18,7 @@ describe Mobility::Plugins::FallthroughAccessors do
         end
       end
 
+      model_class = Class.new
       model_class.include mod
       model_class.include attributes
 

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -27,6 +27,22 @@ describe Mobility::Plugins::FallthroughAccessors do
       options = { some: 'params' }
       expect(instance.foo(**options)).to eq(options)
     end
+
+    it 'does not raise when passed empty options' do
+      mod = Module.new do
+        def method_missing(method_name, *args, &block)
+          method_name == :bar ? args : super
+        end
+      end
+
+      model_class = Class.new
+      model_class.include mod
+      model_class.include attributes
+
+      instance = model_class.new
+
+      expect(instance.bar).to eq([])
+    end
   end
 
   context "option value is false" do


### PR DESCRIPTION
An issue was raised in gitter chat about options keywords being incorrectly passed to `method_missing` in ActiveModel/ActiveRecord with the change in #364.

The problem is subtle but I've added a test and a tentative fix for it here.

Fixes #376.