### PR TITLE
Add depends_on for plugins to declare plugin dependencies

### DIFF
--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -49,6 +49,20 @@ method calls on +Mobility::Attributes+ instance.
       end
     end
 
+    def dependencies
+      @dependencies ||= Set.new
+    end
+
+    def depends_on(plugin)
+      dependencies << plugin
+    end
+
+    def included(attributes_class)
+      dependencies.each do |dependency|
+        attributes_class.plugin dependency
+      end
+    end
+
     private
 
     def plugin_key

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -21,9 +21,7 @@ details.
     module Dirty
       extend Plugin
 
-      def self.included(attributes_class)
-        attributes_class.plugin :fallthrough_accessors
-      end
+      depends_on :fallthrough_accessors
 
       initialize_hook do |dirty: nil|
         @options[:fallthrough_accessors] = true if dirty == true


### PR DESCRIPTION
I'm in the process of breaking up Mobility into some finer-grained plugins (for readers/writers and backend itself), but doing that will require the concept of "dependencies" between plugins. Currently there is only one of these: dirty depends on fallthrough accessors. I'm adding a `depends_on` class method to define the dependency explicitly to make further changes down the line easier.