### PR TITLE
Rename Mobility::Attributes to Mobility::Translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   ([#443](https://github.com/shioyama/mobility/pull/443))
 - Remove `Configuration#accessor_method`
   ([#450](https://github.com/shioyama/mobility/pull/450))
+- Rename `Mobility::Attributes` to `Mobility::Translations`
 
 ## 0.8
 

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -28,7 +28,7 @@ module Mobility
   require "mobility/configuration"
   require "mobility/plugin"
   require "mobility/plugins"
-  require "mobility/attributes"
+  require "mobility/translations"
 
   # General error for version compatibility conflicts
   class VersionNotSupportedError < ArgumentError; end

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -47,7 +47,7 @@ On top of this, a backend will normally:
     end
   end
 
-@see Mobility::Attributes
+@see Mobility::Translations
 
 =end
 

--- a/lib/mobility/configuration.rb
+++ b/lib/mobility/configuration.rb
@@ -26,7 +26,7 @@ Stores shared Mobility configuration referenced by all backends.
     end
 
     def translations_class
-      @translations_class ||= Class.new(Attributes)
+      @translations_class ||= Class.new(Translations)
     end
   end
 end

--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -4,7 +4,7 @@ module Mobility
 =begin
 
 Abstract Module subclass with methods to define plugins and defaults.
-Works with {Mobility::Plugin}. (Subclassed by {Mobility::Attributes}.)
+Works with {Mobility::Plugin}. (Subclassed by {Mobility::Translations}.)
 
 =end
   class Pluggable < Module

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -36,15 +36,15 @@ Also includes a +configure+ class method to apply plugins to a pluggable
   end
 
 @example Configure an attributes class with plugins
-  class TranslatedAttributes < Mobility::Attributes
+  class Translations < Mobility::Translations
   end
 
-  Mobility::Plugin.configure(TranslatedAttributes) do
+  Mobility::Plugin.configure(Translations) do
     cache
     fallbacks
   end
 
-  TranslatedAttributes.included_modules
+  Translations.included_modules
   #=> [Mobility::Plugins::Fallbacks, Mobility::Plugins::Cache, ...]
 =end
   module Plugin
@@ -59,7 +59,7 @@ Also includes a +configure+ class method to apply plugins to a pluggable
       # @return [Hash] Updated plugin defaults
       # @raise [Mobility::Plugin::CyclicDependency] if dependencies cannot be met
       # @example
-      #   Mobility::Plugin.configure(TranslatedAttributes) do
+      #   Mobility::Plugin.configure(Translations) do
       #     cache
       #     fallbacks [:en, :de]
       #   end

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -18,7 +18,7 @@ Then the +Foo+ plugin will be applied with the option value +true+. Applying a
 module calls a class method, +apply+ (in this case +Foo.apply+), which takes
 two arguments:
 
-- an instance of the {Attributes} class, +attributes+, from which the backend
+- an instance of the {Translations} class, +attributes+, from which the backend
   can configure the backend class (+attributes.backend_class+) and the model
   (+attributes.model_class+), and the +attributes+ module itself (which
   will be included into the backend).

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -223,7 +223,7 @@ enabled for any one attribute on the model.
               end
 
               def attribute_modules(scope)
-                scope.model.ancestors.grep(::Mobility::Attributes)
+                scope.model.ancestors.grep(::Mobility::Translations)
               end
 
               def build_predicate(node, values)

--- a/lib/mobility/plugins/attributes.rb
+++ b/lib/mobility/plugins/attributes.rb
@@ -28,7 +28,7 @@ for aggregating attributes.
       # Show useful information about this module.
       # @return [String]
       def inspect
-        "#<Attributes @names=#{names.join(", ")}>"
+        "#<#{name} @names=#{names.join(", ")}>"
       end
 
       included_hook do |klass|

--- a/lib/mobility/plugins/attributes.rb
+++ b/lib/mobility/plugins/attributes.rb
@@ -28,7 +28,7 @@ for aggregating attributes.
       # Show useful information about this module.
       # @return [String]
       def inspect
-        "#<#{name} @names=#{names.join(", ")}>"
+        "#<Translations @names=#{names.join(", ")}>"
       end
 
       included_hook do |klass|

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -74,7 +74,7 @@ Defines:
       # Include backend name in inspect string.
       # @return [String]
       def inspect
-        "#<Attributes (#{backend}) @names=#{names.join(", ")}>"
+        "#<Translations (#{backend}) @names=#{names.join(", ")}>"
       end
 
       def load_backend(backend)

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -28,7 +28,7 @@ model class is generated.
       requires :writer
 
       # Apply fallthrough accessors plugin to attributes.
-      # @param [Attributes] attributes
+      # @param [Translations] translations
       # @param [Boolean] option
       initialize_hook do
         if options[:fallthrough_accessors] && options[:reader] && options[:writer]

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -23,7 +23,7 @@ available locales for a Rails application) will be used by default.
       requires :writer
 
       # Apply locale accessors plugin to attributes.
-      # @param [Attributes] attributes
+      # @param [Translations] translations
       # @param [Boolean] option
       initialize_hook do |*names|
         if locales = options[:locale_accessors]

--- a/lib/mobility/plugins/sequel/query.rb
+++ b/lib/mobility/plugins/sequel/query.rb
@@ -135,7 +135,7 @@ See ActiveRecord::Query plugin.
             end
 
             def attribute_modules(model)
-              model.ancestors.grep(::Mobility::Attributes)
+              model.ancestors.grep(::Mobility::Translations)
             end
 
             def build_predicate(op, values)

--- a/lib/mobility/translations.rb
+++ b/lib/mobility/translations.rb
@@ -4,41 +4,51 @@ require "mobility/pluggable"
 module Mobility
 =begin
 
-Defines accessor methods to include on model class. Inspired by Traco's
-+Traco::Translations+ class.
+Module containing translation accessor methods and other methods for accessing
+translations.
 
-Normally this class will be created through class methods defined using
-{Mobility::Translates} accessor methods, and need not be created directly.
-However, the class is central to how Mobility hooks into models to add
-accessors and other methods, and should be useful as a reference when
-understanding and designing backends.
+Normally this class will be created by calling
+{Mobility::Translates#translates}, which is a class method on any model that
+extends {Mobility}, but it can also be used independent of that macro.
 
 ==Including Translations in a Class
 
 Since {Translations} is a subclass of +Module+, including an instance of it is
-like including a module. Creating an instance like this:
+like including a module. Options passed to the initializer are passed to
+plugins (if those plugins have been enabled).
 
-  Translations.new("title", backend: :my_backend, locale_accessors: [:en, :ja], cache: true, fallbacks: true)
+We can first enable plugins by subclassing `Mobility::Translations`, and
+calling +plugins+ to enable any plugins we want to use. We want reader and
+writer methods for accessing translations, so we enable those plugins:
 
-will generate an anonymous module that behaves approximately like this:
+  class Translations < Mobility::Translations
+    plugins do
+      reader
+      writer
+    end
+  end
+
+Both `reader` and `writer` depend on the `backend` plugin, so this is also enabled.
+
+Then create an instance like this:
+
+  Translations.new("title", backend: :my_backend)
+
+This will generate an anonymous module that behaves approximately like this:
 
   Module.new do
+    # From Mobility::Plugins::Backend module
+    #
     def mobility_backends
       # Returns a memoized hash with attribute name keys and backend instance
       # values.  When a key is fetched from the hash, the hash calls
       # +self.class.mobility_backend_class(name)+ (where +name+ is the
       # attribute name) to get the backend class, then instantiate it (passing
       # the model instance and attribute name to its initializer) and return it.
-      #
-      # The backend class returned from the class method
-      # +mobility_backend_class+ returns a subclass of
-      # +Mobility::Backends::MyBackend+ and includes into it:
-      #
-      # - Mobility::Plugins::Cache (from the +cache: true+ option)
-      # - instance of Mobility::Plugins::Fallbacks (from the +fallbacks: true+ option)
-      # - Mobility::Plugins::Presence (by default, disabled by +presence: false+)
     end
 
+    # From Mobility::Plugins::Reader module
+    #
     def title(locale: Mobility.locale)
       mobility_backends[:title].read(locale)
     end
@@ -47,45 +57,17 @@ will generate an anonymous module that behaves approximately like this:
       mobility_backends[:title].read(locale).present?
     end
 
+    # From Mobility::Plugins::Writer module
     def title=(value, locale: Mobility.locale)
       mobility_backends[:title].write(locale, value)
     end
-
-    # Start Locale Accessors
-    #
-    def title_en
-      title(locale: :en)
-    end
-
-    def title_en?
-      title?(locale: :en)
-    end
-
-    def title_en=(value)
-      public_send(:title=, value, locale: :en)
-    end
-
-    def title_ja
-      title(locale: :ja)
-    end
-
-    def title_ja?
-      title?(locale: :ja)
-    end
-
-    def title_ja=(value)
-      public_send(:title=, value, locale: :ja)
-    end
-    # End Locale Accessors
   end
 
-Including this module into a model class will thus add the backend method, the
-reader, writer and presence methods, and the locale accessor so the model
-class. (These methods are in fact added to the model in an +included+ hook.)
-
-Note that some simplifications have been made above for readability. (In
-reality, all getters and setters accept an options hash which is passed along
-to the backend instance.)
+Including this module into a model class will thus add the backends method and
+reader and writer methods for accessing translations. Other plugins (e.g.
+fallbacks, cache) modify the result returned by the backend, by hooking into
+the +included+ callback method on the module, see {Mobility::Plugin} for
+details.
 
 ==Setting up the Model Class
 

--- a/lib/mobility/translations.rb
+++ b/lib/mobility/translations.rb
@@ -5,7 +5,7 @@ module Mobility
 =begin
 
 Defines accessor methods to include on model class. Inspired by Traco's
-+Traco::Attributes+ class.
++Traco::Translations+ class.
 
 Normally this class will be created through class methods defined using
 {Mobility::Translates} accessor methods, and need not be created directly.
@@ -13,12 +13,12 @@ However, the class is central to how Mobility hooks into models to add
 accessors and other methods, and should be useful as a reference when
 understanding and designing backends.
 
-==Including Attributes in a Class
+==Including Translations in a Class
 
-Since {Attributes} is a subclass of +Module+, including an instance of it is
+Since {Translations} is a subclass of +Module+, including an instance of it is
 like including a module. Creating an instance like this:
 
-  Attributes.new("title", backend: :my_backend, locale_accessors: [:en, :ja], cache: true, fallbacks: true)
+  Translations.new("title", backend: :my_backend, locale_accessors: [:en, :ja], cache: true, fallbacks: true)
 
 will generate an anonymous module that behaves approximately like this:
 
@@ -94,7 +94,7 @@ model class. This hook is provided by the {Backend::Setup#setup_model} method,
 which is added to every backend class when it includes the {Backend} module.
 
 Assuming the backend has defined a setup block by calling +setup+, this block
-will be called when {Attributes} is {#included} in the model class, passed
+will be called when {Translations} is {#included} in the model class, passed
 attributes and options defined when the backend was defined on the model class.
 This allows a backend to do things like (for example) define associations on a
 model class required by the backend, as happens in the {Backends::KeyValue} and
@@ -107,7 +107,7 @@ necessary, ensure that names are defined in such a way as to avoid conflicts
 with other backends.
 
 =end
-  class Attributes < Pluggable
+  class Translations < Pluggable
     include ::Mobility::Plugins.load_plugin(:attributes)
   end
 end

--- a/spec/mobility/plugins/active_model/cache_spec.rb
+++ b/spec/mobility/plugins/active_model/cache_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
-describe "Mobility::Plugins::ActiveModel::Cache", orm: :active_record, type: :plugin do
+return unless defined?(ActiveModel)
+
+require "mobility/plugins/active_model/cache"
+
+describe Mobility::Plugins::ActiveModel::Cache, orm: :active_record, type: :plugin do
   plugins :active_model, :cache
   plugin_setup :title
 

--- a/spec/mobility/plugins/active_record/backend_spec.rb
+++ b/spec/mobility/plugins/active_record/backend_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
-describe "Mobility::Plugins::ActiveRecord::Backend", orm: :active_record, type: :plugin do
-  require "mobility/plugins/active_record/backend"
+require "mobility/plugins/active_record/backend"
 
+describe Mobility::Plugins::ActiveRecord::Backend, orm: :active_record, type: :plugin do
   plugins :active_record_backend
   plugin_setup
 

--- a/spec/mobility/plugins/active_record/cache_spec.rb
+++ b/spec/mobility/plugins/active_record/cache_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
-describe "Mobility::Plugins::ActiveRecord::Cache", orm: :active_record, type: :plugin do
+return unless defined?(ActiveRecord)
+
+require "mobility/plugins/active_record/cache"
+
+describe Mobility::Plugins::ActiveRecord::Cache, orm: :active_record, type: :plugin do
   plugins :active_record, :cache
   plugin_setup :title
 

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -2,7 +2,9 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
-describe "Mobility::Plugins::ActiveRecord::Dirty", orm: :active_record, type: :plugin do
+require "mobility/plugins/active_record/dirty"
+
+describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plugin do
   plugins do
     dirty true
     active_record

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -2,15 +2,15 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
+require "mobility/plugins/active_record/query"
+
 # @note Although this plugin should probably really be tested against an
 #   abstract backend with +build_node+ and +apply_scope+ defined and tested,
 #   doing so would be quite involved, so instead this spec tests against a
 #   complex combination of existing backends, which is less precise but should
 #   be sufficient at this stage.
 #
-describe "Mobility::Plugins::ActiveRecord::Query", orm: :active_record, type: :plugin do
-  require "mobility/plugins/active_record/query"
-
+describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plugin do
   plugins :active_record, :writer, :query
   plugin_setup
 

--- a/spec/mobility/plugins/active_record_spec.rb
+++ b/spec/mobility/plugins/active_record_spec.rb
@@ -2,7 +2,9 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
-describe "Mobility::Plugins::ActiveRecord", orm: :active_record, type: :plugin do
+require "mobility/plugins/active_record"
+
+describe Mobility::Plugins::ActiveRecord, orm: :active_record, type: :plugin do
   plugins :active_record
 
   it "raises TypeError unless class is a subclass of ActiveRecord::Base" do

--- a/spec/mobility/plugins/attribute_methods_spec.rb
+++ b/spec/mobility/plugins/attribute_methods_spec.rb
@@ -2,7 +2,9 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
-describe "Mobility::Plugins::AttributeMethods", orm: :active_record, type: :plugin do
+require "mobility/plugins/attribute_methods"
+
+describe Mobility::Plugins::AttributeMethods, orm: :active_record, type: :plugin do
   plugins :active_record, :attribute_methods, :reader
 
   plugin_setup :title

--- a/spec/mobility/plugins/attributes_spec.rb
+++ b/spec/mobility/plugins/attributes_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+require "mobility/plugins/attributes"
+
+describe Mobility::Plugins::Attributes, type: :plugin do
+  let(:translations_class) do
+    Class.new(Mobility::Pluggable).tap do |translations_class|
+      translations_class.plugin :attributes
+    end
+  end
+
+  describe "#names" do
+    it "returns arguments passed to initialize" do
+      translations = translations_class.new("title", "content")
+      expect(translations.names).to eq(["title", "content"])
+    end
+  end
+
+  describe "#inspect" do
+    it "includes backend name and attribute names" do
+      translations = translations_class.new("title", "content")
+      expect(translations.inspect).to eq("#<Translations @names=title, content>")
+    end
+  end
+
+  describe ".mobility_attribute?" do
+    it "returns true if name is an attribute" do
+      translations = translations_class.new("title", "content")
+      klass = Class.new
+      klass.include translations
+
+      expect(klass.mobility_attribute?("title")).to eq(true)
+      expect(klass.mobility_attribute?("content")).to eq(true)
+      expect(klass.mobility_attribute?("foo")).to eq(false)
+    end
+
+    it "returns true if name is included one of multiple pluggable modules" do
+      translations1 = translations_class.new("title", "content")
+      translations2 = translations_class.new("author")
+      klass = Class.new
+      klass.include translations1
+      klass.include translations2
+
+      expect(klass.mobility_attribute?("title")).to eq(true)
+      expect(klass.mobility_attribute?("content")).to eq(true)
+      expect(klass.mobility_attribute?("author")).to eq(true)
+      expect(klass.mobility_attribute?("foo")).to eq(false)
+    end
+  end
+end

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "mobility/plugins/backend"
 require "mobility/plugins/writer"
 
 describe Mobility::Plugins::Backend, type: :plugin do

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -174,7 +174,7 @@ describe Mobility::Plugins::Backend, type: :plugin do
   describe "#inspect" do
     it "includes backend name and attribute names" do
       translations = translations_class.new("title", "content", backend: :null)
-      expect(translations.inspect).to eq("#<Attributes (null) @names=title, content>")
+      expect(translations.inspect).to eq("#<Translations (null) @names=title, content>")
     end
   end
 
@@ -191,7 +191,7 @@ describe Mobility::Plugins::Backend, type: :plugin do
       end
 
       it "shows backend name in inspect string" do
-        expect(translations_class.new("title").inspect).to eq("#<Attributes (foo) @names=title>")
+        expect(translations_class.new("title").inspect).to eq("#<Translations (foo) @names=title>")
       end
 
       it "calls setup_model on backend" do

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -128,7 +128,7 @@ describe Mobility::Plugins::Fallbacks, type: :plugin do
 
   # We've taken away the ability to customize the fallbacks generator from
   # configuration, but it is still possible by overriding a private method on
-  # the Attributes class.
+  # the Translations class.
   describe "overriding fallbacks generator" do
     plugins do
       fallbacks

--- a/spec/mobility/plugins/sequel/backend_spec.rb
+++ b/spec/mobility/plugins/sequel/backend_spec.rb
@@ -2,8 +2,9 @@ require "spec_helper"
 
 return unless defined?(Sequel)
 
-describe "Mobility::Plugins::Sequel::Backend", orm: :sequel, type: :plugin do
-  require "mobility/plugins/sequel/backend"
+require "mobility/plugins/sequel/backend"
+
+describe Mobility::Plugins::Sequel::Backend, orm: :sequel, type: :plugin do
   plugins :sequel_backend
   plugin_setup
 

--- a/spec/mobility/plugins/sequel/cache_spec.rb
+++ b/spec/mobility/plugins/sequel/cache_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
-describe "Mobility::Plugins::Sequel::Cache", orm: :sequel, type: :plugin do
+return unless defined?(Sequel)
+
+require "mobility/plugins/sequel/cache"
+
+describe Mobility::Plugins::Sequel::Cache, orm: :sequel, type: :plugin do
   plugins :sequel, :cache
   plugin_setup :title
 

--- a/spec/mobility/plugins/sequel/dirty_spec.rb
+++ b/spec/mobility/plugins/sequel/dirty_spec.rb
@@ -2,7 +2,9 @@ require "spec_helper"
 
 return unless defined?(Sequel)
 
-describe "Mobility::Plugins::Sequel::Dirty", orm: :sequel, type: :plugin do
+require "mobility/plugins/sequel/dirty"
+
+describe Mobility::Plugins::Sequel::Dirty, orm: :sequel, type: :plugin do
   plugins do
     dirty true
     sequel

--- a/spec/mobility/plugins/sequel_spec.rb
+++ b/spec/mobility/plugins/sequel_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
-describe "Mobility::Plugins::Sequel", orm: :sequel, type: :plugin do
+return unless defined?(Sequel)
+
+describe Mobility::Plugins::Sequel, orm: :sequel, type: :plugin do
   plugins do
     sequel
   end

--- a/spec/mobility/translations_spec.rb
+++ b/spec/mobility/translations_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 
-describe Mobility::Attributes, orm: 'none' do
+describe Mobility::Translations, orm: 'none' do
   include Helpers::Backend
   before { stub_const 'Article', Class.new }
 
   # In order to be able to stub methods on backend instance methods, which will be
-  # hidden when the backend class is subclassed in Attributes, we inject a double
+  # hidden when the backend class is subclassed in Translations, we inject a double
   # and delegate read and write to the double. (Nice trick, eh?)
   #
   let(:listener) { double("backend") }
@@ -17,7 +17,7 @@ describe Mobility::Attributes, orm: 'none' do
   # for many specs in this suite.
   let(:clean_options) { { cache: false, fallbacks: false } }
 
-  describe "including Attributes in a model" do
+  describe "including Translations in a model" do
     describe "model class methods" do
       describe ".mobility_attributes" do
         it "returns attribute names" do
@@ -59,7 +59,7 @@ describe Mobility::Attributes, orm: 'none' do
   describe "#inspect" do
     it "returns attribute names" do
       attributes = described_class.new("title", "content")
-      expect(attributes.inspect).to eq("#<Attributes @names=title, content>")
+      expect(attributes.inspect).to eq("#<Translations @names=title, content>")
     end
   end
 end

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -18,7 +18,7 @@ describe Mobility, orm: 'none' do
 
     context "with translated attributes" do
       it "includes backend module into model class" do
-        expect(described_class::Attributes).to receive(:new).
+        expect(described_class::Translations).to receive(:new).
           with(:title, reader: true, writer: true, backend: :null, foo: :bar).
           and_call_original
         model.extend described_class

--- a/spec/performance/translations_spec.rb
+++ b/spec/performance/translations_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Mobility::Attributes, orm: 'none' do
+describe Mobility::Translations, orm: 'none' do
   describe "initializing" do
     specify {
       expect { described_class.new(backend: :null) }.to allocate_under(25).objects

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -85,7 +85,7 @@ module Helpers
           end
         end
         let(:translations_class) do
-          Class.new(Mobility::Attributes).tap do |attrs|
+          Class.new(Mobility::Translations).tap do |attrs|
             attrs.plugins(&plugins_block)
           end
         end

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -1,5 +1,5 @@
 shared_examples_for "AR Model with translated scope" do |model_class_name, a1=:title, a2=:content|
-  let(:backend) { model_class.ancestors.grep(Mobility::Attributes).first.backend }
+  let(:backend) { model_class.ancestors.grep(Mobility::Translations).first.backend }
   let(:model_class) { model_class_name.constantize }
   let(:query_scope) { model_class.i18n }
   let(:ordered_results) { query_scope.order("#{model_class.table_name}.id asc") }
@@ -630,7 +630,7 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
   let(:model_class) { constantize(model_class_name) }
   let(:table_name) { model_class.table_name }
   let(:query_scope) { model_class.i18n }
-  let(:backend) { model_class.ancestors.grep(Mobility::Attributes).first.backend }
+  let(:backend) { model_class.ancestors.grep(Mobility::Translations).first.backend }
 
   describe ".where" do
     context "querying on one translated attribute" do


### PR DESCRIPTION
`Mobility::Attributes` is really central to Mobility, but it's confusing since it doesn't even mention anything about translation. I think naming it `Mobility::Translations` is clearer.