### PR TITLE
Default fallbacks plugin to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mobility Changelog
 
 ## 1.0.0.alpha (unreleased)
+- Default fallbacks plugin to `true` when enabled
+  ([#447](https://github.com/shioyama/mobility/pull/447))
 - Remove `Mobility::Backend.method_name`
   ([#400](https://github.com/shioyama/mobility/pull/400))
 - Remove `translated_attribute_names` as alias for `mobility_attributes`

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -112,6 +112,7 @@ the current locale was +nil+.
     module Fallbacks
       extend Plugin
 
+      default true
       requires :backend, include: :before
 
       # Applies fallbacks plugin to attributes. Completely disables fallbacks

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -75,9 +75,9 @@ describe Mobility::Plugins::Fallbacks, type: :plugin do
   end
 
   if ENV['FEATURE'] == 'i18n_fallbacks'
-    context "fallbacks is true" do
+    context "fallbacks is default" do
       plugins do
-        fallbacks true
+        fallbacks
       end
 
       it "uses default fallbacks" do
@@ -93,9 +93,9 @@ describe Mobility::Plugins::Fallbacks, type: :plugin do
     end
   end
 
-  context "fallbacks is default" do
+  context "fallbacks is nil" do
     plugins do
-      fallbacks
+      fallbacks nil
     end
 
     it "does not use fallbacks when accessor fallback option is false or nil" do
@@ -131,7 +131,7 @@ describe Mobility::Plugins::Fallbacks, type: :plugin do
   # the Attributes class.
   describe "overriding fallbacks generator" do
     plugins do
-      fallbacks true
+      fallbacks
     end
 
     before do


### PR DESCRIPTION
Currently, if you have:

```ruby
Mobility.configure do |config|
  config.plugins do
    fallbacks
  end
end
```

... the fallbakcs plugin will not actually apply unless you set `falbacks: true` or assign fallbacks to the hash key in models. This doesn't really make sense now that we're being more explicit about enabling plugins; it should be `true` by default once enabled. That's what this PR does.