### PR TITLE
Pass class explicitly to with_options and configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Remove `Mobility::Configuration#default_accessor_locales`. Use plugin option
   to configure global default instead.
   ([#424](https://github.com/shioyama/mobility/pull/424))
+- Pass `model_class` to `Mobility::Backend#configure` via class method rather
+  than on options hash ([#429](https://github.com/shioyama/mobility/pull/429))
 
 ## 0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Move `_backend` methods into `backend_reader` plugin
   ([#403](https://github.com/shioyama/mobility/pull/403))
 - Replace `Configuration#query_method` configuration with Query plugin option
+  ([#414](https://github.com/shioyama/mobility/pull/414))
 - Remove `Mobility::Configuration#default_accessor_locales`. Use plugin option
   to configure global default instead.
   ([#424](https://github.com/shioyama/mobility/pull/424))

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -139,6 +139,7 @@ On top of this, a backend will normally:
       def inherited(subclass)
         subclass.instance_variable_set(:@setup_block, @setup_block)
         subclass.instance_variable_set(:@options, @options)
+        subclass.instance_variable_set(:@model_class, @model_class)
       end
 
       # Call setup block on a class with attributes and options.

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -115,10 +115,7 @@ On top of this, a backend will normally:
     # Extend included class with +setup+ method and other class methods
     def self.included(base)
       base.extend ClassMethods
-      def base.options
-        @options
-      end
-      base.option_reader :model_class
+      base.singleton_class.attr_reader :options, :model_class
     end
 
     # Defines setup hooks for backend to customize model class.
@@ -156,13 +153,14 @@ On top of this, a backend will normally:
       # Build a subclass of this backend class for a given set of options
       # @note This method also freezes the options hash to prevent it from
       #   being changed.
+      # @param [Class] model_class Class
       # @param [Hash] options
       # @return [Class] backend subclass
-      def with_options(options = {})
-        configure(options) if respond_to?(:configure)
-        options.freeze
+      def build_subclass(model_class, options)
         Class.new(self) do
-          @options = options
+          @model_class = model_class
+          configure(options) if respond_to?(:configure)
+          @options = options.freeze
         end
       end
 

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -71,7 +71,7 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
         private
 
         def get_column_type
-          options[:model_class].type_for_attribute(options[:column_name].to_s).try(:type).tap do |type|
+          model_class.type_for_attribute(options[:column_name].to_s).try(:type).tap do |type|
             unless %i[json jsonb].include? type
               raise InvalidColumnType, "#{options[:column_name]} must be a column of type json or jsonb"
             end

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -39,7 +39,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
             options[:association_name] ||= :"#{options[:type]}_translations"
             options[:class_name]       ||= Mobility::ActiveRecord.const_get("#{type.capitalize}Translation")
           end
-          options[:table_alias_affix] = "#{options[:model_class]}_%s_#{options[:association_name]}"
+          options[:table_alias_affix] = "#{model_class}_%s_#{options[:association_name]}"
         rescue NameError
           raise ArgumentError, "You must define a Mobility::ActiveRecord::#{type.capitalize}Translation class."
         end

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -101,7 +101,7 @@ columns to that table.
         # @option options [Symbol] subclass_name (:Translation) Name of subclass
         #   to append to model class to generate translation class
         def configure(options)
-          table_name = options[:model_class].table_name
+          table_name = model_class.table_name
           options[:table_name]  ||= "#{table_name.singularize}_translations"
           options[:foreign_key] ||= table_name.downcase.singularize.camelize.foreign_key
           if (association_name = options[:association_name]).present?

--- a/lib/mobility/backends/sequel/container.rb
+++ b/lib/mobility/backends/sequel/container.rb
@@ -44,7 +44,7 @@ Implements the {Mobility::Backends::Container} backend for Sequel models.
       def self.configure(options)
         options[:column_name] ||= :translations
         options[:column_name] = options[:column_name].to_sym
-        column_name, db_schema = options[:column_name], options[:model_class].db_schema
+        column_name, db_schema = options[:column_name], model_class.db_schema
         options[:column_type] = db_schema[column_name] && (db_schema[column_name][:db_type]).to_sym
         unless %i[json jsonb].include?(options[:column_type])
           raise InvalidColumnType, "#{options[:column_name]} must be a column of type json or jsonb"

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -36,7 +36,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
             options[:association_name] ||= :"#{options[:type]}_translations"
             options[:class_name]       ||= Mobility::Sequel.const_get("#{type.capitalize}Translation")
           end
-          options[:table_alias_affix] = "#{options[:model_class]}_%s_#{options[:association_name]}"
+          options[:table_alias_affix] = "#{model_class}_%s_#{options[:association_name]}"
         rescue NameError
           raise ArgumentError, "You must define a Mobility::Sequel::#{type.capitalize}Translation class."
         end

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -34,7 +34,7 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
         # @raise [CacheRequired] if cache option is false
         def configure(options)
           raise CacheRequired, "Cache required for Sequel::Table backend" if options[:cache] == false
-          table_name = Util.singularize(options[:model_class].table_name)
+          table_name = Util.singularize(model_class.table_name)
           options[:table_name]  ||= :"#{table_name}_translations"
           options[:foreign_key] ||= Util.foreign_key(Util.camelize(table_name.downcase))
           if association_name = options[:association_name]

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -37,8 +37,8 @@ Defines:
         super
 
         if backend_name
-          @backend_class = load_backend(backend_name)
-            .with_options(options.merge(model_class: klass))
+          @backend_class = load_backend(backend_name).
+            build_subclass(klass, options)
 
           klass.include InstanceMethods
           klass.extend ClassMethods

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -151,6 +151,12 @@ describe Mobility::Backend do
         expect(Class.new(subclass).options).to eq(foo: "bar")
       end
 
+      it "assigns model_class to descendants" do
+        model_class = Class.new
+        subclass = backend_class.build_subclass(model_class, foo: "bar")
+        expect(Class.new(subclass).model_class).to eq(model_class)
+      end
+
       it "concatenates blocks when called multiple times" do
         backend_class.class_eval do
           setup do |attributes, options|

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -126,28 +126,28 @@ describe Mobility::Backend do
 
       it "stores setup as block which is called in model class" do
         model_class = Class.new
-        backend_class.with_options(foo: "bar").setup_model(model_class, ["title"])
+        backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title"])
         expect(model_class.foo).to eq("foo")
         expect(model_class.new.bar).to eq("bar")
       end
 
       it "passes attributes and options to setup block when called on class" do
         model_class = Class.new
-        backend_class.with_options(foo: "bar").setup_model(model_class, ["title"])
+        backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title"])
         expect(model_class.new.my_attributes).to eq(["title"])
         expect(model_class.new.my_options).to eq({ foo: "bar" })
       end
 
       it "assigns setup block to descendants" do
         model_class = Class.new
-        subclass = backend_class.with_options(foo: "bar")
+        subclass = backend_class.build_subclass(model_class, foo: "bar")
         Class.new(subclass).setup_model(model_class, ["title"])
         expect(model_class.foo).to eq("foo")
       end
 
       it "assigns options to descendants" do
         model_class = Class.new
-        subclass = backend_class.with_options(foo: "bar")
+        subclass = backend_class.build_subclass(model_class, foo: "bar")
         expect(Class.new(subclass).options).to eq(foo: "bar")
       end
 
@@ -166,7 +166,7 @@ describe Mobility::Backend do
           end
         end
         model_class = Class.new
-        backend_class.with_options(foo: "bar").setup_model(model_class, ["title", "content"])
+        backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title", "content"])
 
         aggregate_failures do
           expect(model_class.foo).to eq("foo2")

--- a/spec/mobility/backends/active_record/column_spec.rb
+++ b/spec/mobility/backends/active_record/column_spec.rb
@@ -18,7 +18,7 @@ describe "Mobility::Backends::ActiveRecord::Column", orm: :active_record do
     let(:attributes) { %w[content author] }
     let(:options) { {} }
     let(:backend) do
-      described_class.with_options(options).new(comment, attributes.first)
+      described_class.build_subclass(Comment, options).new(comment, attributes.first)
     end
     let(:comment) do
       Comment.create(content_en: "Good post!",

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -333,43 +333,44 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record do
     end
 
     describe ".configure" do
+      let(:backend_class) do
+        Class.new(described_class) { @model_class = Post }
+      end
+
       it "sets association_name, class_name and table_alias_affix from string type" do
-        options = { type: :string, model_class: Post }
-        described_class.configure(options)
+        options = { type: :string }
+        backend_class.configure(options)
         expect(options).to eq({
           type: :string,
           class_name: Mobility::ActiveRecord::StringTranslation,
-          model_class: Post,
           association_name: :string_translations,
           table_alias_affix: "Post_%s_string_translations"
         })
       end
 
       it "sets association_name, class_name and table_alias_affix from text type" do
-        options = { type: :text, model_class: Post }
-        described_class.configure(options)
+        options = { type: :text }
+        backend_class.configure(options)
         expect(options).to eq({
           type: :text,
           class_name: Mobility::ActiveRecord::TextTranslation,
-          model_class: Post,
           association_name: :text_translations,
           table_alias_affix: "Post_%s_text_translations"
         })
       end
 
       it "raises ArgumentError if type has no corresponding model class" do
-        expect { described_class.configure(type: "integer") }
+        expect { backend_class.configure(type: "integer") }
           .to raise_error(ArgumentError,
                           "You must define a Mobility::ActiveRecord::IntegerTranslation class.")
       end
 
       it "sets default association_name and class_name from type" do
-        options = { type: :text, model_class: Post }
-        described_class.configure(options)
+        options = { type: :text }
+        backend_class.configure(options)
         expect(options).to eq({
           type: :text,
           class_name: Mobility::ActiveRecord::TextTranslation,
-          model_class: Post,
           association_name: :text_translations,
           table_alias_affix: "Post_%s_text_translations"
         })

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -238,24 +238,28 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record do
   end
 
   describe ".configure" do
-    let(:options) { { model_class: Article } }
+    let(:options) { {} }
+    let(:backend_class) do
+      Class.new(described_class) { @model_class = Article }
+    end
+
     it "sets association_name" do
-      described_class.configure(options)
+      backend_class.configure(options)
       expect(options[:association_name]).to eq(:translations)
     end
 
     it "sets subclass_name" do
-      described_class.configure(options)
+      backend_class.configure(options)
       expect(options[:subclass_name]).to eq(:Translation)
     end
 
     it "sets table_name" do
-      described_class.configure(options)
+      backend_class.configure(options)
       expect(options[:table_name]).to eq(:article_translations)
     end
 
     it "sets foreign_key" do
-      described_class.configure(options)
+      backend_class.configure(options)
       expect(options[:foreign_key]).to eq(:article_id)
     end
   end

--- a/spec/mobility/backends/sequel/key_value_spec.rb
+++ b/spec/mobility/backends/sequel/key_value_spec.rb
@@ -359,44 +359,45 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel do
     end
 
     describe ".configure" do
+      let(:backend_class) do
+        Class.new(described_class) { @model_class = Post }
+      end
+
       it "sets association_name, class_name and table_alias_affix from string type" do
-        options = { type: :string, model_class: Post }
-        described_class.configure(options)
+        options = { type: :string }
+        backend_class.configure(options)
         expect(options).to eq({
           type: :string,
           class_name: Mobility::Sequel::StringTranslation,
-          model_class: Post,
           association_name: :string_translations,
           table_alias_affix: "Post_%s_string_translations"
         })
       end
 
       it "sets association_name, class_name and table_alias_affix from text type" do
-        options = { type: :text, model_class: Post }
-        described_class.configure(options)
+        options = { type: :text }
+        backend_class.configure(options)
         expect(options).to eq({
           type: :text,
           class_name: Mobility::Sequel::TextTranslation,
-          model_class: Post,
           association_name: :text_translations,
           table_alias_affix: "Post_%s_text_translations"
         })
       end
 
       it "raises ArgumentError if type has no corresponding model class" do
-        expect { described_class.configure(type: "integer") }
+        expect { backend_class.configure(type: "integer") }
           .to raise_error(ArgumentError,
                           "You must define a Mobility::Sequel::IntegerTranslation class.")
       end
 
 
       it "sets default association_name, class_name and table_alias_affix from type" do
-        options = { type: :text, model_class: Post }
-        described_class.configure(options)
+        options = { type: :text }
+        backend_class.configure(options)
         expect(options).to eq({
           type: :text,
           class_name: Mobility::Sequel::TextTranslation,
-          model_class: Post,
           association_name: :text_translations,
           table_alias_affix: "Post_%s_text_translations"
         })

--- a/spec/mobility/backends/sequel/table_spec.rb
+++ b/spec/mobility/backends/sequel/table_spec.rb
@@ -148,24 +148,28 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel do
     end
 
     describe ".configure" do
-      let(:options) { { model_class: Article } }
+      let(:options) { {} }
+      let(:backend_class) do
+        Class.new(described_class) { @model_class = Article }
+      end
+
       it "sets association_name" do
-        described_class.configure(options)
+        backend_class.configure(options)
         expect(options[:association_name]).to eq(:translations)
       end
 
       it "sets subclass_name" do
-        described_class.configure(options)
+        backend_class.configure(options)
         expect(options[:subclass_name]).to eq(:Translation)
       end
 
       it "sets table_name" do
-        described_class.configure(options)
+        backend_class.configure(options)
         expect(options[:table_name]).to eq(:article_translations)
       end
 
       it "sets foreign_key" do
-        described_class.configure(options)
+        backend_class.configure(options)
         expect(options[:foreign_key]).to eq(:article_id)
       end
     end

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -13,8 +13,8 @@ describe Mobility::Plugins::Backend do
   let(:model_class) { Class.new }
 
   describe "#included" do
-    it "calls with_options on backend class with options merged with default options" do
-      expect(backend_class).to receive(:with_options).with(hash_including(foo: "bar", model_class: model_class)).and_return(Class.new(backend_class))
+    it "calls build_subclass on backend class with options merged with default options" do
+      expect(backend_class).to receive(:build_subclass).with(model_class, hash_including(foo: "bar")).and_return(Class.new(backend_class))
       attributes = attributes_class.new("title", backend: backend_class, foo: "bar")
       model_class.include attributes
     end
@@ -22,7 +22,7 @@ describe Mobility::Plugins::Backend do
     it "assigns options to backend class" do
       attributes = attributes_class.new("title", backend: backend_class, foo: "bar")
       model_class.include attributes
-      expect(attributes.backend_class.options).to eq(backend: backend_class, model_class: model_class, foo: "bar")
+      expect(attributes.backend_class.options).to eq(backend: backend_class, foo: "bar")
     end
 
     it "freezes backend options after inclusion into model class" do

--- a/spec/support/shared_examples/backend_examples.rb
+++ b/spec/support/shared_examples/backend_examples.rb
@@ -2,8 +2,7 @@ shared_examples_for "Mobility backend" do |backend_class, model_class, attribute
   let(:backend) do
     model_class = model_class.constantize if model_class.is_a?(String)
 
-    options = { model_class: model_class, **options }
-    klass = backend_class.with_options(options)
+    klass = backend_class.build_subclass(model_class, options.dup)
     klass.setup_model(model_class, [attribute])
     klass.new(model_class.new, attribute)
   end


### PR DESCRIPTION
Merging the class into the options isn't really a very good idea, since it clutters the hash and makes it less clear what comes from where. Let's just pass it as a separate argument.