### PR TITLE
Raise an exception if invalid options are passed to Translations initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([#454](https://github.com/shioyama/mobility/pull/454))
 - Instance exec configure block if it takes no arguments
   ([#456](https://github.com/shioyama/mobility/pull/456))
+- Raise an exception if invalid options are passed to Translations initializer
+  ([#457](https://github.com/shioyama/mobility/pull/457/files))
 
 ## 1.0.0.alpha (pre-release)
 

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -120,6 +120,11 @@ On top of this, a backend will normally:
 
     # Defines setup hooks for backend to customize model class.
     module ClassMethods
+      # @return [Array] Valid option keys for this backend
+      def valid_keys
+        []
+      end
+
       # Assign block to be called on model class.
       # @yield [attribute_names, options]
       # @note When called multiple times, setup blocks will be appended

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -17,6 +17,10 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
       #   @return [Symbol] (:translations) Name of translations column
       option_reader :column_name
 
+      def self.valid_keys
+        [:column_name]
+      end
+
       # @!group Backend Accessors
       #
       # @note Translation may be a string, integer, boolean, hash or array

--- a/lib/mobility/backends/active_record/serialized.rb
+++ b/lib/mobility/backends/active_record/serialized.rb
@@ -30,6 +30,10 @@ Implements {Mobility::Backends::Serialized} backend for ActiveRecord models.
       include ActiveRecord
       include HashValued
 
+      def self.valid_keys
+        super + [:format]
+      end
+
       # @!group Backend Configuration
       # @param (see Backends::Serialized.configure)
       # @option (see Backends::Serialized.configure)

--- a/lib/mobility/backends/hash_valued.rb
+++ b/lib/mobility/backends/hash_valued.rb
@@ -36,6 +36,10 @@ Defines read and write methods that access the value at a key with value
       end
 
       module ClassMethods
+        def valid_keys
+          [:column_prefix, :column_suffix]
+        end
+
         def configure(options)
           options[:column_affix] = "#{options[:column_prefix]}%s#{options[:column_suffix]}"
         end

--- a/lib/mobility/backends/jsonb.rb
+++ b/lib/mobility/backends/jsonb.rb
@@ -6,7 +6,7 @@ Stores translations as hash on Postgres jsonb column.
 
 ==Backend Options
 
-===+prefix+ and +suffix+
+===+column_prefix+ and +column_suffix+
 
 Prefix and suffix to add to attribute name to generate jsonb column name.
 

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -83,6 +83,10 @@ other backends on model (otherwise one will overwrite the other).
       end
 
       module ClassMethods
+        def valid_keys
+          [:type, :association_name, :class_name]
+        end
+
         # @!group Backend Configuration
         # @option options [Symbol,String] type Column type to use
         # @option options [Symbol] association_name (:<type>_translations) Name

--- a/lib/mobility/backends/sequel/container.rb
+++ b/lib/mobility/backends/sequel/container.rb
@@ -16,6 +16,10 @@ Implements the {Mobility::Backends::Container} backend for Sequel models.
       #   @return [Symbol] (:translations) Name of translations column
       option_reader :column_name
 
+      def self.valid_keys
+        [:column_name]
+      end
+
       # @!group Backend Accessors
       #
       # @note Translation may be a string, integer, boolean, hash or array

--- a/lib/mobility/backends/sequel/serialized.rb
+++ b/lib/mobility/backends/sequel/serialized.rb
@@ -36,6 +36,10 @@ Sequel serialization plugin.
       include Sequel
       include HashValued
 
+      def self.valid_keys
+        super + [:format]
+      end
+
       # @!group Backend Configuration
       # @param (see Backends::Serialized.configure)
       # @option (see Backends::Serialized.configure)

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -113,6 +113,10 @@ set.
       end
 
       module ClassMethods
+        def valid_keys
+          [:association_name, :subclass_name, :foreign_key, :table_name]
+        end
+
         # Apply custom processing for cache plugin
         def include_cache
           include self::Cache

--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -17,6 +17,10 @@ Works with {Mobility::Plugin}. (Subclassed by {Mobility::Translations}.)
         Plugin.configure(self, defaults, &block)
       end
 
+      def included_plugins
+        included_modules.grep(Plugin)
+      end
+
       def defaults
         @defaults ||= {}
       end

--- a/lib/mobility/pluggable.rb
+++ b/lib/mobility/pluggable.rb
@@ -32,9 +32,25 @@ Works with {Mobility::Plugin}. (Subclassed by {Mobility::Translations}.)
     end
 
     def initialize(*, **options)
-      @options = self.class.defaults.merge(options)
+      initialize_options(options)
+      validate_options(@options)
     end
 
     attr_reader :options
+
+    private
+
+    def initialize_options(options)
+      @options = self.class.defaults.merge(options)
+    end
+
+    # This is overridden by backend plugin to exclude mixed-in backend options.
+    def validate_options(options)
+      plugin_keys = self.class.included_plugins.map { |p| Plugins.lookup_name(p) }
+      extra_keys = options.keys - plugin_keys
+      raise InvalidOptionKey, "No plugin configured for these keys: #{extra_keys.join(', ')}." unless extra_keys.empty?
+    end
+
+    class InvalidOptionKey < Error; end
   end
 end

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -33,7 +33,12 @@ Defines:
       def initialize(*args, **original_options)
         super
 
-        Backend.validate_default(self.class.defaults[:backend])
+        # Validate that the default backend from config has valid keys
+        if (default = self.class.defaults[:backend])
+          name, backend_options = default
+          extra_keys = backend_options.keys - backend.valid_keys
+          raise InvalidOptionKey, "These are not valid #{name} backend keys: #{extra_keys.join(', ')}." unless extra_keys.empty?
+        end
 
         include InstanceMethods
       end
@@ -103,15 +108,6 @@ Defines:
       # with plugin name.
       def self.configure_default(defaults, key, *args, **kwargs)
         defaults[key] = [args[0], kwargs] unless args.empty?
-      end
-
-      def self.validate_default(default)
-        return unless default
-
-        name, backend_options = default
-        backend = Backends.load_backend(name)
-        extra_keys = backend_options.keys - backend.valid_keys
-        raise InvalidOptionKey, "These are not valid #{name} backend keys: #{extra_keys.join(', ')}." unless extra_keys.empty?
       end
 
       module InstanceMethods

--- a/spec/integration/active_record_compatibility_spec.rb
+++ b/spec/integration/active_record_compatibility_spec.rb
@@ -6,12 +6,12 @@ describe "ActiveRecord compatibility", orm: :active_record do
   include Helpers::Plugins
   include Helpers::Translates
   # Enable all plugins that are enabled by default pre v1.0
-  plugins :active_record, :reader, :writer, :cache, :dirty, :presence, :query, :attribute_methods
+  plugins :active_record, :reader, :writer, :cache, :dirty, :presence, :query, :attribute_methods, :fallbacks
 
   before { stub_const 'Post', Class.new(ActiveRecord::Base) }
 
   describe "#assign_attributes" do
-    before { translates Post, :title, backend: :key_value, type: :string }
+    before { translates Post, :title, backend: :key_value, type: :string, fallbacks: false }
     let!(:post) { Post.create(title: "foo title") }
 
     it "assigns translated attributes" do

--- a/spec/mobility/pluggable_spec.rb
+++ b/spec/mobility/pluggable_spec.rb
@@ -4,15 +4,24 @@ describe Mobility::Pluggable do
   include Helpers::PluginSetup
 
   describe "#initialize" do
-    define_plugins(:foo)
+    define_plugins(:foo, :other)
 
     it "merges defaults into @options when initializing" do
       klass = Class.new(described_class)
 
       klass.plugin :foo, 'bar'
+      klass.plugin :other
 
       pluggable = klass.new(other: 'param')
       expect(pluggable.options).to eq(foo: 'bar', other: 'param')
+    end
+
+    it "raises InvalidOptionKey error if no plugin is configured for an options key" do
+      klass = Class.new(described_class)
+
+      expect {
+        klass.new(foo: 'foo', bar: 'bar')
+      }.to raise_error(Mobility::Pluggable::InvalidOptionKey, "No plugin configured for these keys: foo, bar.")
     end
   end
 

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -169,9 +169,7 @@ describe Mobility::Plugins::Backend, type: :plugin do
       klass.plugin :backend, backend_class
       klass.plugin :foo
 
-      expect {
-        klass.new(foo: 'foo', bar: 'bar')
-      }.not_to raise_error(Mobility::Pluggable::InvalidOptionKey, "No plugin configured for these keys: foo, bar.")
+      expect { klass.new(foo: 'foo', bar: 'bar') }.not_to raise_error
 
       expect {
         klass.new(foo: 'foo', other: 'other')

--- a/spec/mobility/plugins/sequel/dirty_spec.rb
+++ b/spec/mobility/plugins/sequel/dirty_spec.rb
@@ -175,7 +175,7 @@ describe Mobility::Plugins::Sequel::Dirty, orm: :sequel, type: :plugin do
       ArticleWithFallbacks.class_eval do
         dataset = DB[:articles]
       end
-      translates ArticleWithFallbacks, :title, backend: backend_class, dirty: true, cache: false, fallbacks: { en: 'ja' }
+      translates ArticleWithFallbacks, :title, backend: backend_class, dirty: true, fallbacks: { en: 'ja' }
     end
 
     it "does not compare with fallback value" do

--- a/spec/mobility/translations_spec.rb
+++ b/spec/mobility/translations_spec.rb
@@ -4,32 +4,21 @@ describe Mobility::Translations, orm: :none do
   include Helpers::Backend
   before { stub_const 'Article', Class.new }
 
-  # In order to be able to stub methods on backend instance methods, which will be
-  # hidden when the backend class is subclassed in Translations, we inject a double
-  # and delegate read and write to the double. (Nice trick, eh?)
-  #
-  let(:listener) { double("backend") }
-  let(:backend_class) { backend_listener(listener) }
-  let(:backend) { backend_class.new }
   let(:model_class) { Article }
-
-  # These options disable all inclusion of modules into backend, which is useful
-  # for many specs in this suite.
-  let(:clean_options) { { cache: false, fallbacks: false } }
 
   describe "including Translations in a model" do
     describe "model class methods" do
       describe ".mobility_attributes" do
         it "returns attribute names" do
-          model_class.include described_class.new("title", "content", backend: backend_class)
-          model_class.include described_class.new("foo", backend: backend_class)
+          model_class.include described_class.new("title", "content")
+          model_class.include described_class.new("foo")
 
           expect(model_class.send(:mobility_attributes)).to match_array(["title", "content", "foo"])
         end
 
         it "only returns unique attributes" do
-          model_class.include described_class.new("title", backend: :null)
-          model_class.include described_class.new("title", backend: :null)
+          model_class.include described_class.new("title")
+          model_class.include described_class.new("title")
 
           expect(model_class.send(:mobility_attributes)).to eq(["title"])
         end
@@ -38,7 +27,7 @@ describe Mobility::Translations, orm: :none do
       describe ".mobility_attribute?" do
         it "returns true if and only if attribute name is translated" do
           names = %w[title content]
-          model_class.include described_class.new(*names, backend: :null)
+          model_class.include described_class.new(*names)
           names.each do |name|
             expect(model_class.mobility_attribute?(name)).to eq(true)
             expect(model_class.mobility_attribute?(name.to_sym)).to eq(true)
@@ -51,7 +40,7 @@ describe Mobility::Translations, orm: :none do
 
   describe "#each" do
     it "delegates to attributes" do
-      attributes = described_class.new("title", "content", backend: :null)
+      attributes = described_class.new("title", "content")
       expect { |b| attributes.each(&b) }.to yield_successive_args("title", "content")
     end
   end

--- a/spec/mobility_spec.rb
+++ b/spec/mobility_spec.rb
@@ -17,8 +17,14 @@ describe Mobility, orm: :none do
     end
 
     context "with translated attributes" do
+      include Helpers::PluginSetup
+      define_plugins :foo
+      plugins :foo, :backend
+
       it "includes backend module into model class" do
         klass = Class.new(described_class::Translations)
+        klass.plugin :foo
+        klass.plugin :backend
         Mobility.translates_with(klass)
         expect(klass).to receive(:new).
           with(:title, backend: :null, foo: :bar).


### PR DESCRIPTION
I've noticed that with the changes to how plugins and backends are now configured, it's very easy to forget to define a plugin and pass the plugin option, without realizing that the option is just being ignored. This could have very problematic consequences, so we should raise in this case.

This should be simple, but in fact because of the way that backend options are mixed in, it's somewhat ugly to implement. This works but could perhaps be improved.