### PR TITLE
Add Pluggable class

### DIFF
--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
-require "mobility/util"
-require "tsort"
+require "mobility/pluggable"
 
 module Mobility
 =begin
@@ -108,21 +107,7 @@ necessary, ensure that names are defined in such a way as to avoid conflicts
 with other backends.
 
 =end
-  class Attributes < Module
-    class << self
-      def plugin(name, **options)
-        Plugin.configure(self, defaults) { __send__ name, **options }
-      end
-
-      def plugins(&block)
-        Plugin.configure(self, defaults, &block)
-      end
-
-      def defaults
-        @defaults ||= {}
-      end
-    end
-
+  class Attributes < Pluggable
     # Attribute names for which accessors will be defined
     # @return [Array<String>] Array of names
     attr_reader :names
@@ -130,7 +115,7 @@ with other backends.
     # @param [Array<String>] attribute_names Names of attributes to define backend for
     # @param [Hash] options Backend options hash
     def initialize(*attribute_names, **options)
-      @options = self.class.defaults.merge(options)
+      super
       @names = attribute_names.map(&:to_s).freeze
     end
 

--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mobility
+=begin
+
+Abstract Module subclass with methods to define plugins and defaults.
+Works with {Mobility::Plugin}. (Subclassed by {Mobility::Attributes}.)
+
+=end
+  class Pluggable < Module
+    class << self
+      def plugin(name, **options)
+        Plugin.configure(self, defaults) { __send__ name, **options }
+      end
+
+      def plugins(&block)
+        Plugin.configure(self, defaults, &block)
+      end
+
+      def defaults
+        @defaults ||= {}
+      end
+    end
+
+    def initialize(*, **options)
+      @options = self.class.defaults.merge(options)
+    end
+  end
+end

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -107,7 +107,6 @@ Also includes a +configure+ class method to apply plugins to a pluggable
         tree = create_tree(plugins)
 
         pluggable.include(*tree.tsort.reverse) unless tree.empty?
-        defaults
       rescue TSort::Cyclic => e
         raise_cyclic_dependency!(e.message)
       end

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -1,19 +1,21 @@
 # frozen-string-literal: true
+require "tsort"
+require "mobility/util"
 
 module Mobility
 =begin
 
 Defines convenience methods on plugin module to hook into initialize/included
-method calls on +Mobility::Attributes+ instance.
+method calls on +Mobility::Pluggable+ instance.
 
-- #initialize_hook: called after {{Mobility::Attributes#initialize}, with
+- #initialize_hook: called after {Mobility::Pluggable#initialize}, with
   attribute names and options hash.
-- #included_hook: called after {{Mobility::Attributes#included}, with included
-  class (model class) and backend class. (Use this hook to include any
-  module(s) into backend class.)
+- #included_hook: called after {Mobility::Pluggable#included}. (This can be
+  used to include any module(s) into the backend class, see
+  {Mobility::Plugins::Backend}.)
 
 Also includes a +configure+ class method to apply plugins to a pluggable
-instance (+Mobility::Attributes+), with a block.
+({Mobility::Pluggable} instance), with a block.
 
 @example Defining a plugin
   module MyPlugin
@@ -33,7 +35,7 @@ instance (+Mobility::Attributes+), with a block.
     end
   end
 
-@example Configure a pluggable class with plugins
+@example Configure an attributes class with plugins
   class TranslatedAttributes < Mobility::Attributes
   end
 
@@ -47,7 +49,7 @@ instance (+Mobility::Attributes+), with a block.
 =end
   module Plugin
     class << self
-      # Configure a pluggable {Mobility::Attributes} with a block. Yields to a
+      # Configure a pluggable {Mobility::Pluggable} with a block. Yields to a
       # clean room where plugin names define plugins on the module. Plugin
       # dependencies are resolved before applying them.
       #

--- a/spec/performance/attributes_spec.rb
+++ b/spec/performance/attributes_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Mobility::Attributes do
   describe "initializing" do
     specify {
-      expect { described_class.new(backend: :null) }.to allocate_under(10).objects
+      expect { described_class.new(backend: :null) }.to allocate_under(15).objects
     }
   end
 


### PR DESCRIPTION
Plugin inclusion and dependency resolving logic is pretty much entirely divorced now from any real concept of "attributes", so we can split the two cleanly and just have `Mobility::Attributes` subclass a minimal Module subclass, which I'll call `Mobility::Pluggable`.

With this separation, the remaining methods in `Mobility::Attributes` are non-essential and I think we can simply remove most of them since they are not widely used. The goal here is to have as close to zero assumptions baked into `Mobility::Attributes` as possible.