### PR TITLE
Rename depends_on to requires

### DIFF
--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -126,9 +126,9 @@ Also includes a +configure+ class method to apply plugins to a pluggable
     #
     # @param [Symbol] plugin Name of plugin dependency
     # @option [TrueClass, FalseClass, Symbol] include
-    def depends_on(plugin, include: true)
+    def requires(plugin, include: true)
       unless [true, false, :before, :after].include?(include)
-        raise ArgumentError, "depends_on 'include' keyword argument must be one of: true, false, :before or :after"
+        raise ArgumentError, "requires 'include' keyword argument must be one of: true, false, :before or :after"
       end
       dependencies[plugin] = include
     end

--- a/lib/mobility/plugins/active_model.rb
+++ b/lib/mobility/plugins/active_model.rb
@@ -13,9 +13,9 @@ not ActiveRecord models.
     module ActiveModel
       extend Plugin
 
-      depends_on :active_model_dirty
-      depends_on :active_model_cache
-      depends_on :backend, include: :before
+      requires :active_model_dirty
+      requires :active_model_cache
+      requires :backend, include: :before
     end
 
     register_plugin(:active_model, ActiveModel)

--- a/lib/mobility/plugins/active_model/cache.rb
+++ b/lib/mobility/plugins/active_model/cache.rb
@@ -11,7 +11,7 @@ Adds hooks to clear Mobility cache when AM dirty reset methods are called.
       module Cache
         extend Plugin
 
-        depends_on :cache, include: false
+        requires :cache, include: false
 
         included_hook do |klass, _|
           if options[:cache]

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -44,7 +44,7 @@ the ActiveRecord dirty plugin for more information.
       module Dirty
         extend Plugin
 
-        depends_on :dirty, include: false
+        requires :dirty, include: false
 
         initialize_hook do
           if options[:dirty]

--- a/lib/mobility/plugins/active_record.rb
+++ b/lib/mobility/plugins/active_record.rb
@@ -15,11 +15,11 @@ Plugin for ActiveRecord models.
     module ActiveRecord
       extend Plugin
 
-      depends_on :active_record_backend, include: :after
-      depends_on :active_record_dirty
-      depends_on :active_record_cache
-      depends_on :active_record_query
-      depends_on :active_record_uniqueness_validation
+      requires :active_record_backend, include: :after
+      requires :active_record_dirty
+      requires :active_record_cache
+      requires :active_record_query
+      requires :active_record_uniqueness_validation
 
       included_hook do |klass|
         unless active_record_class?(klass)

--- a/lib/mobility/plugins/active_record/backend.rb
+++ b/lib/mobility/plugins/active_record/backend.rb
@@ -4,7 +4,7 @@ module Mobility
       module Backend
         extend Plugin
 
-        depends_on :backend, include: :before
+        requires :backend, include: :before
 
         def load_backend(backend)
           if Symbol === backend

--- a/lib/mobility/plugins/active_record/cache.rb
+++ b/lib/mobility/plugins/active_record/cache.rb
@@ -13,7 +13,7 @@ methods.
       module Cache
         extend Plugin
 
-        depends_on :cache, include: false
+        requires :cache, include: false
 
         included_hook do |klass, _|
           if options[:cache]

--- a/lib/mobility/plugins/active_record/dirty.rb
+++ b/lib/mobility/plugins/active_record/dirty.rb
@@ -42,8 +42,8 @@ locale suffix, so +title_en+, +title_pt_br+, etc.)
       module Dirty
         extend Plugin
 
-        depends_on :dirty, include: false
-        depends_on :active_model_dirty, include: :before
+        requires :dirty, include: false
+        requires :active_model_dirty, include: :before
 
         initialize_hook do
           if options[:dirty]

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -19,7 +19,7 @@ enabled for any one attribute on the model.
       module Query
         extend Plugin
 
-        depends_on :query, include: false
+        requires :query, include: false
 
         included_hook do |klass, backend_class|
           plugin = self

--- a/lib/mobility/plugins/active_record/uniqueness_validation.rb
+++ b/lib/mobility/plugins/active_record/uniqueness_validation.rb
@@ -4,7 +4,7 @@ module Mobility
       module UniquenessValidation
         extend Plugin
 
-        depends_on :query, include: false
+        requires :query, include: false
 
         included_hook do |klass|
           klass.class_eval do

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -16,7 +16,7 @@ Defines:
     module Backend
       extend Plugin
 
-      depends_on :attributes, include: :before
+      requires :attributes, include: :before
 
       # Backend class
       # @return [Class] Backend class

--- a/lib/mobility/plugins/backend_reader.rb
+++ b/lib/mobility/plugins/backend_reader.rb
@@ -12,7 +12,7 @@ different format string as the plugin option.
       extend Plugin
 
       default true
-      depends_on :backend
+      requires :backend
 
       initialize_hook do |*names|
         backend_reader = options[:backend_reader]

--- a/lib/mobility/plugins/cache.rb
+++ b/lib/mobility/plugins/cache.rb
@@ -23,7 +23,7 @@ Values are added to the cache in two ways:
       extend Plugin
 
       default true
-      depends_on :backend, include: :before
+      requires :backend, include: :before
 
       # Applies cache plugin to attributes.
       included_hook do |_, backend_class|

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -64,7 +64,7 @@ The proc can accept zero to three arguments (see examples below)
     module Default
       extend Plugin
 
-      depends_on :backend, include: :before
+      requires :backend, include: :before
 
       # Applies default plugin to attributes.
       included_hook do |_klass, backend_class|

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -20,8 +20,8 @@ details.
     module Dirty
       extend Plugin
 
-      depends_on :backend, include: :before
-      depends_on :fallthrough_accessors, include: :after
+      requires :backend, include: :before
+      requires :fallthrough_accessors, include: :after
 
       initialize_hook do
         @options[:fallthrough_accessors] = true if options[:dirty]

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -125,7 +125,7 @@ the current locale was +nil+.
     module Fallbacks
       extend Plugin
 
-      depends_on :backend, include: :before
+      requires :backend, include: :before
 
       # Applies fallbacks plugin to attributes. Completely disables fallbacks
       # on model if option is +false+.

--- a/lib/mobility/plugins/presence.rb
+++ b/lib/mobility/plugins/presence.rb
@@ -16,7 +16,7 @@ backend.
       extend Plugin
 
       default true
-      depends_on :backend, include: :before
+      requires :backend, include: :before
 
       # Applies presence plugin to attributes.
       included_hook do |_, backend_class|

--- a/lib/mobility/plugins/query.rb
+++ b/lib/mobility/plugins/query.rb
@@ -10,7 +10,7 @@ module Mobility
       extend Plugin
 
       default :i18n
-      depends_on :backend, include: :before
+      requires :backend, include: :before
 
       def query_method
         (options[:query] == true) ? self.class.defaults[:query] : options[:query]

--- a/lib/mobility/plugins/reader.rb
+++ b/lib/mobility/plugins/reader.rb
@@ -11,7 +11,7 @@ Defines attribute reader that delegates to +Mobility::Backend#read+.
       extend Plugin
 
       default true
-      depends_on :backend
+      requires :backend
 
       initialize_hook do |*names, **|
         if options[:reader]

--- a/lib/mobility/plugins/sequel.rb
+++ b/lib/mobility/plugins/sequel.rb
@@ -16,10 +16,10 @@ module Mobility
     module Sequel
       extend Plugin
 
-      depends_on :sequel_backend, include: :after
-      depends_on :sequel_dirty
-      depends_on :sequel_cache
-      depends_on :sequel_query
+      requires :sequel_backend, include: :after
+      requires :sequel_dirty
+      requires :sequel_cache
+      requires :sequel_query
 
       included_hook do |klass|
         unless sequel_class?(klass)

--- a/lib/mobility/plugins/sequel/backend.rb
+++ b/lib/mobility/plugins/sequel/backend.rb
@@ -4,7 +4,7 @@ module Mobility
       module Backend
         extend Plugin
 
-        depends_on :backend, include: :before
+        requires :backend, include: :before
 
         def load_backend(backend)
           if Symbol === backend

--- a/lib/mobility/plugins/sequel/cache.rb
+++ b/lib/mobility/plugins/sequel/cache.rb
@@ -11,7 +11,7 @@ Adds hook to clear Mobility cache when +refresh+ is called on Sequel model.
       module Cache
         extend Plugin
 
-        depends_on :cache, include: false
+        requires :cache, include: false
 
         included_hook do |klass|
           define_cache_hooks(klass, :refresh) if options[:cache]

--- a/lib/mobility/plugins/sequel/dirty.rb
+++ b/lib/mobility/plugins/sequel/dirty.rb
@@ -15,7 +15,7 @@ Automatically includes dirty plugin in model class when enabled.
       module Dirty
         extend Plugin
 
-        depends_on :dirty, include: false
+        requires :dirty, include: false
 
         initialize_hook do
           # Although we load the plugin in the included callback method, we

--- a/lib/mobility/plugins/sequel/query.rb
+++ b/lib/mobility/plugins/sequel/query.rb
@@ -10,7 +10,7 @@ See ActiveRecord::Query plugin.
       module Query
         extend Plugin
 
-        depends_on :query, include: false
+        requires :query, include: false
 
         included_hook do |klass, _|
           plugin = self

--- a/lib/mobility/plugins/writer.rb
+++ b/lib/mobility/plugins/writer.rb
@@ -11,7 +11,7 @@ Defines attribute writer that delegates to +Mobility::Backend#write+.
       extend Plugin
 
       default true
-      depends_on :backend
+      requires :backend
 
       initialize_hook do |*names|
         if options[:writer]

--- a/spec/mobility/plugin_spec.rb
+++ b/spec/mobility/plugin_spec.rb
@@ -24,8 +24,8 @@ describe Mobility::Plugin do
       end
 
       it 'detects before dependency conflict between two plugins' do
-        foo.depends_on :bar, include: :before
-        bar.depends_on :foo, include: :before
+        foo.requires :bar, include: :before
+        bar.requires :foo, include: :before
         expect {
           described_class.configure(pluggable) do
             __send__ :foo
@@ -36,8 +36,8 @@ describe Mobility::Plugin do
       end
 
       it 'includes pluggable name in cyclic dependency conflict message' do
-        foo.depends_on :bar, include: :before
-        bar.depends_on :foo, include: :before
+        foo.requires :bar, include: :before
+        bar.requires :foo, include: :before
 
         stub_const('Pluggable', pluggable)
         expect {
@@ -50,8 +50,8 @@ describe Mobility::Plugin do
       end
 
       it 'detects after dependency conflict between two plugins' do
-        foo.depends_on :bar, include: :after
-        bar.depends_on :foo, include: :after
+        foo.requires :bar, include: :after
+        bar.requires :foo, include: :after
         expect {
           described_class.configure(pluggable) do
             __send__ :foo
@@ -62,9 +62,9 @@ describe Mobility::Plugin do
       end
 
       it 'detects before dependency conflict between three plugins' do
-        foo.depends_on :baz, include: :before
-        bar.depends_on :foo, include: :before
-        baz.depends_on :bar, include: :before
+        foo.requires :baz, include: :before
+        bar.requires :foo, include: :before
+        baz.requires :bar, include: :before
         expect {
           described_class.configure(pluggable) do
             __send__ :foo
@@ -76,9 +76,9 @@ describe Mobility::Plugin do
       end
 
       it 'detects after dependency conflict between three plugins' do
-        foo.depends_on :baz, include: :after
-        bar.depends_on :foo, include: :after
-        baz.depends_on :bar, include: :after
+        foo.requires :baz, include: :after
+        bar.requires :foo, include: :after
+        baz.requires :bar, include: :after
         expect {
           described_class.configure(pluggable) do
             __send__ :foo
@@ -90,9 +90,9 @@ describe Mobility::Plugin do
       end
 
       it 'correctly includes plugins with no dependency conflicts' do
-        foo.depends_on :bar, include: :before
-        baz.depends_on :foo, include: :before
-        bar.depends_on :baz, include: :after
+        foo.requires :bar, include: :before
+        baz.requires :foo, include: :before
+        bar.requires :baz, include: :after
 
         expect {
           described_class.configure(pluggable) do
@@ -106,7 +106,7 @@ describe Mobility::Plugin do
       end
 
       it 'raises DependencyConflict error if plugin has after dependency on previously included plugin' do
-        bar.depends_on :foo, include: :after
+        bar.requires :foo, include: :after
 
         described_class.configure(pluggable) do
           __send__ :foo
@@ -121,7 +121,7 @@ describe Mobility::Plugin do
       end
 
       it 'includes pluggable name in after dependency conflict error message' do
-        bar.depends_on :foo, include: :after
+        bar.requires :foo, include: :after
 
         described_class.configure(pluggable) do
           __send__ :foo
@@ -139,9 +139,9 @@ describe Mobility::Plugin do
       end
 
       it 'skips mutual before dependencies which have already been included' do
-        foo.depends_on :baz, include: :before
-        bar.depends_on :foo, include: :before
-        bar.depends_on :baz, include: :before
+        foo.requires :baz, include: :before
+        bar.requires :foo, include: :before
+        bar.requires :baz, include: :before
 
         described_class.configure(pluggable) do
           __send__ :foo
@@ -157,9 +157,9 @@ describe Mobility::Plugin do
       end
 
       it 'handles non-conflicting cyclic dependencies which have already been included' do
-        foo.depends_on :baz
-        bar.depends_on :foo, include: :before
-        bar.depends_on :baz, include: :before
+        foo.requires :baz
+        bar.requires :foo, include: :before
+        bar.requires :baz, include: :before
 
         described_class.configure(pluggable) do
           __send__ :foo
@@ -177,9 +177,9 @@ describe Mobility::Plugin do
       end
 
       it 'handles multiple dependency levels' do
-        foo.depends_on :bar
-        bar.depends_on :baz, include: :after
-        baz.depends_on :qux, include: :before
+        foo.requires :bar
+        bar.requires :baz, include: :after
+        baz.requires :qux, include: :before
 
         expect {
           described_class.configure(pluggable) do
@@ -193,7 +193,7 @@ describe Mobility::Plugin do
       end
 
       it 'does not include dependency for include: false' do
-        foo.depends_on :bar, include: false
+        foo.requires :bar, include: false
 
         expect {
           described_class.configure(pluggable) do
@@ -207,8 +207,8 @@ describe Mobility::Plugin do
       it 'does not run hooks if direct dependency is not included for include: false' do
         # Note that foo hooks *are* run, although bar dependencies are not met.
         # So include: false is not applied recursively to dependents.
-        foo.depends_on :bar
-        bar.depends_on :baz, include: false
+        foo.requires :bar
+        bar.requires :baz, include: false
 
         foo_listener = double
         bar_listener = double
@@ -233,7 +233,7 @@ describe Mobility::Plugin do
       end
 
       it 'does run hooks if dependency is included for include: false' do
-        foo.depends_on :bar, include: false
+        foo.requires :bar, include: false
         listener = double
 
         bar.initialize_hook do |*|


### PR DESCRIPTION
The `include: false` usage is pretty cryptic with the method name "depends_on". Using the name "requires" makes the meaning clearer:

```ruby
module Mobility
  module Foo
    extend Plugin

    requires :bar, include: false
  end
end
```

So the `Foo` plugin *requires* `Bar`, but does not include it. If you want to use `Foo`, you need to also have the `Bar` plugin explicitly enabled (either included from another plugin, or included explicitly in the list of configuraiton plugins).