### PR TITLE
Instance exec configure block if it takes no arguments

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -57,9 +57,13 @@ module Mobility
 
     # Configure Mobility
     # @yield [Mobility::Translations]
-    def configure
+    def configure(&block)
       translates_with(Class.new(Translations)) unless @translations_class
-      yield translations_class
+      if block.arity == 0
+        translations_class.instance_exec(&block)
+      else
+        yield translations_class
+      end
     end
     # @!endgroup
 

--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -1,7 +1,7 @@
-Mobility.configure do |config|
+Mobility.configure do
 
   # PLUGINS
-  config.plugins do
+  plugins do
     # Backend
     #
     # Sets the default backend to use in models. This can be overridden in models

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -24,7 +24,8 @@ describe Mobility::InstallGenerator, type: :generator do
         directory "config" do
           directory "initializers" do
             file "mobility.rb" do
-              contains "Mobility.configure do |config|"
+              contains "Mobility.configure do"
+              contains "plugins do"
               contains "backend :key_value"
               contains "backend_reader"
               contains "query"

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -176,6 +176,15 @@ describe Mobility, orm: :none do
         described_class.configure &block
       }.to yield_with_args(klass)
     end
+
+    it "yields in context of class if block is not passed an argument" do
+      klass = Class.new(Mobility::Translations)
+      described_class.translates_with(klass)
+      expect(klass).to receive(:plugins).once
+      described_class.configure do
+        plugins
+      end
+    end
   end
 
   describe "#translates" do


### PR DESCRIPTION
This makes configuring Mobility slightly simpler.

So while we continue supporting this format:

```ruby
Mobility.configure do |config|
  config.plugins do
    # ...
  end
end
```

we also suppport this:

```ruby
Mobility.configure do
  plugins do
    # ...
  end
end
```