### PR TITLE
Fix Ruby 2.7.0 Deprecation Warnings

### DIFF
--- a/lib/mobility/arel.rb
+++ b/lib/mobility/arel.rb
@@ -38,7 +38,7 @@ module Mobility
       attr_reader :locale
       attr_reader :attribute_name
 
-      def initialize(relation, column_name, locale, backend_class, attribute_name: nil)
+      def initialize(relation, column_name, locale, backend_class, attribute_name = nil)
         @backend_class = backend_class
         @locale = locale
         @attribute_name = attribute_name || column_name

--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -100,7 +100,7 @@ On top of this, a backend will normally:
     # @param [Symbol] locale Locale to read
     # @return [TrueClass,FalseClass] Whether translation is present for locale
     def present?(locale, options = {})
-      Util.present?(read(locale, options))
+      Util.present?(read(locale, **options))
     end
 
     # @!method model_class

--- a/lib/mobility/backends/active_record/hstore.rb
+++ b/lib/mobility/backends/active_record/hstore.rb
@@ -18,7 +18,7 @@ Implements the {Mobility::Backends::Hstore} backend for ActiveRecord models.
 
         # @!macro backend_writer
         def write(locale, value, options = {})
-          super(locale, value && value.to_s, options)
+          super(locale, value && value.to_s, **options)
         end
         # @!endgroup
 

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -51,7 +51,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
         #   translation table value column
         def build_node(attr, locale)
           aliased_table = class_name.arel_table.alias(table_alias(attr, locale))
-          Arel::Attribute.new(aliased_table, :value, locale, self, attribute_name: attr.to_sym)
+          Arel::Attribute.new(aliased_table, :value, locale, self, attr.to_sym)
         end
 
         # Joins translations using either INNER/OUTER join appropriate to the query.

--- a/lib/mobility/backends/active_record/table.rb
+++ b/lib/mobility/backends/active_record/table.rb
@@ -283,7 +283,7 @@ columns to that table.
 
       # Returns translation for a given locale, or builds one if none is present.
       # @param [Symbol] locale
-      def translation_for(locale, _)
+      def translation_for(locale, **)
         translation = translations.in_locale(locale)
         translation ||= translations.build(locale: locale)
         translation

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -54,13 +54,13 @@ other backends on model (otherwise one will overwrite the other).
 
       # @!group Backend Accessors
       # @!macro backend_reader
-      def read(locale, options = {})
-        translation_for(locale, options).value
+      def read(locale, **options)
+        translation_for(locale, **options).value
       end
 
       # @!macro backend_writer
-      def write(locale, value, options = {})
-        translation_for(locale, options).value = value
+      def write(locale, value, **options)
+        translation_for(locale, **options).value = value
       end
       # @!endgroup
 
@@ -120,7 +120,7 @@ other backends on model (otherwise one will overwrite the other).
           if cache.has_key?(locale)
             cache[locale]
           else
-            cache[locale] = super(locale, options)
+            cache[locale] = super(locale, **options)
           end
         end
 

--- a/lib/mobility/backends/sequel/hstore.rb
+++ b/lib/mobility/backends/sequel/hstore.rb
@@ -20,7 +20,7 @@ Implements the {Mobility::Backends::Hstore} backend for Sequel models.
         # @!group Backend Accessors
         # @!macro backend_writer
         def write(locale, value, options = {})
-          super(locale, value && value.to_s, options)
+          super(locale, value && value.to_s, **options)
         end
         # @!endgroup
 

--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -83,13 +83,13 @@ set.
 
       # @!group Backend Accessors
       # @!macro backend_reader
-      def read(locale, options = {})
-        translation_for(locale, options).send(attribute)
+      def read(locale, **options)
+        translation_for(locale, **options).send(attribute)
       end
 
       # @!macro backend_writer
-      def write(locale, value, options = {})
-        translation_for(locale, options).send("#{attribute}=", value)
+      def write(locale, value, **options)
+        translation_for(locale, **options).send("#{attribute}=", value)
       end
       # @!endgroup
 
@@ -135,7 +135,7 @@ set.
           if cache.has_key?(locale)
             cache[locale]
           else
-            cache[locale] = super(locale, options)
+            cache[locale] = super(locale, **options)
           end
         end
 

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -79,8 +79,8 @@ the ActiveRecord dirty plugin for more information.
         def define_dirty_methods(attribute_names)
           attribute_names.each do |name|
             dirty_handler_methods.each_pattern(name) do |method_name, attribute_method|
-              define_method(method_name) do |*args, **kwargs|
-                mutations_from_mobility.send(attribute_method, Dirty.append_locale(name), *args, **kwargs)
+              define_method(method_name) do |*args|
+                mutations_from_mobility.send(attribute_method, Dirty.append_locale(name), *args)
               end
             end
 
@@ -131,12 +131,12 @@ the ActiveRecord dirty plugin for more information.
               method_name = pattern % 'attribute'
 
               module_eval <<-EOM, __FILE__, __LINE__ + 1
-              def #{method_name}(attr_name, *rest, **kwargs)
+              def #{method_name}(attr_name, *rest)
                 if (mutations_from_mobility.attribute_changed?(attr_name) ||
                     mutations_from_mobility.attribute_previously_changed?(attr_name))
-                  mutations_from_mobility.send(#{method_name.inspect}, attr_name, *rest, **kwargs)
+                  mutations_from_mobility.send(#{method_name.inspect}, attr_name, *rest)
                 else
-                  super
+                  super(attr_name, *rest)
                 end
               end
               EOM

--- a/lib/mobility/plugins/active_record/uniqueness_validation.rb
+++ b/lib/mobility/plugins/active_record/uniqueness_validation.rb
@@ -35,7 +35,7 @@ module Mobility
                 error_options = options.except(:case_sensitive, :scope, :conditions)
                 error_options[:value] = value
 
-                record.errors.add(attribute, :taken, error_options)
+                record.errors.add(attribute, :taken, **error_options)
               end
             else
               super

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -106,8 +106,8 @@ Defines:
 
       # Override default argument-handling in DSL to store kwargs passed along
       # with plugin name.
-      def self.configure_default(defaults, key, *args, **kwargs)
-        defaults[key] = [args[0], kwargs] unless args.empty?
+      def self.configure_default(defaults, key, backend = nil, backend_options = {})
+        defaults[key] = [backend, backend_options] if backend
       end
 
       module InstanceMethods

--- a/lib/mobility/plugins/cache.rb
+++ b/lib/mobility/plugins/cache.rb
@@ -62,11 +62,11 @@ Values are added to the cache in two ways:
         # @!method read(locale, value, options = {})
         #   @option options [Boolean] cache *false* to disable cache.
         def read(locale, **options)
-          return super(locale, options) if options.delete(:cache) == false
+          return super(locale, **options) if options.delete(:cache) == false
           if cache.has_key?(locale)
             cache[locale]
           else
-            cache[locale] = super(locale, options)
+            cache[locale] = super(locale, **options)
           end
         end
 

--- a/lib/mobility/plugins/default.rb
+++ b/lib/mobility/plugins/default.rb
@@ -90,7 +90,7 @@ The proc can accept zero to three arguments (see examples below)
         #   *false* to disable presence filter.
         def read(locale, accessor_options = {})
           default = accessor_options.has_key?(:default) ? accessor_options.delete(:default) : options[:default]
-          if (value = super(locale, accessor_options)).nil?
+          if (value = super(locale, **accessor_options)).nil?
             Default[default, locale: locale, accessor_options: accessor_options, model: model, attribute: attribute]
           else
             value

--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -47,7 +47,7 @@ the current locale was +nil+.
   Mobility.locale = :ja
   post.title
   #=> "foo"
- 
+
   post.title = "bar"
   post.title
   #=> "bar"
@@ -144,15 +144,15 @@ the current locale was +nil+.
 
         def define_read(fallbacks)
           define_method :read do |locale, fallback: true, **options|
-            return super(locale, options) if !fallback || options[:locale]
+            return super(locale, **options) if !fallback || options[:locale]
 
             locales = fallback == true ? fallbacks[locale] : [locale, *fallback]
             locales.each do |fallback_locale|
-              value = super(fallback_locale, options)
+              value = super(fallback_locale, **options)
               return value if Util.present?(value)
             end
 
-            super(locale, options)
+            super(locale, **options)
           end
         end
 

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -38,18 +38,20 @@ model class is generated.
       def define_fallthrough_accessors(*names)
         method_name_regex = /\A(#{names.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
 
-        define_method :method_missing do |method_name, *args, **kwargs, &block|
+        define_method :method_missing do |method_name, *args, &block|
           if method_name =~ method_name_regex
             attribute_method = "#{$1}#{$4}"
             locale, suffix = $2.split('_')
             locale = "#{locale}-#{suffix.upcase}" if suffix
             if $4 == '=' # writer
+              kwargs = args[1].is_a?(Hash) ? args[1] : {}
               public_send(attribute_method, args[0], **kwargs, locale: locale)
             else         # reader
+              kwargs = args[0].is_a?(Hash) ? args[0] : {}
               public_send(attribute_method, **kwargs, locale: locale)
             end
           else
-            super(method_name, *args, **kwargs, &block)
+            super(method_name, *args, &block)
           end
         end
 

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -38,18 +38,18 @@ model class is generated.
       def define_fallthrough_accessors(*names)
         method_name_regex = /\A(#{names.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
 
-        define_method :method_missing do |method_name, *args, &block|
+        define_method :method_missing do |method_name, *args, **kwargs, &block|
           if method_name =~ method_name_regex
             attribute_method = "#{$1}#{$4}"
             locale, suffix = $2.split('_')
             locale = "#{locale}-#{suffix.upcase}" if suffix
             if $4 == '=' # writer
-              public_send(attribute_method, args[0], **(args[1] || {}), locale: locale)
+              public_send(attribute_method, args[0], **kwargs, locale: locale)
             else         # reader
-              public_send(attribute_method, **(args[0] || {}), locale: locale)
+              public_send(attribute_method, **kwargs, locale: locale)
             end
           else
-            super(method_name, *args, &block)
+            super(method_name, *args, **kwargs, &block)
           end
         end
 

--- a/lib/mobility/plugins/presence.rb
+++ b/lib/mobility/plugins/presence.rb
@@ -39,7 +39,7 @@ backend.
           if options.delete(:presence) == false
             super
           else
-            super(locale, Presence[value], options)
+            super(locale, Presence[value], **options)
           end
         end
         # @!endgroup

--- a/lib/mobility/plugins/reader.rb
+++ b/lib/mobility/plugins/reader.rb
@@ -19,13 +19,13 @@ Defines attribute reader that delegates to +Mobility::Backend#read+.
             class_eval <<-EOM, __FILE__, __LINE__ + 1
               def #{name}(locale: nil, **options)
                 #{Reader.setup_source}
-                mobility_backends[:#{name}].read(locale, options)
+                mobility_backends[:#{name}].read(locale, **options)
               end
             EOM
             class_eval <<-EOM, __FILE__, __LINE__ + 1
               def #{name}?(locale: nil, **options)
                 #{Reader.setup_source}
-                mobility_backends[:#{name}].present?(locale, options)
+                mobility_backends[:#{name}].present?(locale, **options)
               end
             EOM
           end

--- a/lib/mobility/plugins/sequel/dirty.rb
+++ b/lib/mobility/plugins/sequel/dirty.rb
@@ -56,7 +56,7 @@ Automatically includes dirty plugin in model class when enabled.
             if model.column_changes.has_key?(locale_accessor) && model.initial_values[locale_accessor] == value
               super
               [model.changed_columns, model.initial_values].each { |h| h.delete(locale_accessor) }
-            elsif read(locale, options.merge(fallback: false)) != value
+            elsif read(locale, **options.merge(fallback: false)) != value
               model.will_change_column(locale_accessor)
               super
             end

--- a/lib/mobility/plugins/writer.rb
+++ b/lib/mobility/plugins/writer.rb
@@ -19,7 +19,7 @@ Defines attribute writer that delegates to +Mobility::Backend#write+.
             class_eval <<-EOM, __FILE__, __LINE__ + 1
               def #{name}=(value, locale: nil, **options)
                 #{Writer.setup_source}
-                mobility_backends[:#{name}].write(locale, value, options)
+                mobility_backends[:#{name}].write(locale, value, **options)
               end
             EOM
           end

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -240,6 +240,8 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
 
       aggregate_failures "changed after save" do
         expect(instance.title_changed?).to eq(true)
+        expect(instance.title_changed?(from: 'foo', to: 'bar')).to eq(true)
+        expect(instance.title_changed?(from: 'foo', to: 'baz')).to eq(false)
         expect(instance.title_change).to eq(["foo", "bar"])
         expect(instance.title_was).to eq("foo")
 

--- a/spec/mobility/plugins/attribute_methods_spec.rb
+++ b/spec/mobility/plugins/attribute_methods_spec.rb
@@ -26,14 +26,14 @@ describe Mobility::Plugins::AttributeMethods, orm: :active_record, type: :plugin
 
   describe "#translated_attributes" do
     it "returns hash of translated attribute names/values" do
-      expect(backend).to receive(:read).once.with(Mobility.locale, {}).and_return('foo')
+      expect(backend).to receive(:read).once.with(Mobility.locale, any_args).and_return('foo')
       expect(instance.translated_attributes).to eq('title' => 'foo')
     end
   end
 
   describe "#attributes" do
     it "adds translated attributes to normal attributes" do
-      expect(backend).to receive(:read).once.with(Mobility.locale, {}).and_return('foo')
+      expect(backend).to receive(:read).once.with(Mobility.locale, any_args).and_return('foo')
       expect(instance.attributes).to eq(untranslated_attributes.merge('title' => 'foo'))
     end
   end

--- a/spec/mobility/plugins/cache_spec.rb
+++ b/spec/mobility/plugins/cache_spec.rb
@@ -13,18 +13,18 @@ describe Mobility::Plugins::Cache, type: :plugin do
     describe "#read" do
       it "caches reads" do
         expect(listener).to receive(:read).once.with(locale, options).and_return("foo")
-        2.times { expect(backend.read(locale, options)).to eq("foo") }
+        2.times { expect(backend.read(locale, **options)).to eq("foo") }
       end
 
       it "does not cache reads with cache: false option" do
         expect(listener).to receive(:read).twice.with(locale, options).and_return("foo")
-        2.times { expect(backend.read(locale, options.merge(cache: false))).to eq("foo") }
+        2.times { expect(backend.read(locale, **options.merge(cache: false))).to eq("foo") }
       end
 
       it "does not modify options passed in" do
         allow(listener).to receive(:read).with(locale, any_args).and_return("foo")
         options = { cache: false }
-        backend.read(locale, options)
+        backend.read(locale, **options)
         expect(options).to eq({ cache: false })
       end
     end
@@ -32,27 +32,27 @@ describe Mobility::Plugins::Cache, type: :plugin do
     describe "#write" do
       it "returns value fetched from backend" do
         expect(listener).to receive(:write).twice.with(locale, "foo", options).and_return("bar")
-        2.times { expect(backend.write(locale, "foo", options)).to eq("bar") }
+        2.times { expect(backend.write(locale, "foo", **options)).to eq("bar") }
       end
 
       it "stores value fetched from backend in cache" do
         expect(listener).to receive(:write).once.with(locale, "foo", options).and_return("bar")
-        expect(backend.write(locale, "foo", options)).to eq("bar")
+        expect(backend.write(locale, "foo", **options)).to eq("bar")
         expect(listener).not_to receive(:read)
-        expect(backend.read(locale, options)).to eq("bar")
+        expect(backend.read(locale, **options)).to eq("bar")
       end
 
       it "does not store value in cache with cache: false option" do
         allow(listener).to receive(:write).once.with(locale, "foo", options).and_return("bar")
-        expect(backend.write(locale, "foo", options.merge(cache: false))).to eq("bar")
+        expect(backend.write(locale, "foo", **options.merge(cache: false))).to eq("bar")
         expect(listener).to receive(:read).with(locale, options).and_return("baz")
-        expect(backend.read(locale, options)).to eq("baz")
+        expect(backend.read(locale, **options)).to eq("baz")
       end
 
       it "does not modify options passed in" do
         allow(listener).to receive(:write).with(locale, "foo", any_args)
         options = { cache: false }
-        backend.write(locale, "foo", options)
+        backend.write(locale, "foo", **options)
         expect(options).to eq({ cache: false })
       end
     end

--- a/spec/mobility/plugins/fallbacks_spec.rb
+++ b/spec/mobility/plugins/fallbacks_spec.rb
@@ -69,7 +69,7 @@ describe Mobility::Plugins::Fallbacks, type: :plugin do
     it "does not modify options passed in" do
       options = { fallback: false }
       allow(listener).to receive(:read).once
-      backend.read(:'en-US', options)
+      backend.read(:'en-US', **options)
       expect(options).to eq({ fallback: false })
     end
   end

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -26,8 +26,8 @@ describe Mobility::Plugins::FallthroughAccessors, type: :plugin do
 
     it 'passes arguments and options to super when method does not match' do
       mod = Module.new do
-        def method_missing(method_name, *_args, **options, &block)
-          (method_name == :foo) ? options : super
+        def method_missing(method_name, *args, &block)
+          (method_name == :foo) ? args : super
         end
       end
 
@@ -37,7 +37,7 @@ describe Mobility::Plugins::FallthroughAccessors, type: :plugin do
       instance = model_class.new
 
       options = { some: 'params' }
-      expect(instance.foo(**options)).to eq(options)
+      expect(instance.foo(**options)).to eq([options])
     end
 
     it 'does not pass on empty keyword options hash to super' do

--- a/spec/mobility/plugins/presence_spec.rb
+++ b/spec/mobility/plugins/presence_spec.rb
@@ -36,7 +36,7 @@ describe Mobility::Plugins::Presence, type: :plugin do
       it "does not modify options passed in" do
         options = { presence: false }
         expect(listener).to receive(:read).once.with(:fr, any_args).and_return("")
-        backend.read(:fr, options)
+        backend.read(:fr, **options)
         expect(options).to eq({ presence: false })
       end
     end
@@ -70,7 +70,7 @@ describe Mobility::Plugins::Presence, type: :plugin do
       it "does not modify options passed in" do
         options = { presence: false }
         expect(listener).to receive(:write).once.with(:fr, "foo", any_args)
-        backend.write(:fr, "foo", options)
+        backend.write(:fr, "foo", **options)
         expect(options).to eq({ presence: false })
       end
     end

--- a/spec/performance/translations_spec.rb
+++ b/spec/performance/translations_spec.rb
@@ -1,29 +1,36 @@
 require "spec_helper"
 
-describe Mobility::Translations, orm: 'none' do
+describe Mobility::Translations, orm: :none do
+  let!(:translations_class) do
+    klass = Class.new(Mobility::Translations)
+    klass.plugins do
+      backend
+      reader
+      writer
+    end
+    klass
+  end
+
   describe "initializing" do
     specify {
-      expect { described_class.new(backend: :null) }.to allocate_under(25).objects
+      expect { translations_class.new(backend: :null) }.to allocate_under(60).objects
     }
   end
 
   describe "including into a class" do
     specify {
-      klass = Class.new do
-        extend Mobility
-      end
       expect {
-        klass.include(described_class.new(backend: :null))
+        klass = Class.new
+        klass.include(translations_class.new(backend: :null))
       }.to allocate_under(170).objects
     }
   end
 
   describe "accessors" do
     let(:klass) do
-      Class.new do
-        include Mobility
-        translates :title, backend: :null
-      end
+      klass = Class.new
+      klass.include(translations_class.new(:title, backend: :null))
+      klass
     end
 
     describe "calling attribute getter" do

--- a/spec/support/shared_examples/accessor_examples.rb
+++ b/spec/support/shared_examples/accessor_examples.rb
@@ -36,10 +36,10 @@ shared_examples_for "model with translated attribute accessors" do |model_class_
       Mobility.with_locale(:ja) do
         expect(instance.public_send(attribute1)).to eq("あああ")
         expect(instance.public_send(attribute2)).to eq(nil)
-        expect(instance.public_send(attribute1, { locale: :en })).to eq("foo")
-        expect(instance.public_send(attribute2, { locale: :en })).to eq("bar")
+        expect(instance.public_send(attribute1, **{ locale: :en })).to eq("foo")
+        expect(instance.public_send(attribute2, **{ locale: :en })).to eq("bar")
       end
-      expect(instance.public_send(attribute1, { locale: :ja })).to eq("あああ")
+      expect(instance.public_send(attribute1, **{ locale: :ja })).to eq("あああ")
     end
 
     instance.save

--- a/spec/support/shared_examples/locale_accessor_examples.rb
+++ b/spec/support/shared_examples/locale_accessor_examples.rb
@@ -7,17 +7,17 @@ shared_examples_for "locale accessor" do |attribute, locale|
 
     aggregate_failures "getter" do
       expect(instance).to receive(attribute).with(**options, locale: locale).and_return("foo")
-      expect(instance.send(:"#{attribute}_#{normalized_locale}", options)).to eq("foo")
+      expect(instance.send(:"#{attribute}_#{normalized_locale}", **options)).to eq("foo")
     end
 
     aggregate_failures "presence" do
       expect(instance).to receive(:"#{attribute}?").with(**options, locale: locale).and_return(true)
-      expect(instance.send(:"#{attribute}_#{normalized_locale}?", options)).to eq(true)
+      expect(instance.send(:"#{attribute}_#{normalized_locale}?", **options)).to eq(true)
     end
 
     aggregate_failures "setter" do
       expect(instance).to receive(:"#{attribute}=").with("value", **options, locale: locale).and_return("value")
-      expect(instance.send(:"#{attribute}_#{normalized_locale}=", "value", options)).to eq("value")
+      expect(instance.send(:"#{attribute}_#{normalized_locale}=", "value", **options)).to eq("value")
     end
   end
 end

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -393,7 +393,7 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, a1=:t
 
   describe "Arel queries" do
     # Shortcut for passing block to e.g. Post.i18n
-    def query(*args, &block); model_class.i18n(*args, &block); end
+    def query(*args, **kwargs, &block); model_class.i18n(*args, **kwargs, &block); end
 
     context "single-block querying" do
       let!(:i) { [


### PR DESCRIPTION
Replaces #357. This is an attempt to get rid of deprecation warnings on 1.0. Original PR by @f1sherman, syncing it up with changes since that PR.