### PR TITLE
Support include: false in depends_on

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,7 +3,7 @@ version: "2"
 checks:
   method-complexity:
     config:
-      threshold: 6
+      threshold: 8
   method-lines:
     enabled: false
 engines:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.5
 
 #################### Lint ################################
 
@@ -92,12 +93,6 @@ Lint/FormatParameterMismatch:
 Lint/HandleExceptions:
   Description: "Don't suppress exception."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
-  Enabled: true
-
-Lint/InvalidCharacterLiteral:
-  Description: >-
-                 Checks for invalid character literals with a non-escaped
-                 whitespace character.
   Enabled: true
 
 Lint/LiteralInCondition:
@@ -1013,11 +1008,6 @@ Style/SpaceAroundEqualsInParameterDefault:
 Style/SpaceAroundOperators:
   Description: 'Use a single space around operators.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceInsideBrackets:
-  Description: 'No spaces after [ or before ].'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
   Enabled: false
 
 Style/SpaceInsideHashLiteralBraces:

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -68,25 +68,25 @@ Also includes a +configure+ class method to apply plugins to a pluggable
     end
 
     def initialize_hook(&block)
-      key = plugin_key
+      plugin = self
       call_with_kwargs = call_with_kwargs?(block)
 
       define_method :initialize do |*names, **options|
         super(*names, **options)
         call_with_kwargs ?
-          class_exec(*names, **@options.slice(key), &block) :
+          class_exec(*names, **@options.slice(Plugins.lookup_name(plugin)), &block) :
           class_exec(*names, &block)
       end
     end
 
     def included_hook(&block)
-      key = plugin_key
+      plugin = self
       call_with_kwargs = call_with_kwargs?(block)
 
       define_method :included do |klass|
         super(klass).tap do |backend_class|
           call_with_kwargs ?
-            class_exec(klass, backend_class, **@options.slice(key), &block) :
+            class_exec(klass, backend_class, **@options.slice(Plugins.lookup_name(plugin)), &block) :
             class_exec(klass, backend_class, &block)
         end
       end
@@ -104,10 +104,6 @@ Also includes a +configure+ class method to apply plugins to a pluggable
     end
 
     private
-
-    def plugin_key
-      Util.underscore(to_s.split('::').last).to_sym
-    end
 
     def call_with_kwargs?(block)
       [:keyrest, :keyreq, :key].include?(block.parameters.last.first)

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -32,6 +32,7 @@ option value. For examples, see classes under the {Mobility::Plugins} namespace.
 =end
   module Plugins
     @plugins = {}
+    @names = {}
 
     class << self
       # @param [Symbol] name Name of plugin to load.
@@ -45,11 +46,12 @@ option value. For examples, see classes under the {Mobility::Plugins} namespace.
 
       # @param [Module] plugin Plugin module to lookup. Plugin must already be loaded.
       def lookup_name(plugin)
-        @plugins.invert[plugin]
+        @names.fetch(plugin)
       end
 
-      def register_plugin(name, mod)
-        @plugins[name] = mod
+      def register_plugin(name, plugin)
+        @plugins[name] = plugin
+        @names[plugin] = name
       end
     end
   end


### PR DESCRIPTION
There are situations where we want one plugin to depend on another one, without actually including it. e.g. I'm planning to restructure the Dirty and Query plugins so that you have an `active_record` plugin, an `active_record_dirty` plugin and a `dirty` plugin, where `active_record` depends on `active_record_dirty` (which has all the important code), and `active_record_dirty` depends on `dirty`, but in the latter case the dependency shouldn't automatically run unless `dirty` is explicitly included.

The change here adds the option to have `depends_on :foo, include: false`, which basically means you don't automatically include the dependency but just check in the initialize/included hooks to see if the dependency was included (separately), and only if so, run the code.

This way `dirty` becomes like a trigger which (for AR or Sequel models) triggers the corresponding ORM-specific code.

Kind of hard to understand until that's worked out, but for this first change the added spec basically explains what it does.