### PR TITLE
Set plugin default via DSL instead of keyword argument

### DIFF
--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -30,5 +30,7 @@ Works with {Mobility::Plugin}. (Subclassed by {Mobility::Attributes}.)
     def initialize(*, **options)
       @options = self.class.defaults.merge(options)
     end
+
+    attr_reader :options
   end
 end

--- a/lib/mobility/plugins/attribute_methods.rb
+++ b/lib/mobility/plugins/attribute_methods.rb
@@ -15,8 +15,8 @@ attributes only.
       extend Plugin
 
       # Applies attribute_methods plugin for a given option value.
-      included_hook do |model_class, attribute_methods: nil|
-        if attribute_methods
+      included_hook do |model_class|
+        if options[:attribute_methods]
           include_attribute_methods_module(model_class, *names)
         end
       end

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -26,8 +26,8 @@ Defines:
       # @return [Symbol,Class] Name of backend, or backend class
       attr_reader :backend_name
 
-      initialize_hook do |*, backend:|
-        @backend_name = backend
+      initialize_hook do
+        @backend_name = options[:backend]
       end
 
       # Setup backend class, include modules into model class, include/extend

--- a/lib/mobility/plugins/backend_reader.rb
+++ b/lib/mobility/plugins/backend_reader.rb
@@ -11,9 +11,11 @@ different format string as the plugin option.
     module BackendReader
       extend Plugin
 
+      default true
       depends_on :backend
 
-      initialize_hook do |*names, backend_reader: true|
+      initialize_hook do |*names|
+        backend_reader = options[:backend_reader]
         backend_reader = "%s_backend" if backend_reader == true
         if backend_reader
           names.each do |name|

--- a/lib/mobility/plugins/cache.rb
+++ b/lib/mobility/plugins/cache.rb
@@ -22,11 +22,12 @@ Values are added to the cache in two ways:
     module Cache
       extend Plugin
 
+      default true
       depends_on :backend, include: :before
 
       # Applies cache plugin to attributes.
-      included_hook do |model_class, backend_class, cache: true|
-        if cache
+      included_hook do |model_class, backend_class|
+        if options[:cache]
           backend_class.include(BackendMethods) unless backend_class.apply_plugin(:cache)
           model_class.include CacheResetter.new(*names)
         end

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -23,12 +23,12 @@ details.
       depends_on :backend, include: :before
       depends_on :fallthrough_accessors, include: :after
 
-      initialize_hook do |dirty: nil|
-        @options[:fallthrough_accessors] = true if dirty == true
+      initialize_hook do
+        @options[:fallthrough_accessors] = true if options[:dirty]
       end
 
-      included_hook do |model_class, backend_class, dirty: nil|
-        if dirty
+      included_hook do |model_class, backend_class|
+        if options[:dirty]
           include_dirty_modules(backend_class, model_class, *names)
         end
       end

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -129,7 +129,8 @@ the current locale was +nil+.
 
       # Applies fallbacks plugin to attributes. Completely disables fallbacks
       # on model if option is +false+.
-      included_hook do |_, backend_class, fallbacks: nil|
+      included_hook do |_, backend_class|
+        fallbacks = options[:fallbacks]
         backend_class.include(Methods.new(fallbacks)) unless fallbacks == false
       end
 

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -40,8 +40,8 @@ model class is generated.
       # Apply fallthrough accessors plugin to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option
-      initialize_hook do |fallthrough_accessors: nil|
-        define_fallthrough_accessors(names) if fallthrough_accessors
+      initialize_hook do
+        define_fallthrough_accessors(names) if options[:fallthrough_accessors]
       end
 
       private

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -35,8 +35,8 @@ available locales for a Rails application) will be used by default.
       # Apply locale accessors plugin to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option
-      initialize_hook do |locale_accessors: nil|
-        if locales = locale_accessors
+      initialize_hook do
+        if locales = options[:locale_accessors]
           locales = Mobility.config.default_accessor_locales if locales == true
           names.each do |name|
             locales.each do |locale|

--- a/lib/mobility/plugins/presence.rb
+++ b/lib/mobility/plugins/presence.rb
@@ -15,11 +15,12 @@ backend.
     module Presence
       extend Plugin
 
+      default true
       depends_on :backend, include: :before
 
       # Applies presence plugin to attributes.
-      included_hook do |_, backend_class, presence: true|
-        backend_class.include(BackendMethods) if presence
+      included_hook do |_, backend_class|
+        backend_class.include(BackendMethods) if options[:presence]
       end
 
       module BackendMethods

--- a/lib/mobility/plugins/query.rb
+++ b/lib/mobility/plugins/query.rb
@@ -9,11 +9,12 @@ module Mobility
     module Query
       extend Plugin
 
+      default true
       depends_on :backend, include: :before
 
       # Applies query plugin to attributes.
-      included_hook do |model_class, backend_class, query: true|
-        if query
+      included_hook do |model_class, backend_class|
+        if options[:query]
           include_query_module(model_class, backend_class)
         end
       end

--- a/lib/mobility/plugins/reader.rb
+++ b/lib/mobility/plugins/reader.rb
@@ -10,10 +10,11 @@ Defines attribute reader that delegates to +Mobility::Backend#read+.
 =end
       extend Plugin
 
+      default true
       depends_on :backend
 
-      initialize_hook do |*names, reader: true|
-        if reader
+      initialize_hook do |*names, **|
+        if options[:reader]
           names.each do |name|
             class_eval <<-EOM, __FILE__, __LINE__ + 1
               def #{name}(locale: nil, **options)

--- a/lib/mobility/plugins/writer.rb
+++ b/lib/mobility/plugins/writer.rb
@@ -9,10 +9,12 @@ Defines attribute writer that delegates to +Mobility::Backend#write+.
 
 =end
       extend Plugin
+
+      default true
       depends_on :backend
 
-      initialize_hook do |*names, writer: true|
-        if writer
+      initialize_hook do |*names|
+        if options[:writer]
           names.each do |name|
             class_eval <<-EOM, __FILE__, __LINE__ + 1
               def #{name}=(value, locale: nil, **options)

--- a/spec/mobility/plugins/backend_reader_spec.rb
+++ b/spec/mobility/plugins/backend_reader_spec.rb
@@ -5,7 +5,9 @@ describe Mobility::Plugins::BackendReader do
   include Helpers::Plugins
 
   context "with default format string" do
-    plugin_setup() { backend_reader }
+    plugin_setup do
+      backend_reader
+    end
 
     it "defines <attr>_backend methods mapping to backend instance for <attr>" do
       expect(instance.respond_to?(:title_backend)).to eq(true)
@@ -14,7 +16,9 @@ describe Mobility::Plugins::BackendReader do
   end
 
   context "with custom format string" do
-    plugin_setup() { backend_reader default: "%s_translations" }
+    plugin_setup do
+      backend_reader default: "%s_translations"
+    end
 
     it "defines backend reader methods with custom format string" do
       expect(instance.respond_to?(:title_translations)).to eq(true)
@@ -24,7 +28,9 @@ describe Mobility::Plugins::BackendReader do
   end
 
   context "with true as format string" do
-    plugin_setup() { backend_reader default: true }
+    plugin_setup do
+      backend_reader default: true
+    end
 
     it "defines backend reader methods with default format string" do
       expect(instance.respond_to?(:title_backend)).to eq(true)
@@ -33,7 +39,9 @@ describe Mobility::Plugins::BackendReader do
   end
 
   context "with falsey format string" do
-    plugin_setup() { backend_reader default: false }
+    plugin_setup do
+      backend_reader default: false
+    end
 
     it "does not define backend reader methods" do
       expect(instance.respond_to?(:title_backend)).to eq(false)

--- a/spec/mobility/plugins/cache_spec.rb
+++ b/spec/mobility/plugins/cache_spec.rb
@@ -5,7 +5,9 @@ describe Mobility::Plugins::Cache do
   include Helpers::Plugins
 
   describe "backend methods" do
-    plugin_setup cache: true, these: "options"
+    plugin_setup do
+      cache
+    end
 
     let(:locale) { :cz }
     let(:options) { { these: "options" } }

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -89,8 +89,10 @@ describe Mobility::Plugins::Fallbacks do
     end
   end
 
-  context "fallbacks is nil" do
-    plugin_setup fallbacks: nil
+  context "fallbacks is default" do
+    plugin_setup do
+      fallbacks
+    end
 
     it "does not use fallbacks when accessor fallback option is false or nil" do
       expect(listener).to receive(:read).with(:'en-US', any_args).once.and_return('')

--- a/spec/mobility/plugins/presence_spec.rb
+++ b/spec/mobility/plugins/presence_spec.rb
@@ -4,8 +4,10 @@ require "mobility/plugins/presence"
 describe Mobility::Plugins::Presence do
   include Helpers::Plugins
 
-  context "option = true" do
-    plugin_setup presence: true
+  context "default option value" do
+    plugin_setup do
+      presence
+    end
 
     describe "#read" do
       it "passes through present values unchanged" do

--- a/spec/mobility/plugins/reader_spec.rb
+++ b/spec/mobility/plugins/reader_spec.rb
@@ -4,7 +4,9 @@ require "mobility/plugins/reader"
 describe Mobility::Plugins::Reader do
   include Helpers::Plugins
 
-  plugin_setup reader: true
+  plugin_setup do
+    reader
+  end
 
   describe "getters" do
     let(:instance) { model_class.new }

--- a/spec/mobility/plugins/writer_spec.rb
+++ b/spec/mobility/plugins/writer_spec.rb
@@ -4,7 +4,7 @@ require "mobility/plugins/writer"
 describe Mobility::Plugins::Writer do
   include Helpers::Plugins
 
-  plugin_setup writer: true
+  plugin_setup { writer }
 
   describe "getters" do
     let(:instance) { model_class.new }


### PR DESCRIPTION
Setting the default for a plugin via a keyword argument to initialize_hook and/or included_hook is problematic because then other plugins cannot see this default. It's better just to be explicit about it and declare the default, then we can set it on the defaults hash as soon as the plugin is included into a pluggable (module), so all plugins can see it from both hooks.

So now inside the hooks we have to be a bit more explicit and fetch `options[:foo]` instead of using a keyword parameter `foo: ...`, but after thinking this over carefully I think this is actually preferable.