### PR TITLE
Use const_get instead of constantize to avoid dependency on inflections

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -32,7 +32,7 @@ module Helpers
       while this_metadata do
         candidate = this_metadata[:description_args].first
         begin
-          return candidate.constantize if String === candidate
+          return Object.const_get(candidate) if String === candidate
         rescue NameError, NoMethodError
         end
         this_metadata = this_metadata[:parent_example_group]


### PR DESCRIPTION
We shouldn't be depending on `String#constantize` being defined, even in a spec. `Object.const_get` should work just as well here.