### PR TITLE
Streamline backends

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -120,7 +120,9 @@ On top of this, a backend will normally:
 
     # Defines setup hooks for backend to customize model class.
     module ClassMethods
-      # @return [Array] Valid option keys for this backend
+      # Returns valid option keys for this backend. This is overriden in
+      # backends to define which keys are valid for each backend class.
+      # @return [Array]
       def valid_keys
         []
       end

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "mobility/backends/active_record"
+require "mobility/backends/container"
 require "mobility/arel/nodes/pg_ops"
 
 module Mobility
@@ -11,15 +12,7 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
 =end
     class ActiveRecord::Container
       include ActiveRecord
-
-      # @!method column_name
-      #   Returns name of json or jsonb column used to store translations
-      #   @return [Symbol] (:translations) Name of translations column
-      option_reader :column_name
-
-      def self.valid_keys
-        [:column_name]
-      end
+      include Container
 
       # @!group Backend Accessors
       #

--- a/lib/mobility/backends/container.rb
+++ b/lib/mobility/backends/container.rb
@@ -19,8 +19,16 @@ stored).
 
 =end
     module Container
-    end
+      def self.included(backend_class)
+        backend_class.extend ClassMethods
+        backend_class.option_reader :column_name
+      end
 
-    register_backend(:container, Container)
+      module ClassMethods
+        def valid_keys
+          [:column_name]
+        end
+      end
+    end
   end
 end

--- a/lib/mobility/backends/sequel.rb
+++ b/lib/mobility/backends/sequel.rb
@@ -5,8 +5,8 @@ module Mobility
   module Backends
     module Sequel
       def self.included(backend_class)
-        backend_class.include(Backend)
-        backend_class.extend(ClassMethods)
+        backend_class.include Backend
+        backend_class.extend ClassMethods
       end
 
       module ClassMethods

--- a/lib/mobility/backends/sequel/container.rb
+++ b/lib/mobility/backends/sequel/container.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-require "mobility/backends/sequel/json"
+require "mobility/backends/sequel"
 require "mobility/backends/sequel/jsonb"
+require "mobility/backends/container"
 
 module Mobility
   module Backends
@@ -11,14 +12,7 @@ Implements the {Mobility::Backends::Container} backend for Sequel models.
 =end
     class Sequel::Container
       include Sequel
-
-      # @!method column_name
-      #   @return [Symbol] (:translations) Name of translations column
-      option_reader :column_name
-
-      def self.valid_keys
-        [:column_name]
-      end
+      include Container
 
       # @!group Backend Accessors
       #

--- a/lib/mobility/backends/sequel/json.rb
+++ b/lib/mobility/backends/sequel/json.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mobility/backends/sequel/pg_hash'
 
 Sequel.extension :pg_json, :pg_json_ops

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -104,12 +104,12 @@ set.
         model.send(association_name)
       end
 
-      def self.included(backend)
-        backend.extend ClassMethods
-        backend.option_reader :association_name
-        backend.option_reader :subclass_name
-        backend.option_reader :foreign_key
-        backend.option_reader :table_name
+      def self.included(backend_class)
+        backend_class.extend ClassMethods
+        backend_class.option_reader :association_name
+        backend_class.option_reader :subclass_name
+        backend_class.option_reader :foreign_key
+        backend_class.option_reader :table_name
       end
 
       module ClassMethods
@@ -154,7 +154,5 @@ set.
         end
       end
     end
-
-    register_backend(:table, Table)
   end
 end


### PR DESCRIPTION
A few things:
- we should not register generic backends that have ORM-specific counterparts, like "Container", because they cannot actually be used on their own
- declare valid keys for backends in the generic backend module so these keys are the same for both ORM
- other minor stuff like using same variable naming, etc