### PR TITLE
Add convenience method to define arbitrary defaults on Pluggable

### DIFF
--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -20,6 +20,10 @@ Stores shared Mobility configuration referenced by all backends.
       attributes_class.plugin(name, **options)
     end
 
+    def default(name, value)
+      attributes_class.default(name, value)
+    end
+
     # @param [Symbol] name Plugin name
     def plugins(*names)
       names.each { |name| attributes_class.plugin name }

--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -21,6 +21,10 @@ Works with {Mobility::Plugin}. (Subclassed by {Mobility::Attributes}.)
         @defaults ||= {}
       end
 
+      def default(name, value)
+        @defaults[name.to_sym] = value
+      end
+
       def inherited(klass)
         super
         klass.defaults.merge!(defaults)

--- a/spec/mobility/configuration_spec.rb
+++ b/spec/mobility/configuration_spec.rb
@@ -36,4 +36,11 @@ describe Mobility::Configuration do
       subject.plugin :foo, these: 'params'
     end
   end
+
+  describe "#default" do
+    it "delegates to attributes_class#default" do
+      expect(subject.attributes_class).to receive(:default).with(:foo, 'bar')
+      subject.default :foo, 'bar'
+    end
+  end
 end

--- a/spec/mobility/pluggable_spec.rb
+++ b/spec/mobility/pluggable_spec.rb
@@ -3,38 +3,63 @@ require "spec_helper"
 describe Mobility::Pluggable do
   include Helpers::Plugins
 
-  define_plugins(:foo, :bar, :baz)
+  describe "#default" do
+    it "defines default on defaults hash" do
+      klass = Class.new(described_class)
 
-  it "dupes parent class defaults in descendants" do
-    klass = Class.new(described_class)
-    klass.plugin(:foo, default: 'foo')
-
-    subclass = Class.new(klass)
-    subclass.plugin(:bar, default: 'bar')
-
-    expect(klass.defaults).to eq(foo: 'foo')
-    expect(subclass.defaults).to eq(foo: 'foo', bar: 'bar')
+      klass.default(:foo, 'bar')
+      expect(klass.defaults).to eq(foo: 'bar')
+    end
   end
 
-  it "overrides parent default in descendant if set" do
-    klass = Class.new(described_class)
-    klass.plugin(:foo, default: 'foo')
+  describe "#initialize" do
+    define_plugins(:foo)
 
-    subclass = Class.new(klass)
-    subclass.plugin(:foo, default: 'foo2')
+    it "merges defaults into @options when initializing" do
+      klass = Class.new(described_class)
 
-    expect(klass.defaults).to eq(foo: 'foo')
-    expect(subclass.defaults).to eq(foo: 'foo2')
+      klass.plugin :foo, default: 'bar'
+      klass.default :baz, 'qux'
+
+      pluggable = klass.new(other: 'param')
+      expect(pluggable.options).to eq(foo: 'bar', baz: 'qux', other: 'param')
+    end
   end
 
-  it "inherits parent default if default unset in descendant" do
-    klass = Class.new(described_class)
-    klass.plugin(:foo, default: 'foo')
+  describe "subclassing" do
+    define_plugins(:foo, :bar, :baz)
 
-    subclass = Class.new(klass)
-    subclass.plugin(:foo)
+    it "dupes parent class defaults in descendants" do
+      klass = Class.new(described_class)
+      klass.plugin(:foo, default: 'foo')
 
-    expect(klass.defaults).to eq(foo: 'foo')
-    expect(subclass.defaults).to eq(foo: 'foo')
+      subclass = Class.new(klass)
+      subclass.plugin(:bar, default: 'bar')
+
+      expect(klass.defaults).to eq(foo: 'foo')
+      expect(subclass.defaults).to eq(foo: 'foo', bar: 'bar')
+    end
+
+    it "overrides parent default in descendant if set" do
+      klass = Class.new(described_class)
+      klass.plugin(:foo, default: 'foo')
+
+      subclass = Class.new(klass)
+      subclass.plugin(:foo, default: 'foo2')
+
+      expect(klass.defaults).to eq(foo: 'foo')
+      expect(subclass.defaults).to eq(foo: 'foo2')
+    end
+
+    it "inherits parent default if default unset in descendant" do
+      klass = Class.new(described_class)
+      klass.plugin(:foo, default: 'foo')
+
+      subclass = Class.new(klass)
+      subclass.plugin(:foo)
+
+      expect(klass.defaults).to eq(foo: 'foo')
+      expect(subclass.defaults).to eq(foo: 'foo')
+    end
   end
 end


### PR DESCRIPTION
Currently on `master` there is no obvious way to set defaults for backends, since defaults are tied to plugins. With this change you can now define them with a `default` class method on `Pluggable`.

With this change, we basically have patterns to replace `default_options` and `default_backend`. So here's how you configure options on 0.8.x:

```ruby
Mobility.configure do |config|
  config.default_backend :key_value
  config.default_options[:locale_accessors] = [:en, :ja]
  config.default_options[:type] = :text
  # ...
end
```

Notice here that `locale_accessors` is a plugin option, whereas `type` is an option for the `key_value` backend. The fact that the two look the same is a bad thing, I think, because they are handled differently.

In 1.0, this becomes:

```ruby
class TranslatedAttributes < Mobility::Attributes
  plugin :backend,          default: :key_value
  plugin :locale_accessors, default: [:en, :ja]
  default :type, :text
  # ...
end
```

It's much clearer now which options are associated with a plugin, and which are associated with the backend, which I think is a good thing. I'm still wondering if we should really separate the latter from the former, because internally they are just merged together, but I think on the whole sharing a namespace is probably ok and saves a lot of hassle, as long as the declaration maintains a clear separation.

The subclassing thing might be unintuitive, so this is all also possible using `Mobility.configure`, like this:

```ruby
Mobility.configure do |config|
  config.plugin :backend,          default: :key_value
  config.plugin :locale_accessors, default: [:en, :ja]
  config.default :type, :text
  # ...
end
```

Internally, `Mobility::Configuration` is just creating an anonymous subclass of `Mobility::Attributes` and delegating to `plugin` and `default` on that class.