### PR TITLE
Postgres constant is PG, not Pg

### DIFF
--- a/spec/mobility/backends/sequel/container_spec.rb
+++ b/spec/mobility/backends/sequel/container_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-return unless defined?(Sequel) && defined?(Pg)
+return unless defined?(Sequel) && defined?(PG)
 
 describe "Mobility::Backends::Sequel::Container", orm: :sequel, db: :postgres do
   require "mobility/backends/sequel/container"

--- a/spec/mobility/backends/sequel/json_spec.rb
+++ b/spec/mobility/backends/sequel/json_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-return unless defined?(Sequel) && defined?(Pg)
+return unless defined?(Sequel) && defined?(PG)
 
 describe "Mobility::Backends::Sequel::Json", orm: :sequel, db: :postgres do
   require "mobility/backends/sequel/json"

--- a/spec/mobility/backends/sequel/jsonb_spec.rb
+++ b/spec/mobility/backends/sequel/jsonb_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-return unless defined?(Sequel) && defined?(Pg)
+return unless defined?(Sequel) && defined?(PG)
 
 describe "Mobility::Backends::Sequel::Jsonb", orm: :sequel, db: :postgres do
   require "mobility/backends/sequel/jsonb"


### PR DESCRIPTION
Tests were incorrectly checking if `Pg` is defined, but in fact the constant is `PG`.

Extracted from #437