### PR TITLE
Update readme to new v1 usage

### DIFF
--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -96,14 +96,6 @@ Mobility.configure do |config|
     # locale_accessors [:en, :ja]
   end
 
-  # You can also include backend-specific default options. For example, if you
-  # want to default to using the text-type translation table with the KeyValue
-  # backend, you can set that as a default by uncommenting this line, or change
-  # it to :string to default to the string-type translation table instead. (For
-  # other backends, this option is ignored.)
-  #
-  # default :type, :text
-
   # OTHER CONFIGURATION
 
   # By default, Mobility uses the +translates+ class method in models to


### PR DESCRIPTION
It's going to be pretty confusing for anyone trying to use Mobility from the master branch with the currrent readme. Although some of this usage is not really "final", I think it's better to at least keep things roughly in sync.

I intend to rewrite a lot of this once the changes are done, since there is a single pattern for defining plugins and a lot of the readme sounds repetitive now. So consider this a "quick fix".