### PR TITLE
Default locale_accessors and fallthough_accessors to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Move `_backend` methods into `backend_reader` plugin
   ([#403](https://github.com/shioyama/mobility/pull/403))
 - Replace `Configuration#query_method` configuration with Query plugin option
+- Remove `Mobility::Configuration#default_accessor_locales`. Use plugin option
+  to configure global default instead.
+  ([#424](https://github.com/shioyama/mobility/pull/424))
 
 ## 0.8
 

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -110,10 +110,7 @@ module Mobility
 
     # (see Mobility::Configuration#plugins)
     # @!method plugins
-    #
-    # (see Mobility::Configuration#default_accessor_locales)
-    # @!method default_accessor_locales
-    %w[accessor_method default_backend plugins default_accessor_locales].each do |method_name|
+    %w[accessor_method default_backend plugins].each do |method_name|
       define_method method_name do
         config.public_send(method_name)
       end

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -48,22 +48,9 @@ Stores shared Mobility configuration referenced by all backends.
       attributes_class.defaults[:backend]
     end
 
-    # Returns set of default accessor locales to use (defaults to
-    # +I18n.available_locales+)
-    # @return [Array<Symbol>]
-    def default_accessor_locales
-      if @default_accessor_locales.is_a?(Proc)
-        @default_accessor_locales.call
-      else
-        @default_accessor_locales
-      end
-    end
-    attr_writer :default_accessor_locales
-
     def initialize
       @accessor_method = :translates
       @fallbacks_generator = lambda { |fallbacks| Mobility::Fallbacks.build(fallbacks) }
-      @default_accessor_locales = lambda { Mobility.available_locales }
     end
 
     def attributes_class

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -22,6 +22,13 @@ details.
 
       requires :backend, include: :before
       requires :fallthrough_accessors
+
+      initialize_hook do
+        if options[:dirty] && !options[:fallthrough_accessors]
+          warn 'The Dirty plugin depends on Fallthrough Accessors being enabled,'\
+            'but fallthrough_accessors option is falsey'
+        end
+      end
     end
 
     register_plugin(:dirty, Dirty)

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -21,11 +21,7 @@ details.
       extend Plugin
 
       requires :backend, include: :before
-      requires :fallthrough_accessors, include: :after
-
-      initialize_hook do
-        @options[:fallthrough_accessors] = true if options[:dirty]
-      end
+      requires :fallthrough_accessors
     end
 
     register_plugin(:dirty, Dirty)

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -37,6 +37,8 @@ model class is generated.
     module FallthroughAccessors
       extend Plugin
 
+      default true
+
       # Apply fallthrough accessors plugin to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -18,21 +18,6 @@ This is a less efficient (but more open-ended) implementation of locale
 accessors, for use in cases where the locales to be used are not known when the
 model class is generated.
 
-@example Using fallthrough locales on a plain old ruby class
-  class Post
-    def title
-      "title in #{Mobility.locale}"
-    end
-    include Mobility::FallthroughAccessors.new("title")
-  end
-
-  Mobility.locale = :en
-  post = Post.new
-  post.title
-  #=> "title in en"
-  post.title_fr
-  #=> "title in fr"
-
 =end
     module FallthroughAccessors
       extend Plugin

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -13,21 +13,6 @@ If no locales are passed as an option to the initializer,
 +Mobility.available_locales+ (i.e. +I18n.available_locales+, or Rails-set
 available locales for a Rails application) will be used by default.
 
-@example
-  class Post
-    def title
-      "title in #{Mobility.locale}"
-    end
-    include Mobility::Plugins::LocaleAccessors.new("title", locales: [:en, :fr])
-  end
-
-  Mobility.locale = :en
-  post = Post.new
-  post.title
-  #=> "title in en"
-  post.title_fr
-  #=> "title in fr"
-
 =end
     module LocaleAccessors
       extend Plugin

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -32,6 +32,8 @@ available locales for a Rails application) will be used by default.
     module LocaleAccessors
       extend Plugin
 
+      default true
+
       # Apply locale accessors plugin to attributes.
       # @param [Attributes] attributes
       # @param [Boolean] option

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -39,7 +39,7 @@ available locales for a Rails application) will be used by default.
       # @param [Boolean] option
       initialize_hook do |*names|
         if locales = options[:locale_accessors]
-          locales = Mobility.config.default_accessor_locales if locales == true
+          locales = Mobility.available_locales if locales == true
           names.each do |name|
             locales.each do |locale|
               define_locale_reader(name, locale)

--- a/spec/mobility/configuration_spec.rb
+++ b/spec/mobility/configuration_spec.rb
@@ -7,27 +7,8 @@ describe Mobility::Configuration do
     expect(subject.new_fallbacks).to be_a(I18n::Locale::Fallbacks)
   end
 
-  it "initializes default accessor_locales to I18n.available_locales" do
-    expect(subject.default_accessor_locales).to eq(I18n.available_locales)
-  end
-
   it "sets default_backend to nil" do
     expect(subject.default_backend).to eq(nil)
-  end
-
-  describe "#default_accessor_locales=" do
-    it "returns array of locales if assigned array" do
-      subject.default_accessor_locales = [:en, :ja]
-      expect(subject.default_accessor_locales).to eq([:en, :ja])
-    end
-
-    it "returned proc evaluated when called if assigned a proc" do
-      @accessor_locales = [:en, :fr]
-      subject.default_accessor_locales = lambda { @accessor_locales }
-      expect(subject.default_accessor_locales).to eq([:en, :fr])
-      @accessor_locales = [:en, :de]
-      expect(subject.default_accessor_locales).to eq([:en, :de])
-    end
   end
 
   describe "#plugin" do

--- a/spec/mobility/plugins/dirty_spec.rb
+++ b/spec/mobility/plugins/dirty_spec.rb
@@ -3,22 +3,9 @@ require "mobility/plugins/dirty"
 
 describe Mobility::Plugins::Dirty do
   include Helpers::Plugins
+  plugin_setup dirty: true
 
-  context "option value is truthy" do
-    plugin_setup dirty: true
-
-    it "does defines method_missing override" do
-      model_class.include attributes
-      expect(attributes.instance_methods(false)).to include(:method_missing)
-    end
-  end
-
-  context "option value is falsey" do
-    plugin_setup dirty: false
-
-    it "does not define method_missing override" do
-      model_class.include attributes
-      expect(attributes.instance_methods(false)).not_to include(:method_missing)
-    end
+  it "requires fallthrough_accessors" do
+    expect(attributes).to have_plugin(:fallthrough_accessors)
   end
 end

--- a/spec/mobility/plugins/dirty_spec.rb
+++ b/spec/mobility/plugins/dirty_spec.rb
@@ -3,9 +3,22 @@ require "mobility/plugins/dirty"
 
 describe Mobility::Plugins::Dirty do
   include Helpers::Plugins
-  plugin_setup dirty: true
 
-  it "requires fallthrough_accessors" do
-    expect(attributes).to have_plugin(:fallthrough_accessors)
+  context "dirty enabled" do
+    plugin_setup dirty: true
+
+    it "requires fallthrough_accessors" do
+      expect(attributes).to have_plugin(:fallthrough_accessors)
+    end
+  end
+
+  context "fallthrough accessors is falsey" do
+    plugin_setup dirty: true, fallthrough_accessors: false
+
+    it "emits warning" do
+      expect { instance }.to output(
+        /The Dirty plugin depends on Fallthrough Accessors being enabled,/
+      ).to_stderr
+    end
   end
 end

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -4,8 +4,13 @@ require "mobility/plugins/fallthrough_accessors"
 describe Mobility::Plugins::FallthroughAccessors do
   include Helpers::Plugins
 
-  context "option value is truthy" do
-    plugin_setup fallthrough_accessors: true, reader: true, writer: true
+  context "option value is default" do
+    plugin_setup do
+      fallthrough_accessors
+      reader
+      writer
+    end
+
     it_behaves_like "locale accessor", :title, 'en'
     it_behaves_like "locale accessor", :title, 'de'
     it_behaves_like "locale accessor", :title, 'pt-BR'
@@ -46,7 +51,10 @@ describe Mobility::Plugins::FallthroughAccessors do
   end
 
   context "option value is false" do
-    plugin_setup fallthrough_accessors: false
+    plugin_setup do
+      fallthrough_accessors default: false
+    end
+
     it "does not include instance of FallthroughAccessors into attributes class" do
       instance = model_class.new
       expect { instance.title_en }.to raise_error(NoMethodError)

--- a/spec/mobility/plugins/locale_accessors_spec.rb
+++ b/spec/mobility/plugins/locale_accessors_spec.rb
@@ -32,54 +32,69 @@ describe Mobility::Plugins::LocaleAccessors do
     end
   end
 
-   context "with option = true" do
-     plugin_setup locale_accessors: true
+  context "with default option" do
+    plugin_setup do
+      locale_accessors
+    end
 
-     it "defines locale accessors for all locales in I18n.available_locales" do
-       methods = model_class.instance_methods
-       I18n.available_locales.each do |locale|
-         expect(methods).to include(:"title_#{Mobility.normalize_locale(locale)}")
-         expect(methods).to include(:"title_#{Mobility.normalize_locale(locale)}?")
-         expect(methods).to include(:"title_#{Mobility.normalize_locale(locale)}=")
-       end
-     end
+    it "defines locale accessors for all locales in I18n.available_locales" do
+      methods = model_class.instance_methods
+      I18n.available_locales.each do |locale|
+        expect(methods).to include(:"title_#{Mobility.normalize_locale(locale)}")
+        expect(methods).to include(:"title_#{Mobility.normalize_locale(locale)}?")
+        expect(methods).to include(:"title_#{Mobility.normalize_locale(locale)}=")
+      end
+    end
 
-     describe "super: true" do
-       let(:option) { [:en] }
-       let(:spy) { double("model") }
-       let(:model_class) do
-         spy_ = spy
-         Class.new.tap do |klass|
-           mod = Module.new do
-             define_method :title_en do
-               spy_.title_en
-             end
-             define_method :title_en? do
-               spy_.title_en?
-             end
-             define_method :title_en= do |value|
-               spy_.title_en = value
-             end
-           end
-           klass.include mod
-           klass.include attributes
-         end
-       end
+    describe "super: true" do
+      let(:option) { [:en] }
+      let(:spy) { double("model") }
+      let(:model_class) do
+        spy_ = spy
+        Class.new.tap do |klass|
+          mod = Module.new do
+            define_method :title_en do
+              spy_.title_en
+            end
+            define_method :title_en? do
+              spy_.title_en?
+            end
+            define_method :title_en= do |value|
+              spy_.title_en = value
+            end
+          end
+          klass.include mod
+          klass.include attributes
+        end
+      end
 
-       it "calls super of locale accessor method" do
-         instance = model_class.new
+      it "calls super of locale accessor method" do
+        instance = model_class.new
 
-         aggregate_failures do
-           expect(spy).to receive(:title_en).and_return("model foo")
-           expect(instance.title_en(super: true)).to eq("model foo")
+        aggregate_failures do
+          expect(spy).to receive(:title_en).and_return("model foo")
+          expect(instance.title_en(super: true)).to eq("model foo")
 
-           expect(spy).to receive(:title_en?).and_return(true)
-           expect(instance.title_en?(super: true)).to eq(true)
+          expect(spy).to receive(:title_en?).and_return(true)
+          expect(instance.title_en?(super: true)).to eq(true)
 
-           expect(spy).to receive(:title_en=).with("model foo")
-           instance.send(:title_en=, "model foo", super: true)
-         end
-       end
-     end
+          expect(spy).to receive(:title_en=).with("model foo")
+          instance.send(:title_en=, "model foo", super: true)
+        end
+      end
+    end
+  end
+
+  context "with falsey option" do
+    plugin_setup locale_accesors: false
+
+    it "does not locale accessors for any locales" do
+      methods = model_class.instance_methods
+      I18n.available_locales.each do |locale|
+        expect(methods).not_to include(:"title_#{Mobility.normalize_locale(locale)}")
+        expect(methods).not_to include(:"title_#{Mobility.normalize_locale(locale)}?")
+        expect(methods).not_to include(:"title_#{Mobility.normalize_locale(locale)}=")
+      end
+    end
   end
 end

--- a/spec/support/matchers/have_plugin.rb
+++ b/spec/support/matchers/have_plugin.rb
@@ -1,0 +1,6 @@
+RSpec::Matchers.define :have_plugin do |expected|
+  match do |actual|
+    raise ArgumentError, "#{actual} should be a Mobility::Pluggable" unless Mobility::Pluggable === actual
+    actual.class.ancestors.include? Mobility::Plugins.load_plugin(expected)
+  end
+end


### PR DESCRIPTION
With the new plugin setup in v1.0, you need to explicitly enable plugins, like this:

```ruby
Mobility.configure do |config|
  config.plugin :locale_accessors
end
```

Currently, this will not actually get you locale_accessors since the default option is `nil`. This PR makes the default for both `locale_accessors` and `fallthrough_accessors` be `true`, which in the former case defaults to `I18n.available_locales`.

This PR also removes the `default_accessor_locales` configuration setting, since there should be no need for it. Global defaults can now be defined from plugin configuration.