### PR TITLE
Clean up spec helper and fix kwargs issue with plugins block

### DIFF
--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -114,7 +114,7 @@ Also includes a +configure+ class method to apply plugins to a pluggable
     # @param [Hash] defaults
     # @param [Symbol] key Plugin key on hash
     # @param [Array] args Method arguments
-    def configure_default(defaults, key, *args, **)
+    def configure_default(defaults, key, *args)
       defaults[key] = args[0] unless args.empty?
     end
 
@@ -245,10 +245,10 @@ Also includes a +configure+ class method to apply plugins to a pluggable
           @defaults = defaults
         end
 
-        def method_missing(m, *args, **kwargs)
+        def method_missing(m, *args)
           plugin = Plugins.load_plugin(m)
           @plugins << plugin
-          plugin.configure_default(@defaults, m, *args, **kwargs)
+          plugin.configure_default(@defaults, m, *args)
         end
       end
     end

--- a/spec/mobility/plugins/active_model/cache_spec.rb
+++ b/spec/mobility/plugins/active_model/cache_spec.rb
@@ -2,7 +2,10 @@ require "spec_helper"
 
 describe "Mobility::Plugins::ActiveModel::Cache", orm: :active_record do
   include Helpers::Plugins
-  plugin_setup active_model: true, cache: true
+  plugin_setup do
+    active_model
+    cache
+  end
 
   let(:model_class) do
     Class.new do

--- a/spec/mobility/plugins/active_model/dirty_spec.rb
+++ b/spec/mobility/plugins/active_model/dirty_spec.rb
@@ -6,7 +6,12 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
   require "mobility/plugins/active_model/dirty"
 
   include Helpers::Plugins
-  plugin_setup active_model: true, dirty: true, reader: true, writer: true
+  plugin_setup do
+    active_model
+    dirty true
+    reader
+    writer
+  end
 
   it "raises TypeError unless class is a subclass of ActiveModel::Dirty" do
     klass = Class.new
@@ -343,7 +348,13 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record do
   end
 
   describe "fallbacks compatiblity" do
-    plugin_setup active_model: true, dirty: true, fallbacks: { en: 'ja' }, reader: true, writer: true
+    plugin_setup do
+      active_model
+      dirty true
+      fallbacks({ en: 'ja' })
+      reader
+      writer
+    end
 
     let(:model_class) do
       stub_const 'ArticleWithFallbacks', Class.new

--- a/spec/mobility/plugins/active_record/cache_spec.rb
+++ b/spec/mobility/plugins/active_record/cache_spec.rb
@@ -2,7 +2,10 @@ require "spec_helper"
 
 describe "Mobility::Plugins::ActiveRecord::Cache", orm: :active_record do
   include Helpers::Plugins
-  plugin_setup active_record: true, cache: true
+  plugin_setup do
+    active_record
+    cache
+  end
 
   let(:model_class) do
     klass = Class.new(ActiveRecord::Base)

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -4,7 +4,12 @@ return unless defined?(ActiveRecord)
 
 describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record do
   include Helpers::Plugins
-  plugin_setup "title", dirty: true, active_record: true, reader: true, writer: true
+  plugin_setup "title" do
+    dirty true
+    active_record
+    reader
+    writer
+  end
 
   let(:model_class) do
     stub_const 'Article', Class.new(ActiveRecord::Base)

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -20,7 +20,10 @@ describe "Mobility::Plugins::ActiveRecord::Query", orm: :active_record do
     end
 
     context "default query scope" do
-      plugin_setup query: true, active_record: true
+      plugin_setup do
+        query
+        active_record
+      end
 
       it "defines query scope" do
         expect(model_class.i18n).to eq(model_class.__mobility_query_scope__)
@@ -28,7 +31,10 @@ describe "Mobility::Plugins::ActiveRecord::Query", orm: :active_record do
     end
 
     context "custom query scope" do
-      plugin_setup query: :foo, active_record: true
+      plugin_setup do
+        query :foo
+        active_record
+      end
 
       it "defines query scope" do
         expect(model_class.foo).to eq(model_class.__mobility_query_scope__)

--- a/spec/mobility/plugins/attribute_methods_spec.rb
+++ b/spec/mobility/plugins/attribute_methods_spec.rb
@@ -4,7 +4,11 @@ return unless defined?(ActiveRecord)
 
 describe "Mobility::Plugins::AttributeMethods", orm: :active_record do
   include Helpers::Plugins
-  plugin_setup active_record: true, attribute_methods: true, reader: true
+  plugin_setup do
+    active_record
+    attribute_methods true
+    reader
+  end
 
   let(:untranslated_attributes) do
     {

--- a/spec/mobility/plugins/cache_spec.rb
+++ b/spec/mobility/plugins/cache_spec.rb
@@ -100,7 +100,10 @@ describe Mobility::Plugins::Cache do
 
     context "ActiveRecord model", orm: :active_record do
       context "with one backend" do
-        plugin_setup cache: true, active_record: true
+        plugin_setup do
+          cache
+          active_record
+        end
 
         let(:model_class) do
           stub_const 'Article', Class.new(ActiveRecord::Base)
@@ -132,7 +135,10 @@ describe Mobility::Plugins::Cache do
       end
 
       context "with multiple backends" do
-        plugin_setup "title", cache: true, active_record: true
+        plugin_setup "title" do
+          cache
+          active_record
+        end
 
         let(:instance) { model_class.create }
         let(:content_listener) { double(:backend) }
@@ -150,7 +156,10 @@ describe Mobility::Plugins::Cache do
 
     context "Sequel model", orm: :sequel do
       context "with one backend" do
-        plugin_setup "title", cache: true, sequel: true
+        plugin_setup "title" do
+          cache
+          sequel
+        end
         let(:instance) { model_class.create }
         let(:model_class) do
           stub_const 'Article', Class.new(Sequel::Model)
@@ -163,7 +172,10 @@ describe Mobility::Plugins::Cache do
       end
 
       context "with multiple backends" do
-        plugin_setup "title", cache: true, sequel: true
+        plugin_setup "title" do
+          cache
+          sequel
+        end
 
         let(:instance) { model_class.create }
         let(:content_listener) { double(:backend) }

--- a/spec/mobility/plugins/default_spec.rb
+++ b/spec/mobility/plugins/default_spec.rb
@@ -5,7 +5,9 @@ describe Mobility::Plugins::Default do
   include Helpers::Plugins
 
   context "option = 'foo'" do
-    plugin_setup default: 'default foo'
+    plugin_setup do
+      default 'default foo'
+    end
 
     describe "#read" do
       it "returns value if not nil" do
@@ -41,7 +43,9 @@ describe Mobility::Plugins::Default do
   end
 
   context "default is a Proc" do
-    plugin_setup default: Proc.new { |attribute, locale, options| "#{attribute} in #{locale} with #{options[:this]}" }
+    plugin_setup do
+      default Proc.new { |attribute, locale, options| "#{attribute} in #{locale} with #{options[:this]}" }
+    end
 
     it "calls default with model and attribute as args if default is a Proc" do
       expect(listener).to receive(:read).once.with(:fr, this: 'option').and_return(nil)

--- a/spec/mobility/plugins/dirty_spec.rb
+++ b/spec/mobility/plugins/dirty_spec.rb
@@ -15,7 +15,10 @@ describe Mobility::Plugins::Dirty do
   end
 
   context "fallthrough accessors is falsey" do
-    plugin_setup dirty: true, fallthrough_accessors: false
+    plugin_setup do
+      dirty true
+      fallthrough_accessors false
+    end
 
     it "emits warning" do
       expect { instance }.to output(

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -5,7 +5,9 @@ describe Mobility::Plugins::Fallbacks do
   include Helpers::Plugins
 
   context "fallbacks is a hash" do
-    plugin_setup fallbacks: { :'en-US' => 'de-DE', :pt => 'de-DE' }
+    plugin_setup do
+      fallbacks({ :'en-US' => 'de-DE', :pt => 'de-DE' })
+    end
 
     it "returns value when value is not nil" do
       allow(listener).to receive(:read).once.with(:ja, any_args).and_return("ja val")
@@ -74,7 +76,9 @@ describe Mobility::Plugins::Fallbacks do
 
   if ENV['FEATURE'] == 'i18n_fallbacks'
     context "fallbacks is true" do
-      plugin_setup fallbacks: true
+      plugin_setup do
+        fallbacks true
+      end
 
       it "uses default fallbacks" do
         i18n_fallbacks = I18n.fallbacks

--- a/spec/mobility/plugins/locale_accessors_spec.rb
+++ b/spec/mobility/plugins/locale_accessors_spec.rb
@@ -5,7 +5,11 @@ describe Mobility::Plugins::LocaleAccessors do
   include Helpers::Plugins
 
   context "with option = [locales]" do
-    plugin_setup locale_accessors: [:cz, :de, :'pt-BR'], reader: true, writer: true
+    plugin_setup do
+      locale_accessors [:cz, :de, :'pt-BR']
+      reader
+      writer
+    end
 
     it_behaves_like "locale accessor", :title, :cz
     it_behaves_like "locale accessor", :title, :de
@@ -86,7 +90,9 @@ describe Mobility::Plugins::LocaleAccessors do
   end
 
   context "with falsey option" do
-    plugin_setup locale_accesors: false
+    plugin_setup do
+      locale_accessors false
+    end
 
     it "does not locale accessors for any locales" do
       methods = model_class.instance_methods

--- a/spec/mobility/plugins/presence_spec.rb
+++ b/spec/mobility/plugins/presence_spec.rb
@@ -79,7 +79,9 @@ describe Mobility::Plugins::Presence do
   end
 
   context "option = false" do
-    plugin_setup presence: false
+    plugin_setup do
+      presence false
+    end
 
     describe "#read" do
       it "does not convert blank strings to nil" do

--- a/spec/mobility/plugins/sequel/cache_spec.rb
+++ b/spec/mobility/plugins/sequel/cache_spec.rb
@@ -2,7 +2,10 @@ require "spec_helper"
 
 describe "Mobility::Plugins::Sequel::Cache", orm: :sequel do
   include Helpers::Plugins
-  plugin_setup sequel: true, cache: true
+  plugin_setup do
+    sequel
+    cache
+  end
 
   let(:model_class) do
     stub_const 'Article', Class.new(Sequel::Model)

--- a/spec/mobility/plugins/sequel/dirty_spec.rb
+++ b/spec/mobility/plugins/sequel/dirty_spec.rb
@@ -4,7 +4,12 @@ return unless defined?(Sequel)
 
 describe "Mobility::Plugins::Sequel::Dirty", orm: :sequel do
   include Helpers::Plugins
-  plugin_setup "title", dirty: true, sequel: true, reader: true, writer: true
+  plugin_setup "title" do
+    dirty true
+    sequel
+    reader
+    writer
+  end
 
   let(:model_class) do
     stub_const 'Article', Class.new(Sequel::Model)

--- a/spec/mobility/plugins/writer_spec.rb
+++ b/spec/mobility/plugins/writer_spec.rb
@@ -4,7 +4,9 @@ require "mobility/plugins/writer"
 describe Mobility::Plugins::Writer do
   include Helpers::Plugins
 
-  plugin_setup { writer }
+  plugin_setup do
+    writer
+  end
 
   describe "getters" do
     let(:instance) { model_class.new }

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -142,19 +142,12 @@ module Helpers
       # backend.
       # Pass block to define plugins in block.
       def plugin_setup(attribute_name = "title", *other_names, **options, &block)
-        if block_given?
-          plugin_definer = block
-        else
-          plugin_names = options.keys & Dir['./lib/mobility/plugins/*.rb'].map { |f| File.basename(f, '.rb').to_sym }
-          plugin_definer = proc { plugin_names.each { |plugin| __send__(plugin) } }
-        end
-
         attribute_names = [attribute_name, *other_names]
         let(:attribute_name) { attribute_name }
 
         let(:attributes_class) do
           Class.new(TestAttributes).tap do |attrs|
-            attrs.plugins(&plugin_definer)
+            attrs.plugins(&block)
           end
         end
 


### PR DESCRIPTION
This started as a simple spec cleanup but in the process I realized that the way the `plugins` block now works, it accepts optional kwargs which breaks setting a default hash in plugins that don't accept kwargs.

Mobility has to get this whole keyword arguments thing in order... but anyway the fix here is just to treat all arguments passed in the block as positional arguments, and let the backend plugin (which is the only plugin that accepts an options hash along with the backend name) handle the special case.