### PR TITLE
Remove Mobility::Backend.method_name

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -123,13 +123,6 @@ On top of this, a backend will normally:
       base.option_reader :model_class
     end
 
-    # @param [String] attribute
-    # @return [String] name of backend reader method
-    def self.method_name(attribute)
-      @backend_method_names ||= {}
-      @backend_method_names[attribute] ||= "#{attribute}_backend"
-    end
-
     # Defines setup hooks for backend to customize model class.
     module ClassMethods
       # Assign block to be called on model class.

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -153,7 +153,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
           end
           define_method :after_save do
             super()
-            attributes.each { |attribute| public_send(Backend.method_name(attribute)).save_translations }
+            attributes.each { |attribute| mobility_backends[attribute].save_translations }
           end
         end
         include callback_methods

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -56,7 +56,7 @@ plugins must depend on this.
 
       def define_backend(attribute)
         module_eval <<-EOM, __FILE__, __LINE__ + 1
-        def #{Mobility::Backend.method_name(attribute)}
+        def #{attribute}_backend
           mobility_backends[:#{attribute}]
         end
         EOM

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -184,10 +184,4 @@ describe Mobility::Backend do
       expect(Class.new(backend).inspect).to match(/MyBackend/)
     end
   end
-
-  describe ".method_name" do
-    it "returns <attribute>_translations" do
-      expect(Mobility::Backend.method_name("foo")).to eq("foo_backend")
-    end
-  end
 end


### PR DESCRIPTION
This method is barely used and code is easier to read if we just inline it.