### PR TITLE
Register backends explicitly

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -152,15 +152,6 @@ module Mobility
       @configuration ||= Configuration.new
     end
 
-    # @param [Class] parent_class Parent class in namespace
-    # @param [Symbol] key Name of class to find in namespace
-    # @return [Class] Class in namespace matching key
-    # @api private
-    def get_class_from_key(parent_class, key)
-      klass_name = key.to_s.gsub(/(^|_)(.)/){|x| x[-1..-1].upcase}
-      parent_class.const_get(klass_name)
-    end
-
     # (see Mobility::Configuration#accessor_method)
     # @!method accessor_method
     #

--- a/lib/mobility/backends.rb
+++ b/lib/mobility/backends.rb
@@ -1,13 +1,22 @@
 module Mobility
   module Backends
+    @backends = {}
+
     class << self
-      # @param [Symbol, Object] backend Name of backend class to load, or
-      #   backend class itself.
-      def load_backend(backend)
-        return backend if Module === backend
-        require "mobility/backends/#{backend}"
-        Mobility.get_class_from_key(self, backend)
+      # @param [Symbol, Object] backend Name of backend to load.
+      def load_backend(name)
+        return name if Module === name
+
+        unless (backend = @backends[name])
+          require "mobility/backends/#{name}"
+          raise Error, "backend #{name} did not register itself correctly in Mobility::Backends" unless (backend = @backends[name])
+        end
+        backend
       end
+    end
+
+    def self.register_backend(name, mod)
+      @backends[name] = mod
     end
   end
 end

--- a/lib/mobility/backends/column.rb
+++ b/lib/mobility/backends/column.rb
@@ -49,5 +49,7 @@ be ignored if set, since it would cause a conflict with column accessors.
         base.extend Backend::OrmDelegator
       end
     end
+
+    register_backend(:column, Column)
   end
 end

--- a/lib/mobility/backends/container.rb
+++ b/lib/mobility/backends/container.rb
@@ -21,5 +21,7 @@ stored).
     module Container
       extend Backend::OrmDelegator
     end
+
+    register_backend(:container, Container)
   end
 end

--- a/lib/mobility/backends/hash.rb
+++ b/lib/mobility/backends/hash.rb
@@ -33,5 +33,7 @@ Backend which stores translations in an in-memory hash.
         @translations ||= {}
       end
     end
+
+    register_backend(:hash, Hash)
   end
 end

--- a/lib/mobility/backends/hstore.rb
+++ b/lib/mobility/backends/hstore.rb
@@ -19,5 +19,7 @@ Prefix and suffix to add to attribute name to generate hstore column name.
     module Hstore
       extend Backend::OrmDelegator
     end
+
+    register_backend(:hstore, Hstore)
   end
 end

--- a/lib/mobility/backends/json.rb
+++ b/lib/mobility/backends/json.rb
@@ -18,5 +18,7 @@ Prefix and suffix to add to attribute name to generate json column name.
     module Json
       extend Backend::OrmDelegator
     end
+
+    register_backend(:json, Json)
   end
 end

--- a/lib/mobility/backends/jsonb.rb
+++ b/lib/mobility/backends/jsonb.rb
@@ -18,5 +18,7 @@ Prefix and suffix to add to attribute name to generate jsonb column name.
     module Jsonb
       extend Backend::OrmDelegator
     end
+
+    register_backend(:jsonb, Jsonb)
   end
 end

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -140,5 +140,7 @@ other backends on model (otherwise one will overwrite the other).
         end
       end
     end
+
+    register_backend(:key_value, KeyValue)
   end
 end

--- a/lib/mobility/backends/null.rb
+++ b/lib/mobility/backends/null.rb
@@ -20,5 +20,7 @@ Backend which does absolutely nothing. Mostly for testing purposes.
       def self.configure(_); end
       # @!endgroup
     end
+
+    register_backend(:null, Null)
   end
 end

--- a/lib/mobility/backends/serialized.rb
+++ b/lib/mobility/backends/serialized.rb
@@ -70,5 +70,7 @@ Format for serialization. Either +:yaml+ (default) or +:json+.
         end
       end
     end
+
+    register_backend(:serialized, Serialized)
   end
 end

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -158,5 +158,7 @@ set.
         end
       end
     end
+
+    register_backend(:table, Table)
   end
 end


### PR DESCRIPTION
Declares backends the way we now declare plugins, making the relationship between the backend key and the backend class explicit and customizable.

Similar to #393 for plugins, but for backends.