### PR TITLE
Allow passing options to attributes_class from configuration#plugin

### DIFF
--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -16,8 +16,8 @@ Stores shared Mobility configuration referenced by all backends.
     attr_accessor :query_method
 
     # @param [Symbol] name Plugin name
-    def plugin(name)
-      attributes_class.plugin(name)
+    def plugin(name, **options)
+      attributes_class.plugin(name, **options)
     end
 
     # @param [Symbol] name Plugin name

--- a/spec/mobility/configuration_spec.rb
+++ b/spec/mobility/configuration_spec.rb
@@ -29,4 +29,11 @@ describe Mobility::Configuration do
       expect(subject.default_accessor_locales).to eq([:en, :de])
     end
   end
+
+  describe "#plugin" do
+    it "delegates to attributes_class#plugin" do
+      expect(subject.attributes_class).to receive(:plugin).with(:foo, these: 'params')
+      subject.plugin :foo, these: 'params'
+    end
+  end
 end


### PR DESCRIPTION
I'm not yet quite sure how we'll handle Configuration in v1.0, but basically it should delegate to the attributes class. With this change, you can now do this in 1.0:

```ruby
Mobility.configure do |config|
  config.plugin :fallbacks, default: [:en, :ja]
end
```

This is just short for assigning the following class to `@attributes_class` on
`Mobility.configuration`:

```ruby
Class.new(Attributes) do
  plugin :fallbacks, default: [:en, :ja]
end
```