### PR TITLE
Handle options keywords correctly in FalthroughAccessors plugin (0-8-stable branch)

### DIFF
--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -46,14 +46,18 @@ model class is generated.
       def initialize(*attributes)
         method_name_regex = /\A(#{attributes.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
 
-        define_method :method_missing do |method_name, *arguments, **options, &block|
+        define_method :method_missing do |method_name, *args, &block|
           if method_name =~ method_name_regex
-            attribute = $1.to_sym
+            attribute_method = "#{$1}#{$4}"
             locale, suffix = $2.split('_')
             locale = "#{locale}-#{suffix.upcase}" if suffix
-            public_send("#{attribute}#{$4}", *arguments, **options, locale: locale.to_sym)
+            if $4 == '=' # writer
+              public_send(attribute_method, args[0], **(args[1] || {}), locale: locale.to_sym)
+            else         # reader
+              public_send(attribute_method, **(args[0] || {}), locale: locale.to_sym)
+            end
           else
-            super(method_name, *arguments, **options, &block)
+            super(method_name, *args, &block)
           end
         end
 

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -33,6 +33,22 @@ describe Mobility::Plugins::FallthroughAccessors do
       options = { some: 'params' }
       expect(instance.foo(**options)).to eq(options)
     end
+
+    it 'does not pass on empty keyword options hash to super' do
+      mod = Module.new do
+        def method_missing(method_name, *args, &block)
+          method_name == :bar ? args : super
+        end
+      end
+
+      klass = Class.new
+      klass.include mod
+      klass.include described_class.new
+
+      instance = klass.new
+
+      expect(instance.bar).to eq([])
+    end
   end
 
   describe ".apply" do


### PR DESCRIPTION
Fixes #376 for 0-8-stable branch.

Related: #377