### PR TITLE
Add BackendReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   ([#400](https://github.com/shioyama/mobility/pull/400))
 - Remove `translated_attribute_names` as alias for `mobility_attributes`
   ([#402](https://github.com/shioyama/mobility/pull/402))
+- Move `_backend` methods into `backend_reader` plugin
+  ([#403](https://github.com/shioyama/mobility/pull/403))
 
 ## 0.8
 

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -6,6 +6,12 @@ module Mobility
 Plugin for setting up a backend for a set of model attributes. All backend
 plugins must depend on this.
 
+Defines:
+- instance method +mobility_backends+ which returns a hash whose keys are
+  attribute names and values a backend for each attribute.
+- class method +mobility_backend_class+ which takes an attribute name and
+  returns the backend class for that name.
+
 =end
     module Backend
       extend Plugin
@@ -18,12 +24,8 @@ plugins must depend on this.
       # @return [Symbol,Class] Name of backend, or backend class
       attr_reader :backend_name
 
-      initialize_hook do |*names, backend:|
+      initialize_hook do |*, backend:|
         @backend_name = backend
-
-        names.each do |name|
-          define_backend(name)
-        end
       end
 
       # Setup backend class, include modules into model class, include/extend
@@ -50,16 +52,6 @@ plugins must depend on this.
       # @return [String]
       def inspect
         "#<Attributes (#{backend_name}) @names=#{names.join(", ")}>"
-      end
-
-      private
-
-      def define_backend(attribute)
-        module_eval <<-EOM, __FILE__, __LINE__ + 1
-        def #{attribute}_backend
-          mobility_backends[:#{attribute}]
-        end
-        EOM
       end
 
       module InstanceMethods

--- a/lib/mobility/plugins/backend_reader.rb
+++ b/lib/mobility/plugins/backend_reader.rb
@@ -5,7 +5,7 @@ module Mobility
 
 Defines convenience methods for accessing backends, of the form
 "<name>_backend". The format for this method can be customized by passing a
-different interpolation string as the plugin option.
+different format string as the plugin option.
 
 =end
     module BackendReader

--- a/lib/mobility/plugins/backend_reader.rb
+++ b/lib/mobility/plugins/backend_reader.rb
@@ -1,0 +1,33 @@
+# frozen-string-literal: true
+module Mobility
+  module Plugins
+=begin
+
+Defines convenience methods for accessing backends, of the form
+"<name>_backend". The format for this method can be customized by passing a
+different interpolation string as the plugin option.
+
+=end
+    module BackendReader
+      extend Plugin
+
+      depends_on :backend
+
+      initialize_hook do |*names, backend_reader: "%s_backend"|
+        names.each { |name| define_backend(name, backend_reader) } if backend_reader
+      end
+
+      private
+
+      def define_backend(attribute, format_string)
+        module_eval <<-EOM, __FILE__, __LINE__ + 1
+        def #{format_string % attribute}
+          mobility_backends[:#{attribute}]
+        end
+        EOM
+      end
+    end
+
+    register_plugin(:backend_reader, BackendReader)
+  end
+end

--- a/spec/integration/active_record_compatibility_spec.rb
+++ b/spec/integration/active_record_compatibility_spec.rb
@@ -30,11 +30,11 @@ describe "ActiveRecord compatibility", orm: :active_record do
 
     it "updates cache when translations association is modified directly" do
       expect(post.title).to eq("foo title")
-      post.send(post.title_backend.association_name).first.value = "association changed value"
+      post.send(backend_for(post, :title).association_name).first.value = "association changed value"
       expect(post.title).to eq("association changed value")
       post.title = "writer changed value"
       expect(post.title).to eq("writer changed value")
-      post.send(post.title_backend.association_name).first.value = "association changed value"
+      post.send(backend_for(post, :title).association_name).first.value = "association changed value"
       post.save
       expect(Post.first.title).to eq("association changed value")
     end

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -14,8 +14,8 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
   end
 
   context "with standard plugins applied" do
-    let(:title_backend)   { article.mobility_backends[:title] }
-    let(:content_backend) { article.mobility_backends[:content] }
+    let(:title_backend)   { backend_for(article, :title) }
+    let(:content_backend) { backend_for(article, :content) }
     let(:cache) { false }
 
     before do

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -21,7 +21,7 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
 
     it "finds translation on every read/write" do
       article = Article.new
-      title_backend = article.mobility_backends[:title]
+      title_backend = backend_for(article, :title)
       expect(title_backend.model.send(title_backend.association_name)).to receive(:find).thrice.and_call_original
       title_backend.write(:en, "foo")
       title_backend.write(:en, "bar")
@@ -35,7 +35,7 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
 
     it "only fetches translation once per locale" do
       article = Article.new
-      title_backend = article.mobility_backends[:title]
+      title_backend = backend_for(article, :title)
 
       aggregate_failures do
         expect(title_backend.model.send(title_backend.association_name)).to receive(:find).twice.and_call_original
@@ -49,8 +49,8 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
 
     it "resets model translations cache when model is saved or reloaded" do
       article = Article.new
-      title_backend = article.mobility_backends[:title]
-      content_backend = article.mobility_backends[:content]
+      title_backend = backend_for(article, :title)
+      content_backend = backend_for(article, :content)
 
       aggregate_failures "cacheing reads" do
         title_backend.read(:en)
@@ -77,7 +77,7 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
     before { Article.translates :title, :content, backend: :table, cache: true }
 
     describe "cleaning up blank translations" do
-      let(:title_backend) { article.mobility_backends[:title] }
+      let(:title_backend) { backend_for(article, :title) }
 
       it "builds nil translations when reading but does not save them" do
         Mobility.locale = :en
@@ -137,8 +137,8 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
       %w[foo bar baz].each { |slug| Article.create!(slug: slug) }
     end
     let(:article) { Article.find_by(slug: "baz") }
-    let(:title_backend) { article.mobility_backends[:title] }
-    let(:content_backend) { article.mobility_backends[:content] }
+    let(:title_backend) { backend_for(article, :title) }
+    let(:content_backend) { backend_for(article, :content) }
 
     subject { article }
 

--- a/spec/mobility/backends/hash_spec.rb
+++ b/spec/mobility/backends/hash_spec.rb
@@ -40,7 +40,7 @@ describe Mobility::Backends::Hash do
       expect(instance.name(locale: :en)).to eq("foo")
       expect(instance.name(locale: :ja)).to eq("アアア")
 
-      expect(instance.name_backend.locales).to match_array([:en, :ja])
+      expect(backend_for(instance, :name).locales).to match_array([:en, :ja])
     end
   end
 end

--- a/spec/mobility/backends/sequel/table_spec.rb
+++ b/spec/mobility/backends/sequel/table_spec.rb
@@ -33,7 +33,7 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel do
     it "only fetches translation once per locale" do
       article = Article.new
       title_backend = article.mobility_backends[:title]
-      expect(article.send(article.title_backend.association_name)).to receive(:find).twice.and_call_original
+      expect(article.send(backend_for(article, :title).association_name)).to receive(:find).twice.and_call_original
       title_backend.write(:en, "foo")
       title_backend.write(:en, "bar")
       expect(title_backend.read(:en)).to eq("bar")

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -80,7 +80,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
       instance = model_class.create(title: "foo")
 
       aggregate_failures do
-        instance.title_backend.write(:en, "bar")
+        backend_for(instance, :title).write(:en, "bar")
         expect(instance.changed?).to eq(true)
 
         instance.save
@@ -94,7 +94,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
       Mobility.locale = locale = :en
       instance = model_class.create(title: "foo")
 
-      instance.title_backend.write(locale, 'bar')
+      backend_for(instance, :title).write(locale, 'bar')
       instance.save
 
       instance.singleton_class.class_eval do
@@ -134,7 +134,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
       Mobility.locale = :en
       instance = model_class.create(title_en: "English title 1", title_fr: "Titre en Francais 1")
 
-      backend = instance.title_backend
+      backend = backend_for(instance, :title)
 
       backend.write(:en, "English title 2")
       backend.write(:fr, "Titre en Francais 2")
@@ -316,7 +316,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
     it "returns changes on attribute for current locale" do
       instance = model_class.create(title: "foo")
 
-      backend = instance.title_backend
+      backend = backend_for(instance, :title)
       backend.write(:en, "bar")
 
       aggregate_failures do
@@ -373,7 +373,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
 
     it "handles translated attributes when passed to restore_attributes" do
       instance = model_class.create(title: "foo")
-      backend = instance.title_backend
+      backend = backend_for(instance, :title)
 
       expect(backend.read(:en)).to eq("foo")
 
@@ -388,7 +388,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
     shared_examples_for "resets on model action" do |action|
       it "resets changes when model on #{action}" do
         instance = model_class.create
-        backend = instance.title_backend
+        backend = backend_for(instance, :title)
 
         aggregate_failures do
           backend.write(:en, 'foo')
@@ -450,7 +450,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
   describe '#has_changes_to_save?', rails_version_geq: '6.0' do
     it 'detects changes to translated and untranslated attributes' do
       instance = model_class.new
-      backend = instance.title_backend
+      backend = backend_for(instance, :title)
 
       expect(instance.has_changes_to_save?).to eq(false)
 
@@ -488,7 +488,7 @@ describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
   describe '#changed_attribute_names_to_save', rails_version_geq: '5.1' do
     it 'includes translated attributes and untranslated attributes' do
       instance = model_class.new
-      backend = instance.title_backend
+      backend = backend_for(instance, :title)
       expect(instance.changed_attribute_names_to_save).to eq([])
 
       backend.write(:en, 'foo en')

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -118,7 +118,7 @@ describe Mobility::Plugins::Backend do
         article.mobility_backends[:title] # trigger memoization
         other = article.dup
 
-        expect(other.title_backend).not_to eq(article.title_backend)
+        expect(other.mobility_backends[:title]).not_to eq(article.mobility_backends[:title])
       end
     end
   end

--- a/spec/mobility/plugins/cache_spec.rb
+++ b/spec/mobility/plugins/cache_spec.rb
@@ -81,9 +81,9 @@ describe Mobility::Plugins::Cache do
           expect(listener).to receive(:write).with(:en, "foo", any_args).and_return("foo set")
           expect(content_listener).to receive(:write).with(:en, "bar", any_args).and_return("bar set")
           backend.write(:en, "foo")
-          instance.content_backend.write(:en, "bar")
+          backend_for(instance, :content).write(:en, "bar")
           expect(backend.read(:en)).to eq("foo set")
-          expect(instance.content_backend.read(:en)).to eq("bar set")
+          expect(backend_for(instance, :content).read(:en)).to eq("bar set")
         end
 
         aggregate_failures "resetting model" do
@@ -91,7 +91,7 @@ describe Mobility::Plugins::Cache do
           expect(listener).to receive(:read).with(:en, any_args).and_return("from title backend")
           expect(backend.read(:en)).to eq("from title backend")
           expect(content_listener).to receive(:read).with(:en, any_args).and_return("from content backend")
-          expect(instance.content_backend.read(:en)).to eq("from content backend")
+          expect(backend_for(instance, :content).read(:en)).to eq("from content backend")
         end
       end
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -16,6 +16,11 @@ module Helpers
     I18n.class_variable_set(:@@fallbacks, nil)
   end
 
+  # Define as helper to make it easy in the future to update if this changes.
+  def backend_for(object, name)
+    object.mobility_backends[name]
+  end
+
   module LazyDescribedClass
     # lazy-load described_class if it's a string
     def described_class

--- a/spec/support/shared_examples/dup_examples.rb
+++ b/spec/support/shared_examples/dup_examples.rb
@@ -4,13 +4,13 @@ shared_examples_for "dupable model"  do |model_class_name, attribute=:title|
   it "dups persisted model" do
     skip_if_duping_not_implemented
     instance = model_class.new
-    instance_backend = instance.send("#{attribute}_backend")
+    instance_backend = backend_for(instance, attribute)
     instance_backend.write(:en, "foo")
     instance_backend.write(:ja, "ほげ")
     save_or_raise(instance)
 
     dupped_instance = instance.dup
-    dupped_backend = dupped_instance.send("#{attribute}_backend")
+    dupped_backend = backend_for(dupped_instance, attribute)
     expect(dupped_backend.read(:en)).to eq("foo")
     expect(dupped_backend.read(:ja)).to eq("ほげ")
 


### PR DESCRIPTION
The Backend plugin does three basic things on the model class:
- defines getter method for each attribute (`title_backend` etc)
- defines `mobility_backends` (instance method) and
  `mobility_backend_class` (class method) on model class
- sets up model with backend (calls `backend.setup_model` on model)

The defining of getter methods is not really required for any other plugins, since internally everything goes to `mobility_backends[:title]` instead of `title_backend` (former is faster, and for accessor methods in particular speed is important).

Also, the "X_backend" format being hard-coded has always kind of bothered me. So I thought, now that we have plugins, why not just split off that part into its own plugin? Call it `BackendReader.` And the format string can be the argument to that plugin, since it doesn't actually need to know the backend itself to define the reader method.

This also allows disabling those reader methods, if for some reason you don't want them. You'd just do like this:

```ruby
class TranslatedAttributes < Mobility::Attributes
  # ..
  plugin :backend_reader, false
end
```

Or, alternatively just pass `backend_reader: false` to `translates`.