### PR TITLE
Define defaults with plugins

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -164,15 +164,12 @@ module Mobility
     # (see Mobility::Configuration#default_backend)
     # @!method default_backend
 
-    # (see Mobility::Configuration#default_options)
-    # @!method default_options
-    #
     # (see Mobility::Configuration#plugins)
     # @!method plugins
     #
     # (see Mobility::Configuration#default_accessor_locales)
     # @!method default_accessor_locales
-    %w[accessor_method query_method default_backend default_options plugins default_accessor_locales].each do |method_name|
+    %w[accessor_method query_method default_backend plugins default_accessor_locales].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -110,12 +110,16 @@ with other backends.
 =end
   class Attributes < Module
     class << self
-      def plugin(name)
-        Plugin.configure(self) { __send__ name }
+      def plugin(name, **options)
+        Plugin.configure(self, defaults) { __send__ name, **options }
       end
 
       def plugins(&block)
-        Plugin.configure(self, &block)
+        Plugin.configure(self, defaults, &block)
+      end
+
+      def defaults
+        @defaults ||= {}
       end
     end
 
@@ -124,9 +128,9 @@ with other backends.
     attr_reader :names
 
     # @param [Array<String>] attribute_names Names of attributes to define backend for
-    # @param [Hash] backend_options Backend options hash
-    def initialize(*attribute_names, **backend_options)
-      @options = Mobility.default_options.to_h.merge(backend_options)
+    # @param [Hash] options Backend options hash
+    def initialize(*attribute_names, **options)
+      @options = self.class.defaults.merge(options)
       @names = attribute_names.map(&:to_s).freeze
     end
 

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -7,8 +7,6 @@ Stores shared Mobility configuration referenced by all backends.
 
 =end
   class Configuration
-    RESERVED_OPTION_KEYS = %i[backend model_class].freeze
-
     # Alias for mobility_accessor (defaults to +translates+)
     # @return [Symbol]
     attr_accessor :accessor_method
@@ -16,12 +14,6 @@ Stores shared Mobility configuration referenced by all backends.
     # Name of query scope/dataset method (defaults to +i18n+)
     # @return [Symbol]
     attr_accessor :query_method
-
-    # Default set of options. These will be merged with any backend options
-    # when defining translated attributes (with +translates+). Default options
-    # may not include the keys 'backend' or 'model_class'.
-    # @return [Hash]
-    attr_reader :default_options
 
     # @param [Symbol] name Plugin name
     def plugin(name)
@@ -52,7 +44,9 @@ Stores shared Mobility configuration referenced by all backends.
 
     # Default backend to use (can be symbol or actual backend class)
     # @return [Symbol,Class]
-    attr_accessor :default_backend
+    def default_backend
+      attributes_class.defaults[:backend]
+    end
 
     # Returns set of default accessor locales to use (defaults to
     # +I18n.available_locales+)
@@ -71,23 +65,10 @@ Stores shared Mobility configuration referenced by all backends.
       @query_method = :i18n
       @fallbacks_generator = lambda { |fallbacks| Mobility::Fallbacks.build(fallbacks) }
       @default_accessor_locales = lambda { Mobility.available_locales }
-      @default_options = Options[{
-      }]
     end
 
     def attributes_class
       @attributes_class ||= Class.new(Attributes)
-    end
-
-    class ReservedOptionKey < Exception; end
-
-    class Options < ::Hash
-      def []=(key, _)
-        if RESERVED_OPTION_KEYS.include?(key)
-          raise Configuration::ReservedOptionKey, "Default options may not contain the following reserved key: #{key}"
-        end
-        super
-      end
     end
   end
 end

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -152,7 +152,8 @@ instance (+Mobility::Attributes+), with a block.
 
       def check_after_dependency!(dep, dep_name, plugin_name)
         if included_plugins.include?(dep)
-          raise DependencyConflict, "'#{dep_name}' plugin must come after '#{plugin_name}' plugin"
+          message = "'#{dep_name}' plugin must come after '#{plugin_name}' plugin"
+          raise DependencyConflict, append_pluggable_name(message)
         end
       end
 
@@ -161,7 +162,12 @@ instance (+Mobility::Attributes+), with a block.
         names = components.split(', ').map! do |plugin|
           Plugins.lookup_name(Object.const_get(plugin)).to_s
         end
-        raise CyclicDependency, "Dependencies cannot be resolved between: #{names.sort.join(', ')}"
+        message = "Dependencies cannot be resolved between: #{names.sort.join(', ')}"
+        raise CyclicDependency, append_pluggable_name(message)
+      end
+
+      def append_pluggable_name(message)
+        pluggable.name ? "#{message} in #{pluggable}" : message
       end
 
       class DependencyTree < Hash

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -43,6 +43,11 @@ option value. For examples, see classes under the {Mobility::Plugins} namespace.
         plugin
       end
 
+      # @param [Module] plugin Plugin module to lookup. Plugin must already be loaded.
+      def lookup_name(plugin)
+        @plugins.invert[plugin]
+      end
+
       def register_plugin(name, mod)
         @plugins[name] = mod
       end

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -18,7 +18,7 @@ plugins must depend on this.
       # @return [Symbol,Class] Name of backend, or backend class
       attr_reader :backend_name
 
-      initialize_hook do |*names, backend: Mobility.default_backend|
+      initialize_hook do |*names, backend:|
         @backend_name = backend
 
         names.each do |name|

--- a/spec/mobility/configuration_spec.rb
+++ b/spec/mobility/configuration_spec.rb
@@ -29,16 +29,4 @@ describe Mobility::Configuration do
       expect(subject.default_accessor_locales).to eq([:en, :de])
     end
   end
-
-  describe "#default_options" do
-    it "raises exception when reserved option keys are set" do
-      aggregate_failures do
-        %i[backend model_class].each do |reserved_key|
-          expect {
-            subject.default_options[reserved_key] = "value"
-          }.to raise_error(Mobility::Configuration::ReservedOptionKey)
-        end
-      end
-    end
-  end
 end

--- a/spec/mobility/plugin_spec.rb
+++ b/spec/mobility/plugin_spec.rb
@@ -44,7 +44,8 @@ describe Mobility::Plugin do
             __send__ :foo
             __send__ :bar
           end
-        }.to raise_error(Mobility::Plugin::CyclicDependency)
+        }.to raise_error(Mobility::Plugin::CyclicDependency,
+                         "Dependencies cannot be resolved between: bar, foo")
       end
 
       it 'detects after dependency conflict between two plugins' do
@@ -55,7 +56,8 @@ describe Mobility::Plugin do
             __send__ :foo
             __send__ :bar
           end
-        }.to raise_error(Mobility::Plugin::CyclicDependency)
+        }.to raise_error(Mobility::Plugin::CyclicDependency,
+                         "Dependencies cannot be resolved between: bar, foo")
       end
 
       it 'detects before dependency conflict between three plugins' do
@@ -68,7 +70,8 @@ describe Mobility::Plugin do
             __send__ :bar
             __send__ :baz
           end
-        }.to raise_error(Mobility::Plugin::CyclicDependency)
+        }.to raise_error(Mobility::Plugin::CyclicDependency,
+                         "Dependencies cannot be resolved between: bar, baz, foo")
       end
 
       it 'detects after dependency conflict between three plugins' do
@@ -81,7 +84,8 @@ describe Mobility::Plugin do
             __send__ :bar
             __send__ :baz
           end
-        }.to raise_error(Mobility::Plugin::CyclicDependency)
+        }.to raise_error(Mobility::Plugin::CyclicDependency,
+                         "Dependencies cannot be resolved between: bar, baz, foo")
       end
 
       it 'correctly includes plugins with no dependency conflicts' do
@@ -100,7 +104,7 @@ describe Mobility::Plugin do
         expect(included_plugins).to eq([baz, foo, bar])
       end
 
-      it 'raises CyclicDependency error if plugin has after dependency on previously included plugin' do
+      it 'raises DependencyConflict error if plugin has after dependency on previously included plugin' do
         bar.depends_on :foo, include: :after
 
         described_class.configure(pluggable) do
@@ -111,7 +115,8 @@ describe Mobility::Plugin do
           described_class.configure(pluggable) do
             __send__ :bar
           end
-        }.to raise_error(Mobility::Plugin::CyclicDependency)
+        }.to raise_error(Mobility::Plugin::DependencyConflict,
+                         "'foo' plugin must come after 'bar' plugin")
       end
 
       it 'skips mutual before dependencies which have already been included' do

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -20,7 +20,7 @@ describe Mobility::Plugins::Backend do
     it "assigns options to backend class" do
       attributes = attributes_class.new("title", backend: backend_class, foo: "bar")
       model_class.include attributes
-      expect(attributes.backend_class.options).to eq(Mobility.default_options.merge(backend: backend_class, model_class: model_class, foo: "bar"))
+      expect(attributes.backend_class.options).to eq(backend: backend_class, model_class: model_class, foo: "bar")
     end
 
     it "freezes backend options after inclusion into model class" do


### PR DESCRIPTION
Instead of having defaults in the configuration, define them alongside the plugins to which they apply:

```ruby
class TranslatedAttributes < Mobility::Attributes
  plugins do
    backend default: :key_value
    fallbacks default: { en: [:en, :de], de: [:de, :en] }
    locale_accessors default: [:en, :de]
  end
end
```

This also works, provided the order of plugins doesn't conflict with dependency requirements:

```ruby
class TranslatedAttributes < Mobility::Attributes
  plugin :backend, default: :key_value
  plugin :fallbacks, default: { en: [:en, :de], de: [:de, :en] }
  plugin :locale_accessors, default: [:en, :de]
end
```