### PR TITLE
Extract Attributes into its own plugin

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -29,7 +29,6 @@ module Mobility
   class Error < StandardError
   end
 
-  require "mobility/attributes"
   require "mobility/backend"
   require "mobility/backends"
   require "mobility/configuration"
@@ -37,6 +36,7 @@ module Mobility
   require "mobility/loaded"
   require "mobility/plugin"
   require "mobility/plugins"
+  require "mobility/attributes"
   require "mobility/translates"
 
   # General error for version compatibility conflicts

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -256,8 +256,8 @@ module Mobility
   module ClassMethods
     # Return translated attribute names on this model.
     # @return [Array<String>] Attribute names
-    def mobility_attributes
-      []
+    def mobility_attribute?(_)
+      false
     end
   end
 

--- a/lib/mobility/active_record/uniqueness_validator.rb
+++ b/lib/mobility/active_record/uniqueness_validator.rb
@@ -22,7 +22,7 @@ To use the validator, you must +extend Mobility+ before calling +validates+
       def validate_each(record, attribute, value)
         klass = record.class
 
-        if (([*options[:scope]] + [attribute]).map(&:to_s) & klass.mobility_attributes).present?
+        if ([*options[:scope]] + [attribute]).any? { |name| klass.mobility_attribute?(name) }
           return unless value.present?
           relation = klass.unscoped.__mobility_query_scope__ do |m|
             node = m.__send__(attribute)

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -108,32 +108,11 @@ with other backends.
 
 =end
   class Attributes < Pluggable
-    # Attribute names for which accessors will be defined
-    # @return [Array<String>] Array of names
-    attr_reader :names
-
-    # @param [Array<String>] attribute_names Names of attributes to define backend for
-    # @param [Hash] options Backend options hash
-    def initialize(*attribute_names, **options)
-      super
-      @names = attribute_names.map(&:to_s).freeze
-    end
+    include ::Mobility::Plugins.load_plugin(:attributes)
 
     def included(klass)
       klass.extend ClassMethods
       nil
-    end
-
-    # Yield each attribute name to block
-    # @yieldparam [String] Attribute
-    def each &block
-      names.each(&block)
-    end
-
-    # Show useful information about this module.
-    # @return [String]
-    def inspect
-      "#<Attributes @names=#{names.join(", ")}>"
     end
 
     module ClassMethods

--- a/lib/mobility/attributes.rb
+++ b/lib/mobility/attributes.rb
@@ -109,32 +109,5 @@ with other backends.
 =end
   class Attributes < Pluggable
     include ::Mobility::Plugins.load_plugin(:attributes)
-
-    def included(klass)
-      klass.extend ClassMethods
-      nil
-    end
-
-    module ClassMethods
-      # Return all {Mobility::Attributes} module instances from among ancestors
-      # of this model.
-      # @return [Array<Mobility::Attributes>] Attribute modules
-      def mobility_modules
-        ancestors.grep(Attributes)
-      end
-
-      # Return translated attribute names on this model.
-      # @return [Array<String>] Attribute names
-      def mobility_attributes
-        mobility_modules.map(&:names).flatten.uniq
-      end
-
-      # Return true if attribute name is translated on this model.
-      # @param [String, Symbol] Attribute name
-      # @return [Boolean]
-      def mobility_attribute?(name)
-        mobility_attributes.include?(name.to_s)
-      end
-    end
   end
 end

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -265,7 +265,7 @@ columns to that table.
           touch: true
 
         before_save do
-          required_attributes = self.class.mobility_attributes & translation_class.attribute_names
+          required_attributes = translation_class.attribute_names.select { |name| self.class.mobility_attribute?(name) }
           send(association_name).destroy_empty_translations(required_attributes)
         end
 

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -195,11 +195,11 @@ enabled for any one attribute on the model.
               # Builds a translated relation for a given opts hash and optional
               # invert boolean.
               def _build(scope, opts, locale, invert)
-                return yield unless scope.respond_to?(:mobility_modules)
+                return yield if (mods = attribute_modules(scope)).empty?
 
                 keys, predicates = opts.keys.map(&:to_s), []
 
-                query_map = scope.mobility_modules.inject(IDENTITY) do |qm, mod|
+                query_map = mods.inject(IDENTITY) do |qm, mod|
                   i18n_keys = mod.names & keys
                   next qm if i18n_keys.empty?
 
@@ -216,6 +216,10 @@ enabled for any one attribute on the model.
 
                 relation = opts.empty? ? scope : yield(opts)
                 query_map[relation.where(predicates.inject(:and))]
+              end
+
+              def attribute_modules(scope)
+                scope.model.ancestors.grep(::Mobility::Attributes)
               end
 
               def build_predicate(node, values)

--- a/lib/mobility/plugins/attributes.rb
+++ b/lib/mobility/plugins/attributes.rb
@@ -1,0 +1,36 @@
+# frozen-string-literal: true
+module Mobility
+  module Plugins
+=begin
+
+Takes arguments, converts them to strings, and stores in an array +@names+,
+made available with an +attr_reader+.
+
+=end
+    module Attributes
+      extend Plugin
+
+      # Attribute names for which accessors will be defined
+      # @return [Array<String>] Array of names
+      attr_reader :names
+
+      initialize_hook do |*names, **|
+        @names = names.map(&:to_s).freeze
+      end
+
+      # Yield each attribute name to block
+      # @yieldparam [String] Attribute
+      def each &block
+        names.each(&block)
+      end
+
+      # Show useful information about this module.
+      # @return [String]
+      def inspect
+        "#<Attributes @names=#{names.join(", ")}>"
+      end
+    end
+
+    register_plugin(:attributes, Attributes)
+  end
+end

--- a/lib/mobility/plugins/attributes.rb
+++ b/lib/mobility/plugins/attributes.rb
@@ -4,7 +4,8 @@ module Mobility
 =begin
 
 Takes arguments, converts them to strings, and stores in an array +@names+,
-made available with an +attr_reader+.
+made available with an +attr_reader+. Also provides some convenience methods
+for aggregating attributes.
 
 =end
     module Attributes
@@ -28,6 +29,32 @@ made available with an +attr_reader+.
       # @return [String]
       def inspect
         "#<Attributes @names=#{names.join(", ")}>"
+      end
+
+      included_hook do |klass, *, **|
+        klass.extend ClassMethods
+      end
+
+      module ClassMethods
+        # Return all {Mobility::Attributes} module instances from among ancestors
+        # of this model.
+        # @return [Array<Mobility::Attributes>] Attribute modules
+        def mobility_modules
+          ancestors.grep(Attributes)
+        end
+
+        # Return translated attribute names on this model.
+        # @return [Array<String>] Attribute names
+        def mobility_attributes
+          mobility_modules.map(&:names).flatten.uniq
+        end
+
+        # Return true if attribute name is translated on this model.
+        # @param [String, Symbol] Attribute name
+        # @return [Boolean]
+        def mobility_attribute?(name)
+          mobility_attributes.include?(name.to_s)
+        end
       end
     end
 

--- a/lib/mobility/plugins/attributes.rb
+++ b/lib/mobility/plugins/attributes.rb
@@ -15,7 +15,7 @@ for aggregating attributes.
       # @return [Array<String>] Array of names
       attr_reader :names
 
-      initialize_hook do |*names, **|
+      initialize_hook do |*names|
         @names = names.map(&:to_s).freeze
       end
 
@@ -31,7 +31,7 @@ for aggregating attributes.
         "#<Attributes @names=#{names.join(", ")}>"
       end
 
-      included_hook do |klass, *, **|
+      included_hook do |klass|
         klass.extend ClassMethods
         @names.each { |name| klass.register_mobility_attribute(name) }
       end

--- a/lib/mobility/plugins/attributes.rb
+++ b/lib/mobility/plugins/attributes.rb
@@ -33,27 +33,34 @@ for aggregating attributes.
 
       included_hook do |klass, *, **|
         klass.extend ClassMethods
+        @names.each { |name| klass.register_mobility_attribute(name) }
       end
 
       module ClassMethods
-        # Return all {Mobility::Attributes} module instances from among ancestors
-        # of this model.
-        # @return [Array<Mobility::Attributes>] Attribute modules
-        def mobility_modules
-          ancestors.grep(Attributes)
-        end
-
-        # Return translated attribute names on this model.
-        # @return [Array<String>] Attribute names
-        def mobility_attributes
-          mobility_modules.map(&:names).flatten.uniq
-        end
-
         # Return true if attribute name is translated on this model.
         # @param [String, Symbol] Attribute name
         # @return [Boolean]
         def mobility_attribute?(name)
           mobility_attributes.include?(name.to_s)
+        end
+
+        # Register a new attribute name. Public, but treat as internal.
+        # @param [String, Symbol] Attribute name
+        def register_mobility_attribute(name)
+          (self.mobility_attributes << name.to_s).uniq!
+        end
+
+        def inherited(klass)
+          super
+          mobility_attributes.each { |name| klass.register_mobility_attribute(name) }
+        end
+
+        protected
+
+        # Return translated attribute names on this model.
+        # @return [Array<String>] Attribute names
+        def mobility_attributes
+          @mobility_attributes ||= []
         end
       end
     end

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -16,6 +16,8 @@ Defines:
     module Backend
       extend Plugin
 
+      depends_on :attributes, include: :before
+
       # Backend class
       # @return [Class] Backend class
       attr_reader :backend_class

--- a/lib/mobility/plugins/sequel/query.rb
+++ b/lib/mobility/plugins/sequel/query.rb
@@ -109,7 +109,7 @@ See ActiveRecord::Query plugin.
               keys, predicates = cond.keys, []
               model = dataset.model
 
-              query_map = model.mobility_modules.inject(IDENTITY) do |qm, mod|
+              query_map = attribute_modules(model).inject(IDENTITY) do |qm, mod|
                 i18n_keys = mod.names.map(&:to_sym) & keys
                 next qm if i18n_keys.empty?
 
@@ -125,6 +125,10 @@ See ActiveRecord::Query plugin.
 
               predicates = ::Sequel.&(*predicates, cond) unless cond.empty?
               query_map[dataset.public_send(query_method, ::Sequel.&(*predicates))]
+            end
+
+            def attribute_modules(model)
+              model.ancestors.grep(::Mobility::Attributes)
             end
 
             def build_predicate(op, values)

--- a/spec/mobility/attributes_spec.rb
+++ b/spec/mobility/attributes_spec.rb
@@ -26,14 +26,14 @@ describe Mobility::Attributes do
           model_class.include described_class.new("title", "content", backend: backend_class)
           model_class.include described_class.new("foo", backend: backend_class)
 
-          expect(model_class.mobility_attributes).to match_array(["title", "content", "foo"])
+          expect(model_class.send(:mobility_attributes)).to match_array(["title", "content", "foo"])
         end
 
         it "only returns unique attributes" do
           model_class.include described_class.new("title", backend: :null)
           model_class.include described_class.new("title", backend: :null)
 
-          expect(model_class.mobility_attributes).to eq(["title"])
+          expect(model_class.send(:mobility_attributes)).to eq(["title"])
         end
       end
 
@@ -46,16 +46,6 @@ describe Mobility::Attributes do
             expect(model_class.mobility_attribute?(name.to_sym)).to eq(true)
           end
           expect(model_class.mobility_attribute?("foo")).to eq(false)
-        end
-      end
-
-      describe ".mobility_modules" do
-        it "returns attribute modules on class" do
-          modules = [
-            described_class.new("title", "content", backend: :null),
-            described_class.new("foo", backend: :null)]
-          modules.each { |mod| model_class.include mod }
-          expect(model_class.mobility_modules).to match_array(modules)
         end
       end
     end

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -66,6 +66,34 @@ describe Mobility::Plugins::Backend do
 
         expect(model_class.mobility_backend_class("content")).to eq(other_mod.backend_class)
       end
+
+      it "works with subclasses" do
+        backend_class_1 = Class.new
+        backend_class_1.include Mobility::Backend
+
+        mod1 = attributes_class.new("title", backend: backend_class_1)
+        model_class.include mod1
+
+        backend_class_2 = Class.new
+        backend_class_2.include Mobility::Backend
+
+        model_subclass = Class.new(model_class)
+        mod2 = attributes_class.new("content", backend: backend_class_2)
+
+        model_subclass.include mod2
+
+        title_backend_class_1 = model_class.mobility_backend_class("title")
+        title_backend_class_2 = model_subclass.mobility_backend_class("title")
+
+        expect(title_backend_class_1).to be <(backend_class_1)
+        expect(title_backend_class_2).to be <(backend_class_1)
+
+        expect {
+          model_class.mobility_backend_class("content")
+        }.to raise_error(KeyError)
+        content_backend_class = model_subclass.mobility_backend_class("content")
+        expect(content_backend_class).to be <(backend_class_2)
+      end
     end
 
     describe "#mobility_backends" do

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -90,7 +90,7 @@ describe Mobility::Plugins::Backend do
 
         expect {
           model_class.mobility_backend_class("content")
-        }.to raise_error(KeyError)
+        }.to raise_error(KeyError, "No backend for: content")
         content_backend_class = model_subclass.mobility_backend_class("content")
         expect(content_backend_class).to be <(backend_class_2)
       end

--- a/spec/performance/attributes_spec.rb
+++ b/spec/performance/attributes_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Mobility::Attributes do
   describe "initializing" do
     specify {
-      expect { described_class.new(backend: :null) }.to allocate_under(15).objects
+      expect { described_class.new(backend: :null) }.to allocate_under(25).objects
     }
   end
 

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -1,5 +1,5 @@
 shared_examples_for "AR Model with translated scope" do |model_class_name, a1=:title, a2=:content|
-  let(:backend_name) { model_class.mobility_modules.first.backend_name }
+  let(:backend_name) { model_class.ancestors.grep(Mobility::Attributes).first.backend_name }
   let(:model_class) { model_class_name.constantize }
   let(:query_scope) { model_class.i18n }
   let(:ordered_results) { query_scope.order("#{model_class.table_name}.id asc") }
@@ -630,7 +630,7 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
   let(:model_class) { constantize(model_class_name) }
   let(:table_name) { model_class.table_name }
   let(:query_scope) { model_class.i18n }
-  let(:backend_name) { model_class.mobility_modules.first.backend_name }
+  let(:backend_name) { model_class.ancestors.grep(Mobility::Attributes).first.backend_name }
 
   describe ".where" do
     context "querying on one translated attribute" do


### PR DESCRIPTION
That's it, now basically everything is a plugin.

Also, previously when calling methods like `mobility_attributes`, we'd `grep` all modules which are instances of `Mobility::Attributes`, grab their `names` and merge/flatten them. Same idea for backend classes. With this PR, we instead keep a running copy of what they are in an array, and add to it. Same for backend classes except we merge (since backend classes is a hash of keys->class).

Also: removed `BackendCache`, we don't need it.