### PR TITLE
Specify plugins in configure block, and declare before/after on dependencies

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -25,6 +25,10 @@ in backends to define gem-dependent behavior.
 
 =end
 module Mobility
+  # A generic exception used by Mobility.
+  class Error < StandardError
+  end
+
   require "mobility/attributes"
   require "mobility/backend"
   require "mobility/backends"
@@ -34,10 +38,6 @@ module Mobility
   require "mobility/plugin"
   require "mobility/plugins"
   require "mobility/translates"
-
-  # A generic exception used by Mobility.
-  class Error < StandardError
-  end
 
   # General error for version compatibility conflicts
   class VersionNotSupportedError < ArgumentError; end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "mobility/util"
+require "tsort"
 
 module Mobility
 =begin
@@ -108,8 +109,14 @@ with other backends.
 
 =end
   class Attributes < Module
-    def self.plugin(name)
-      include Plugins.load_plugin(name)
+    class << self
+      def plugin(name)
+        Plugin.configure(self) { __send__ name }
+      end
+
+      def plugins(&block)
+        Plugin.configure(self, &block)
+      end
     end
 
     # Attribute names for which accessors will be defined

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -244,7 +244,7 @@ EOL
     end
 
     module ClassMethods
-      # Return all {Mobility::Attribute} module instances from among ancestors
+      # Return all {Mobility::Attributes} module instances from among ancestors
       # of this model.
       # @return [Array<Mobility::Attributes>] Attribute modules
       def mobility_modules

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -30,7 +30,7 @@ Stores shared Mobility configuration referenced by all backends.
 
     # @param [Symbol] name Plugin name
     def plugins(*names)
-      names.each(&method(:plugin))
+      names.each { |name| attributes_class.plugin name }
     end
 
     # Generate new fallbacks instance

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -54,6 +54,7 @@ method calls on +Mobility::Attributes+ instance.
     end
 
     def depends_on(plugin)
+      require "mobility/plugins/#{plugin}"
       dependencies << plugin
     end
 

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -42,10 +42,10 @@ option value. For examples, see classes under the {Mobility::Plugins} namespace.
         end
         plugin
       end
-    end
 
-    def self.register_plugin(name, mod)
-      @plugins[name] = mod
+      def register_plugin(name, mod)
+        @plugins[name] = mod
+      end
     end
   end
 end

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "mobility/plugins/fallthrough_accessors"
 
 module Mobility
   module Plugins
@@ -21,7 +20,7 @@ details.
     module Dirty
       extend Plugin
 
-      depends_on :fallthrough_accessors
+      depends_on :fallthrough_accessors, include: :after
 
       initialize_hook do |dirty: nil|
         @options[:fallthrough_accessors] = true if dirty == true

--- a/spec/mobility/plugin_spec.rb
+++ b/spec/mobility/plugin_spec.rb
@@ -1,0 +1,114 @@
+require "spec_helper"
+
+describe Mobility::Plugin do
+  let(:pluggable) { Class.new(Module) }
+
+  describe 'dependencies' do
+    def self.define_plugin(name)
+      let!(name) do
+        Module.new.tap do |mod|
+          mod.extend Mobility::Plugin
+          Mobility::Plugins.register_plugin(name, mod)
+        end
+      end
+    end
+
+    define_plugin(:foo)
+    define_plugin(:bar)
+    define_plugin(:baz)
+
+    after do
+      plugins = Mobility::Plugins.instance_variable_get(:@plugins)
+      plugins.delete(:foo)
+      plugins.delete(:bar)
+      plugins.delete(:baz)
+    end
+
+    describe '.configure' do
+      it 'includes plugin' do
+        described_class.configure(pluggable) do
+          __send__ :foo
+        end
+        expect(pluggable.included_modules).to include(foo)
+      end
+
+      it 'detects before dependency conflict between two plugins' do
+        foo.depends_on :bar, include: :before
+        bar.depends_on :foo, include: :before
+        expect {
+          described_class.configure(pluggable) do
+            __send__ :foo
+            __send__ :bar
+          end
+        }.to raise_error(Mobility::Plugin::CyclicDependency)
+      end
+
+      it 'detects after dependency conflict between two plugins' do
+        foo.depends_on :bar, include: :after
+        bar.depends_on :foo, include: :after
+        expect {
+          described_class.configure(pluggable) do
+            __send__ :foo
+            __send__ :bar
+          end
+        }.to raise_error(Mobility::Plugin::CyclicDependency)
+      end
+
+      it 'detects before dependency conflict between three plugins' do
+        foo.depends_on :baz, include: :before
+        bar.depends_on :foo, include: :before
+        baz.depends_on :bar, include: :before
+        expect {
+          described_class.configure(pluggable) do
+            __send__ :foo
+            __send__ :bar
+            __send__ :baz
+          end
+        }.to raise_error(Mobility::Plugin::CyclicDependency)
+      end
+
+      it 'detects after dependency conflict between three plugins' do
+        foo.depends_on :baz, include: :after
+        bar.depends_on :foo, include: :after
+        baz.depends_on :bar, include: :after
+        expect {
+          described_class.configure(pluggable) do
+            __send__ :foo
+            __send__ :bar
+            __send__ :baz
+          end
+        }.to raise_error(Mobility::Plugin::CyclicDependency)
+      end
+
+      it 'correctly includes plugins with no dependency conflicts' do
+        foo.depends_on :bar, include: :before
+        baz.depends_on :foo, include: :before
+        bar.depends_on :baz, include: :after
+
+        expect {
+          described_class.configure(pluggable) do
+            __send__ :baz
+            __send__ :bar
+            __send__ :foo
+          end
+        }.not_to raise_error
+
+        expect(pluggable.included_modules.grep(Mobility::Plugin)).to eq([baz, foo, bar])
+      end
+
+      it 'raises CyclicDependency error if plugin has after dependency on previously included plugin' do
+        bar.depends_on :foo, include: :after
+
+        described_class.configure(pluggable) do
+          __send__ :foo
+        end
+
+        expect {
+          described_class.configure(pluggable) do
+            __send__ :bar
+          end
+        }.to raise_error(Mobility::Plugin::CyclicDependency)
+      end
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -119,13 +119,15 @@ module Helpers
       # Sets up attributes module with a listener to listen on reads/writes to the
       # backend. Pass two separate arrays to create separate attributes modules.
       def plugin_setup(attribute_name = "title", *other_names, **options)
-        plugins = options.keys & %i[query cache dirty fallbacks presence default attribute_methods fallthrough_accessors locale_accessors]
+        plugin_names = options.keys & %i[query cache dirty fallbacks presence default attribute_methods fallthrough_accessors locale_accessors]
 
         attribute_names = [attribute_name, *other_names]
         let(:attribute_name) { attribute_name }
         let(:attributes_class) do
-          Class.new(TestAttributes).tap do |attrs|
-            plugins.each { |plugin| attrs.plugin plugin }
+          Class.new(TestAttributes) do
+            plugins do
+              plugin_names.each { |p| __send__ p }
+            end
           end
         end
         let(:model_class) do


### PR DESCRIPTION
Currently, plugins are declared inside the body of a `Mobility::Attributes` instance. Dependencies declared with `depends_on` in the plugin are then included after the plugin itself.

 This may not always be what we want, since multiple plugins may depend on each other. To correctly resolve dependencies, this requires wrapping plugin declarations in a block:

```ruby
class TranslatedAttributes < Mobility::Attributes
 plugins do
   foo
   bar
 end
end
```

In addition, plugins now declare dependencies with a required keyword argument, `include: :before` or `include: :after`, which specifies whether to include the dependency before or after the plugin itself. We then use `TSort` to sort dependencies such that the requirements on include order are met.

You can also add plugins one by one, like previously:

```ruby
class TranslatedAttributes < Mobility::Attributes
  plugin :foo
  plugin :bar
end
```

Internally this does the same as the block format, except with multiple blocks. In this case (and if you define multiple blocks separately), Mobility will raise a `Mobility::Plugin::CyclicDependency` error if there is a failure to resolve dependencies between plugins.

e.g.

```ruby
class TranslatedAttributes < Mobility::Attributes
  plugin :fallthrough_accessors
  plugin :dirty
end
```

This will raise `Plugin dependencies cannot be resolved between: Mobility::Plugins::Dirty, Mobility::Plugins::FallthroughAccessors`, because dirty depends on fallthrough accessors being included after itself.