### PR TITLE
Pass argument to plugin rather than default: kwarg

### DIFF
--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -9,8 +9,8 @@ Works with {Mobility::Plugin}. (Subclassed by {Mobility::Attributes}.)
 =end
   class Pluggable < Module
     class << self
-      def plugin(name, **options)
-        Plugin.configure(self, defaults) { __send__ name, **options }
+      def plugin(name, *args)
+        Plugin.configure(self, defaults) { __send__ name, *args }
       end
 
       def plugins(&block)

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -61,7 +61,7 @@ Also includes a +configure+ class method to apply plugins to a pluggable
       # @example
       #   Mobility::Plugin.configure(TranslatedAttributes) do
       #     cache
-      #     fallbacks default: [:en, :de]
+      #     fallbacks [:en, :de]
       #   end
       def configure(pluggable, defaults = pluggable.defaults, &block)
         DependencyResolver.new(pluggable, defaults).call(&block)
@@ -236,9 +236,9 @@ Also includes a +configure+ class method to apply plugins to a pluggable
           @defaults = defaults
         end
 
-        def method_missing(m, *_args, **options)
+        def method_missing(m, *args)
           @plugins << m
-          @defaults[m] = options[:default] if options.has_key?(:default)
+          @defaults[m] = args[0] unless args.empty?
         end
       end
     end

--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -10,7 +10,7 @@ Mobility.configure do |config|
     # To default to a different backend globally, replace +:key_value+ by another
     # backend name.
     #
-    backend default: :key_value
+    backend :key_value
 
     # ActiveRecord
     #
@@ -48,7 +48,7 @@ Mobility.configure do |config|
     #
     # Or uncomment this line to include but disable by default, and only enable
     # per model by passing +dirty: true+ to +translates+.
-    # dirty default: false
+    # dirty false
 
     # Fallbacks
     #
@@ -56,7 +56,7 @@ Mobility.configure do |config|
     # fallbacks
     #
     # Or uncomment this line to enable fallbacks with a global default.
-    # fallbacks default: { :pt => :en }
+    # fallbacks { :pt => :en }
 
     # Presence
     #
@@ -71,7 +71,7 @@ Mobility.configure do |config|
     # 'foo'+ sets a default translation string to show in case no translation is
     # present. Can also be passed a proc.
     #
-    # default
+    # default 'foo'
 
     # Fallthrough Accessors
     #
@@ -93,7 +93,7 @@ Mobility.configure do |config|
     # locale_accessors
     #
     # Or define specific defaults by uncommenting line below
-    # locale_accessors default: [:en, :ja]
+    # locale_accessors [:en, :ja]
   end
 
   # You can also include backend-specific default options. For example, if you

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -23,7 +23,7 @@ describe Mobility::InstallGenerator, type: :generator do
           directory "initializers" do
             file "mobility.rb" do
               contains "Mobility.configure do |config|"
-              contains "backend default: :key_value"
+              contains "backend :key_value"
               contains "query"
               contains "config.accessor_method = :translates"
             end

--- a/spec/mobility/pluggable_spec.rb
+++ b/spec/mobility/pluggable_spec.rb
@@ -18,7 +18,7 @@ describe Mobility::Pluggable do
     it "merges defaults into @options when initializing" do
       klass = Class.new(described_class)
 
-      klass.plugin :foo, default: 'bar'
+      klass.plugin :foo, 'bar'
       klass.default :baz, 'qux'
 
       pluggable = klass.new(other: 'param')
@@ -31,10 +31,10 @@ describe Mobility::Pluggable do
 
     it "dupes parent class defaults in descendants" do
       klass = Class.new(described_class)
-      klass.plugin(:foo, default: 'foo')
+      klass.plugin(:foo, 'foo')
 
       subclass = Class.new(klass)
-      subclass.plugin(:bar, default: 'bar')
+      subclass.plugin(:bar, 'bar')
 
       expect(klass.defaults).to eq(foo: 'foo')
       expect(subclass.defaults).to eq(foo: 'foo', bar: 'bar')
@@ -42,10 +42,10 @@ describe Mobility::Pluggable do
 
     it "overrides parent default in descendant if set" do
       klass = Class.new(described_class)
-      klass.plugin(:foo, default: 'foo')
+      klass.plugin(:foo, 'foo')
 
       subclass = Class.new(klass)
-      subclass.plugin(:foo, default: 'foo2')
+      subclass.plugin(:foo, 'foo2')
 
       expect(klass.defaults).to eq(foo: 'foo')
       expect(subclass.defaults).to eq(foo: 'foo2')
@@ -53,7 +53,7 @@ describe Mobility::Pluggable do
 
     it "inherits parent default if default unset in descendant" do
       klass = Class.new(described_class)
-      klass.plugin(:foo, default: 'foo')
+      klass.plugin(:foo, 'foo')
 
       subclass = Class.new(klass)
       subclass.plugin(:foo)

--- a/spec/mobility/plugin_spec.rb
+++ b/spec/mobility/plugin_spec.rb
@@ -18,7 +18,7 @@ describe Mobility::Plugin do
 
       it 'updates defaults for plugin' do
         described_class.configure(pluggable) do
-          __send__ :foo, default: 'somedefault'
+          __send__ :foo, 'somedefault'
         end
         expect(pluggable.defaults).to eq(foo: 'somedefault')
       end

--- a/spec/mobility/plugins/backend_reader_spec.rb
+++ b/spec/mobility/plugins/backend_reader_spec.rb
@@ -17,7 +17,7 @@ describe Mobility::Plugins::BackendReader do
 
   context "with custom format string" do
     plugin_setup do
-      backend_reader default: "%s_translations"
+      backend_reader "%s_translations"
     end
 
     it "defines backend reader methods with custom format string" do
@@ -29,7 +29,7 @@ describe Mobility::Plugins::BackendReader do
 
   context "with true as format string" do
     plugin_setup do
-      backend_reader default: true
+      backend_reader true
     end
 
     it "defines backend reader methods with default format string" do
@@ -40,7 +40,7 @@ describe Mobility::Plugins::BackendReader do
 
   context "with falsey format string" do
     plugin_setup do
-      backend_reader default: false
+      backend_reader false
     end
 
     it "does not define backend reader methods" do

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -50,7 +50,7 @@ describe Mobility::Plugins::FallthroughAccessors do
 
   context "option value is false" do
     plugin_setup do
-      fallthrough_accessors default: false
+      fallthrough_accessors false
     end
 
     it "does not include instance of FallthroughAccessors into attributes class" do


### PR DESCRIPTION
Currently, plugins are declared like this:

```ruby
Mobility.configure do |config|
  config.plugins do
    backend default: :key_value
    active_record
    fallbacks default: [:en, :ja]
    # ...
  end
end
```

I find this sounds a bit funny and the syntax ends up being cumberesome. How about we just pass the argument directly to the method, like this?

```ruby
Mobility.configure do |config|
  config.plugins do
    backend :key_value
    active_record
    fallbacks [:en, :ja]
    # ...
  end
end
```

I find this feels more natural. It also gives a nice lead-in to defining backend options directly on the options to the backend plugin, like this:

```ruby
Mobility.configure do |config|
  config.plugins do
    backend :key_value, type: :string, ...
    # ...
  end
end
```

But this would require a bit more work, so I'll leave that to a separate PR.