### PR TITLE
Register plugins explicitly

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -35,6 +35,10 @@ module Mobility
   require "mobility/plugins"
   require "mobility/translates"
 
+  # A generic exception used by Mobility.
+  class Error < StandardError
+  end
+
   # General error for version compatibility conflicts
   class VersionNotSupportedError < ArgumentError; end
   CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -31,12 +31,21 @@ option value. For examples, see classes under the {Mobility::Plugins} namespace.
 
 =end
   module Plugins
+    @plugins = {}
+
     class << self
-      # @param [Symbol] backend Name of plugin to load.
-      def load_plugin(plugin)
-        require "mobility/plugins/#{plugin}"
-        Mobility.get_class_from_key(self, plugin)
+      # @param [Symbol] name Name of plugin to load.
+      def load_plugin(name)
+        unless (plugin = @plugins[name])
+          require "mobility/plugins/#{name}"
+          raise Error, "plugin #{name} did not register itself correctly in Mobility::Plugins" unless (plugin = @plugins[name])
+        end
+        plugin
       end
+    end
+
+    def self.register_plugin(name, mod)
+      @plugins[name] = mod
     end
   end
 end

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -268,5 +268,7 @@ enabled for any one attribute on the model.
         private_constant :QueryExtension, :FindByMethods
       end
     end
+
+    register_plugin(:query, Query)
   end
 end

--- a/lib/mobility/plugins/attribute_methods.rb
+++ b/lib/mobility/plugins/attribute_methods.rb
@@ -34,5 +34,7 @@ attributes only.
         model_class.include module_builder.new(*attribute_names)
       end
     end
+
+    register_plugin(:attribute_methods, AttributeMethods)
   end
 end

--- a/lib/mobility/plugins/cache.rb
+++ b/lib/mobility/plugins/cache.rb
@@ -111,5 +111,7 @@ Values are added to the cache in two ways:
         end
       end
     end
+
+    register_plugin(:cache, Cache)
   end
 end

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -97,5 +97,7 @@ The proc can accept zero to three arguments (see examples below)
         # @!endgroup
       end
     end
+
+    register_plugin(:default, Default)
   end
 end

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -55,5 +55,7 @@ details.
         model_class.include dirty_module.const_get(:MethodsBuilder).new(*attribute_names)
       end
     end
+
+    register_plugin(:dirty, Dirty)
   end
 end

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -163,5 +163,7 @@ the current locale was +nil+.
         end
       end
     end
+
+    register_plugin(:fallbacks, Fallbacks)
   end
 end

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -69,5 +69,7 @@ model class is generated.
         end
       end
     end
+
+    register_plugin :fallthrough_accessors, FallthroughAccessors
   end
 end

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -81,5 +81,7 @@ available locales for a Rails application) will be used by default.
         EOM
       end
     end
+
+    register_plugin(:locale_accessors, LocaleAccessors)
   end
 end

--- a/lib/mobility/plugins/presence.rb
+++ b/lib/mobility/plugins/presence.rb
@@ -46,5 +46,7 @@ backend.
         (value == "") ? nil : value
       end
     end
+
+    register_plugin(:presence, Presence)
   end
 end

--- a/lib/mobility/plugins/query.rb
+++ b/lib/mobility/plugins/query.rb
@@ -28,5 +28,7 @@ module Mobility
         end
       end
     end
+
+    register_plugin(:query, Query)
   end
 end


### PR DESCRIPTION
This is an idea borrowed from Shrine, Roda and other gems. Basically, we shouldn't be just assuming every plugin is in the Mobility::Plugins namespace, and that everything in this namespace is a plugin (some classes like Mobility::Plugins::ActiveModel, etc are actually not).

By explicitly declaring the mapping between keys and plugin modules, things are clearer, easier to test, and easier to extend (e.g. if you don't require a plugin from Mobility, you can use the same key for your own plugin module).