### PR TITLE
Remove unnecessary const_set for uniqueness validator

### DIFF
--- a/lib/mobility/active_record.rb
+++ b/lib/mobility/active_record.rb
@@ -11,13 +11,7 @@ Module loading ActiveRecord-specific classes for Mobility models.
     require "mobility/active_record/uniqueness_validator"
 
     def self.included(model_class)
-      model_class.class_eval do
-        unless const_defined?(:UniquenessValidator)
-          const_set(:UniquenessValidator,
-                    Class.new(::Mobility::ActiveRecord::UniquenessValidator))
-        end
-        delegate :translated_attribute_names, to: :class
-      end
+      model_class.delegate :translated_attribute_names, to: :class
     end
   end
 end


### PR DESCRIPTION
I noticed that this const_set here is not actually doing anything, and in fact uniquenes validation works simply because namespacing leads `conts_get` to `Mobility::ActiveRecord::UniquenessValidator` before `ActiveRecord::Validations::UniquenessValidator`.

This is probably not good... we'd prefer to have a new subclass then to magically resolve to the Mobility validator class. Need to figure out a better way.