### PR TITLE
Remove Mobility::Backend#apply_plugin

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -179,15 +179,6 @@ On top of this, a backend will normally:
         EOM
       end
 
-      # Called from plugins to apply custom processing for this backend.
-      # Name is the name of the plugin.
-      # @param [Symbol] name Name of plugin
-      # @return [Boolean] Whether the plugin was applied
-      # @note This is currently only called by Plugins::Cache.
-      def apply_plugin(_)
-        false
-      end
-
       # Show useful information about this backend class, if it has no name.
       # @return [String]
       def inspect

--- a/lib/mobility/backends.rb
+++ b/lib/mobility/backends.rb
@@ -5,7 +5,7 @@ module Mobility
     class << self
       # @param [Symbol, Object] backend Name of backend to load.
       def load_backend(name)
-        return name if Module === name
+        return name if Module === name || name.nil?
 
         unless (backend = @backends[name])
           require "mobility/backends/#{name}"

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -100,16 +100,9 @@ other backends on model (otherwise one will overwrite the other).
           end
         end
 
-        # Apply custom processing for plugin
-        # @param (see Backend::ClassMethods#apply_plugin)
-        # @return (see Backend::ClassMethods#apply_plugin)
-        def apply_plugin(name)
-          if name == :cache
-            include self::Cache
-            true
-          else
-            super
-          end
+        # Apply custom processing for cache plugin
+        def include_cache
+          include self::Cache
         end
 
         def table_alias(attr, locale)

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -113,16 +113,9 @@ set.
       end
 
       module ClassMethods
-        # Apply custom processing for plugin
-        # @param (see Backend::Setup#apply_plugin)
-        # @return (see Backend::Setup#apply_plugin)
-        def apply_plugin(name)
-          if name == :cache
-            include self::Cache
-            true
-          else
-            super
-          end
+        # Apply custom processing for cache plugin
+        def include_cache
+          include self::Cache
         end
 
         def table_alias(locale)

--- a/lib/mobility/plugins.rb
+++ b/lib/mobility/plugins.rb
@@ -14,6 +14,8 @@ declared in any order (dependencies will be resolved).
     class << self
       # @param [Symbol] name Name of plugin to load.
       def load_plugin(name)
+        return name if Module === name || name.nil?
+
         unless (plugin = @plugins[name])
           require "mobility/plugins/#{name}"
           raise LoadError, "plugin #{name} did not register itself correctly in Mobility::Plugins" unless (plugin = @plugins[name])

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -45,6 +45,8 @@ Defines:
           raise ArgumentError, "backend must be either a backend name, a backend class, or a two-element array"
         end
 
+        @backend = load_backend(backend)
+
         include InstanceMethods
       end
 
@@ -57,8 +59,7 @@ Defines:
         klass.extend ClassMethods
 
         if backend
-          @backend_class = load_backend(backend).
-            build_subclass(klass, backend_options)
+          @backend_class = backend.build_subclass(klass, backend_options)
 
           backend_class.setup_model(klass, names)
 

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -32,7 +32,6 @@ Defines:
 
       def initialize(*args, **original_options)
         super
-        return unless Plugins::Backend.dependencies_satisfied?(self.class)
 
         case options[:backend]
         when String, Symbol, Class

--- a/spec/mobility/backends/sequel/key_value_spec.rb
+++ b/spec/mobility/backends/sequel/key_value_spec.rb
@@ -22,7 +22,7 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
     plugins :cache
 
     backend_class_with_cache = Class.new(described_class)
-    backend_class_with_cache.apply_plugin(:cache)
+    backend_class_with_cache.include_cache
     include_backend_examples backend_class_with_cache, 'Article', type: :text
   end
 

--- a/spec/mobility/backends/sequel/table_spec.rb
+++ b/spec/mobility/backends/sequel/table_spec.rb
@@ -22,7 +22,7 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel, type: :backend do
     plugins :cache
 
     backend_class_with_cache = Class.new(described_class)
-    backend_class_with_cache.apply_plugin(:cache)
+    backend_class_with_cache.include_cache
 
     include_backend_examples backend_class_with_cache, 'Article'
   end

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -166,16 +166,16 @@ describe Mobility::Plugins::Backend, type: :plugin do
   end
 
   describe "#backend" do
-    it "returns backend name" do
+    it "returns backend superclass" do
       translations = translations_class.new("title", "content", backend: :null)
-      expect(translations.backend).to eq(:null)
+      expect(translations.backend).to eq(Mobility::Backends::Null)
     end
   end
 
   describe "#inspect" do
     it "includes backend name and attribute names" do
       translations = translations_class.new("title", "content", backend: :null)
-      expect(translations.inspect).to eq("#<Translations (null) @names=title, content>")
+      expect(translations.inspect).to eq("#<Translations (Mobility::Backends::Null) @names=title, content>")
     end
   end
 
@@ -192,7 +192,7 @@ describe Mobility::Plugins::Backend, type: :plugin do
       end
 
       it "shows backend name in inspect string" do
-        expect(translations_class.new("title").inspect).to eq("#<Translations (foo) @names=title>")
+        expect(translations_class.new("title").inspect).to eq("#<Translations (FooBackend) @names=title>")
       end
 
       it "calls setup_model on backend" do
@@ -207,7 +207,7 @@ describe Mobility::Plugins::Backend, type: :plugin do
       end
 
       it "assigns backend name correctly" do
-        expect(translations_class.new("title").backend).to eq(:foo)
+        expect(translations_class.new("title").backend).to eq(FooBackend)
       end
 
       it "passes backend options to backend" do


### PR DESCRIPTION
This method should not exist; it's only there for backends to hook into the cache plugin. Let's see if we can get rid of it.