### PR TITLE
Don't make locale and fallthrough accessors dependent on backend

### DIFF
--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -24,14 +24,11 @@ model class is generated.
 
       default true
 
-      requires :reader
-      requires :writer
-
       # Apply fallthrough accessors plugin to attributes.
       # @param [Translations] translations
       # @param [Boolean] option
       initialize_hook do
-        if options[:fallthrough_accessors] && options[:reader] && options[:writer]
+        if options[:fallthrough_accessors]
           define_fallthrough_accessors(names)
         end
       end

--- a/lib/mobility/plugins/locale_accessors.rb
+++ b/lib/mobility/plugins/locale_accessors.rb
@@ -19,9 +19,6 @@ available locales for a Rails application) will be used by default.
 
       default true
 
-      requires :reader
-      requires :writer
-
       # Apply locale accessors plugin to attributes.
       # @param [Translations] translations
       # @param [Boolean] option
@@ -30,8 +27,8 @@ available locales for a Rails application) will be used by default.
           locales = Mobility.available_locales if locales == true
           names.each do |name|
             locales.each do |locale|
-              define_locale_reader(name, locale) if options[:reader]
-              define_locale_writer(name, locale) if options[:writer]
+              define_locale_reader(name, locale)
+              define_locale_writer(name, locale)
             end
           end
         end

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -3,6 +3,16 @@ require "mobility/plugins/fallthrough_accessors"
 
 describe Mobility::Plugins::FallthroughAccessors, type: :plugin do
   plugin_setup :title
+  let(:translation_options) { {} }
+  let(:model_class) do
+    klass = Class.new do
+      def title(**); end
+      def title?(**); end
+      def title=(_, **); end
+    end
+    klass.include translations
+    klass
+  end
 
   context "option value is default" do
     plugins do

--- a/spec/mobility/plugins/locale_accessors_spec.rb
+++ b/spec/mobility/plugins/locale_accessors_spec.rb
@@ -3,12 +3,20 @@ require "mobility/plugins/locale_accessors"
 
 describe Mobility::Plugins::LocaleAccessors, type: :plugin do
   plugin_setup :title
+  let(:translation_options) { {} } # override to disable passing backend option
+  let(:model_class) do
+    klass = Class.new do
+      def title(**); end
+      def title?(**); end
+      def title=(value, **); end
+    end
+    klass.include translations
+    klass
+  end
 
   context "with option = [locales]" do
     plugins do
       locale_accessors [:cz, :de, :'pt-BR']
-      reader
-      writer
     end
 
     it_behaves_like "locale accessor", :title, :cz


### PR DESCRIPTION
It should be possible to use locale/fallthrough accessors without a backend, since they simply function to map methods to other methods. The dependency is not meaningful, so I'm removing it.