### PR TITLE
Correctly handle previously-included mutual dependencies

### DIFF
--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -104,8 +104,8 @@ instance (+Mobility::Attributes+), with a block.
 
         # Add any previously included plugins as dependencies of new plugins,
         # ensuring any dependencies between them are met.
-        plugins = included_plugins
-        tree.each_key { |plugin| tree[plugin] += plugins }
+        before_dependencies = included_plugins
+        tree.each_key { |plugin| tree[plugin] += before_dependencies }
 
         pluggable.include(*tree.tsort.reverse) unless tree.empty?
       rescue TSort::Cyclic => e

--- a/spec/mobility/plugin_spec.rb
+++ b/spec/mobility/plugin_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe Mobility::Plugin do
   let(:pluggable) { Class.new(Module) }
+  let(:included_plugins) { pluggable.included_modules.grep(described_class) }
 
   describe 'dependencies' do
     def self.define_plugin(name)
@@ -30,7 +31,7 @@ describe Mobility::Plugin do
         described_class.configure(pluggable) do
           __send__ :foo
         end
-        expect(pluggable.included_modules).to include(foo)
+        expect(included_plugins).to include(foo)
       end
 
       it 'detects before dependency conflict between two plugins' do
@@ -94,7 +95,7 @@ describe Mobility::Plugin do
           end
         }.not_to raise_error
 
-        expect(pluggable.included_modules.grep(Mobility::Plugin)).to eq([baz, foo, bar])
+        expect(included_plugins).to eq([baz, foo, bar])
       end
 
       it 'raises CyclicDependency error if plugin has after dependency on previously included plugin' do
@@ -126,7 +127,7 @@ describe Mobility::Plugin do
           end
         }.not_to raise_error
 
-        expect(pluggable.included_modules.grep(Mobility::Plugin)).to eq([bar, foo, baz])
+        expect(included_plugins).to eq([bar, foo, baz])
       end
 
       it 'handles non-conflicting cyclic dependencies which have already been included' do
@@ -144,7 +145,7 @@ describe Mobility::Plugin do
           end
         }.not_to raise_error
 
-        last_included, *others = pluggable.included_modules.grep(Mobility::Plugin)
+        last_included, *others = included_plugins
         expect(last_included).to eq(bar)
         expect(others).to match_array([foo, baz])
       end

--- a/spec/mobility/plugin_spec.rb
+++ b/spec/mobility/plugin_spec.rb
@@ -9,6 +9,7 @@ describe Mobility::Plugin do
         Module.new.tap do |mod|
           mod.extend Mobility::Plugin
           Mobility::Plugins.register_plugin(name, mod)
+          stub_const(name.to_s.capitalize, mod)
         end
       end
     end


### PR DESCRIPTION
This is a bit of a subtle point, but the code change here simply adds all previously included plugins to `visited` when it starts recursively building the dependency tree, thus skipping them and avoiding conflicts.