### PR TITLE
Allow configuration to define backend options explicitly on backend

### DIFF
--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -21,10 +21,6 @@ Works with {Mobility::Plugin}. (Subclassed by {Mobility::Attributes}.)
         @defaults ||= {}
       end
 
-      def default(name, value)
-        @defaults[name.to_sym] = value
-      end
-
       def inherited(klass)
         super
         klass.defaults.merge!(defaults)

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -106,6 +106,10 @@ Also includes a +configure+ class method to apply plugins to a pluggable
       @default = value
     end
 
+    def configure_default(defaults, key, *args, **kwargs)
+      defaults[key] = args[0] unless args.empty?
+    end
+
     # Does this class include all plugins this plugin depends (directly) on?
     # @param [Class] klass Pluggable class
     def dependencies_satisfied?(klass)
@@ -233,9 +237,10 @@ Also includes a +configure+ class method to apply plugins to a pluggable
           @defaults = defaults
         end
 
-        def method_missing(m, *args)
-          @plugins << Plugins.load_plugin(m)
-          @defaults[m] = args[0] unless args.empty?
+        def method_missing(m, *args, **kwargs)
+          plugin = Plugins.load_plugin(m)
+          @plugins << plugin
+          plugin.configure_default(@defaults, m, *args, **kwargs)
         end
       end
     end

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -106,6 +106,15 @@ Also includes a +configure+ class method to apply plugins to a pluggable
       @default = value
     end
 
+    # Method called when defining plugins to assign a default based on
+    # arguments and keyword arguments to the plugin method. By default, we
+    # simply assign the first argument, but plugins can opt to customize this
+    # if additional arguments or keyword arguments are required.
+    # (The backend plugin uses keyword arguments to set backend options.)
+    #
+    # @param [Hash] defaults
+    # @param [Symbol] key Plugin key on hash
+    # @param [Array] args Method arguments
     def configure_default(defaults, key, *args, **)
       defaults[key] = args[0] unless args.empty?
     end

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -71,11 +71,11 @@ Also includes a +configure+ class method to apply plugins to a pluggable
     def initialize_hook(&block)
       plugin = self
 
-      define_method :initialize do |*names, **options|
-        super(*names, **options)
+      define_method :initialize do |*args, **options|
+        super(*args, **options)
         return unless plugin.dependencies_satisfied?(self.class)
 
-        class_exec(*names, &block)
+        class_exec(*args, &block)
       end
     end
 

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -73,9 +73,8 @@ Also includes a +configure+ class method to apply plugins to a pluggable
 
       define_method :initialize do |*args, **options|
         super(*args, **options)
-        return unless plugin.dependencies_satisfied?(self.class)
 
-        class_exec(*args, &block)
+        class_exec(*args, &block) if plugin.dependencies_satisfied?(self.class)
       end
     end
 

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -106,7 +106,7 @@ Also includes a +configure+ class method to apply plugins to a pluggable
       @default = value
     end
 
-    def configure_default(defaults, key, *args, **kwargs)
+    def configure_default(defaults, key, *args, **)
       defaults[key] = args[0] unless args.empty?
     end
 

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -31,7 +31,7 @@ Defines:
       attr_reader :backend_options
 
       def initialize(*args, **original_options)
-        super(*args, **original_options)
+        super
         return unless Plugins::Backend.dependencies_satisfied?(self.class)
 
         case options[:backend]

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -30,12 +30,16 @@ Defines:
       # @return [Hash] Options for backend
       attr_reader :backend_options
 
-      initialize_hook do
+      def initialize(*args, **original_options)
+        super(*args, **original_options)
+        return unless Plugins::Backend.dependencies_satisfied?(self.class)
+
         case options[:backend]
         when String, Symbol, Module
           @backend_name, @backend_options = options[:backend], options
         when Array
           @backend_name, @backend_options = options[:backend]
+          @backend_options.merge!(original_options)
         else
           raise ArgumentError, "backend must be either a backend name, a backend class, or a two-element array"
         end

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -39,7 +39,7 @@ Defines:
           @backend_name, @backend_options = options[:backend], options
         when Array
           @backend_name, @backend_options = options[:backend]
-          @backend_options.merge!(original_options)
+          @backend_options = @backend_options.merge(original_options)
         else
           raise ArgumentError, "backend must be either a backend name, a backend class, or a two-element array"
         end

--- a/lib/mobility/plugins/dirty.rb
+++ b/lib/mobility/plugins/dirty.rb
@@ -27,7 +27,7 @@ details.
 
       initialize_hook do
         if options[:dirty] && !options[:fallthrough_accessors]
-          warn 'The Dirty plugin depends on Fallthrough Accessors being enabled,'\
+          warn 'The Dirty plugin depends on Fallthrough Accessors being enabled, '\
             'but fallthrough_accessors option is falsey'
         end
       end

--- a/spec/mobility/configuration_spec.rb
+++ b/spec/mobility/configuration_spec.rb
@@ -17,11 +17,4 @@ describe Mobility::Configuration do
       subject.plugin :foo, these: 'params'
     end
   end
-
-  describe "#default" do
-    it "delegates to attributes_class#default" do
-      expect(subject.attributes_class).to receive(:default).with(:foo, 'bar')
-      subject.default :foo, 'bar'
-    end
-  end
 end

--- a/spec/mobility/pluggable_spec.rb
+++ b/spec/mobility/pluggable_spec.rb
@@ -3,15 +3,6 @@ require "spec_helper"
 describe Mobility::Pluggable do
   include Helpers::Plugins
 
-  describe "#default" do
-    it "defines default on defaults hash" do
-      klass = Class.new(described_class)
-
-      klass.default(:foo, 'bar')
-      expect(klass.defaults).to eq(foo: 'bar')
-    end
-  end
-
   describe "#initialize" do
     define_plugins(:foo)
 
@@ -19,10 +10,9 @@ describe Mobility::Pluggable do
       klass = Class.new(described_class)
 
       klass.plugin :foo, 'bar'
-      klass.default :baz, 'qux'
 
       pluggable = klass.new(other: 'param')
-      expect(pluggable.options).to eq(foo: 'bar', baz: 'qux', other: 'param')
+      expect(pluggable.options).to eq(foo: 'bar', other: 'param')
     end
   end
 

--- a/spec/mobility/plugin_spec.rb
+++ b/spec/mobility/plugin_spec.rb
@@ -16,13 +16,6 @@ describe Mobility::Plugin do
         expect(included_plugins).to include(foo)
       end
 
-      it 'updates defaults for plugin' do
-        described_class.configure(pluggable) do
-          __send__ :foo, 'somedefault'
-        end
-        expect(pluggable.defaults).to eq(foo: 'somedefault')
-      end
-
       it 'detects before dependency conflict between two plugins' do
         foo.requires :bar, include: :before
         bar.requires :foo, include: :before

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -214,19 +214,25 @@ describe Mobility::Plugins::Backend do
 
       it "passes backend options to backend" do
         attributes = attributes_class.new("title")
-        expect(FooBackend).to receive(:configure).with({ association_name: :foo })
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :foo))
         model_class.include(attributes)
       end
 
-      it "passes module options if defined" do
+      it "passes module options if backend_options passed explicitly to initializer" do
         attributes = attributes_class.new("title", backend: [:foo, { association_name: :bar }])
-        expect(FooBackend).to receive(:configure).with({ association_name: :bar })
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :bar))
         model_class.include(attributes)
       end
 
-      it "passes module options if overridden with symbol" do
-        attributes = attributes_class.new("title", backend: :foo)
-        expect(FooBackend).to receive(:configure).with({ backend: :foo })
+      it "passes module options if backend options passed implicitly to initializer" do
+        attributes = attributes_class.new("title", backend: :foo, association_name: :bar)
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :bar))
+        model_class.include(attributes)
+      end
+
+      it "overrides backend option from options passed to initializer even when backend: key is missing" do
+        attributes = attributes_class.new("title", association_name: :bar)
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :bar))
         model_class.include(attributes)
       end
     end

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -235,6 +235,14 @@ describe Mobility::Plugins::Backend do
         expect(FooBackend).to receive(:configure).with(hash_including(association_name: :baz))
         model_class.include(attributes)
       end
+
+      it "does not override original backend options hash" do
+        backend_options = { association_name: :foo }
+        expect {
+          attributes = attributes_class.new("title", backend: [:foo, backend_options])
+          model_class.include(attributes)
+        }.not_to change { backend_options }
+      end
     end
   end
 end

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -205,7 +205,7 @@ describe Mobility::Plugins::Backend do
 
     describe "default with backend options" do
       plugin_setup do
-        backend :foo, association_name: :foo
+        backend :foo, association_name: :bar
       end
 
       it "assigns backend name correctly" do
@@ -214,25 +214,25 @@ describe Mobility::Plugins::Backend do
 
       it "passes backend options to backend" do
         attributes = attributes_class.new("title")
-        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :foo))
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :bar))
         model_class.include(attributes)
       end
 
       it "passes module options if backend_options passed explicitly to initializer" do
-        attributes = attributes_class.new("title", backend: [:foo, { association_name: :bar }])
-        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :bar))
+        attributes = attributes_class.new("title", backend: [:foo, { association_name: :baz }])
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :baz))
         model_class.include(attributes)
       end
 
       it "passes module options if backend options passed implicitly to initializer" do
-        attributes = attributes_class.new("title", backend: :foo, association_name: :bar)
-        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :bar))
+        attributes = attributes_class.new("title", backend: :foo, association_name: :baz)
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :baz))
         model_class.include(attributes)
       end
 
       it "overrides backend option from options passed to initializer even when backend: key is missing" do
-        attributes = attributes_class.new("title", association_name: :bar)
-        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :bar))
+        attributes = attributes_class.new("title", association_name: :baz)
+        expect(FooBackend).to receive(:configure).with(hash_including(association_name: :baz))
         model_class.include(attributes)
       end
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -151,19 +151,25 @@ module Helpers
 
         attribute_names = [attribute_name, *other_names]
         let(:attribute_name) { attribute_name }
+
         let(:attributes_class) do
           Class.new(TestAttributes).tap do |attrs|
             attrs.plugins(&plugin_definer)
           end
         end
+
         let(:model_class) do
           Class.new.tap do |klass|
             klass.include attributes
           end
         end unless method_defined?(:model_class)
+
         let(:instance) { model_class.new }
 
-        let(:attributes) { attributes_class.new(*attribute_names, backend: backend_class, **options) }
+        let(:attributes) do
+          attributes_class.new(*attribute_names, backend: backend_class, **options)
+        end
+
         let(:listener) { double(:backend) }
         let(:backend_class) { backend_listener(listener) }
         let(:backend) { instance.mobility_backends[attribute_name] }


### PR DESCRIPTION
Currently, you can define backend options like `association_name` like this:

```ruby
Mobility.configure do |config|
  config.plugins do
    backend :key_value
  end

  default :association_name, :foo
end
```

But I find this problematic for several reasons:

1. the `association_name` default is set on a `defaults` hash which is passed to all plugins, but it's not actually a plugin option but a backend option.
2. if you override the `backend` in options, you still get the `association_name` to the backend. But backend options are specific to the backend to which they are applied, and should not be passed to other backends
3. it's confusing when you read it because it's not clear what the `default` here is connected to.

What I _want_ is this:

```ruby
Mobility.configure do |config|
  config.plugins do
    backend :key_value, association_name: :foo
  end
end
```

Here, it's very clear that the `association_name` is applied to the `key_value` plugin.

This PR makes that happen.