### PR TITLE
Refactor attributes & backend plugins

### DIFF
--- a/lib/mobility/plugins/attributes.rb
+++ b/lib/mobility/plugins/attributes.rb
@@ -55,8 +55,6 @@ for aggregating attributes.
           mobility_attributes.each { |name| klass.register_mobility_attribute(name) }
         end
 
-        protected
-
         # Return translated attribute names on this model.
         # @return [Array<String>] Attribute names
         def mobility_attributes

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -56,8 +56,11 @@ Defines:
 
           backend_class.setup_model(klass, names)
 
-          @names.each do |name|
-            klass.register_mobility_backend_class(name, @backend_class)
+          names = @names
+          backend_class = @backend_class
+
+          klass.class_eval do
+            names.each { |name| mobility_backend_classes[name.to_sym] = backend_class }
           end
 
           backend_class
@@ -137,12 +140,9 @@ Defines:
           raise KeyError, "No backend for: #{name}"
         end
 
-        def register_mobility_backend_class(name, backend_class)
-          mobility_backend_classes[name.to_sym] = backend_class
-        end
-
         def inherited(klass)
-          klass.mobility_backend_classes.merge!(@mobility_backend_classes)
+          parent_classes = mobility_backend_classes.freeze # ensure backend classes are not modified after being inherited
+          klass.class_eval { @mobility_backend_classes = parent_classes.dup }
           super
         end
 

--- a/spec/mobility/plugins/attributes_spec.rb
+++ b/spec/mobility/plugins/attributes_spec.rb
@@ -22,6 +22,18 @@ describe Mobility::Plugins::Attributes, type: :plugin do
     end
   end
 
+  describe ".mobility_attributes" do
+    it "returns attributes included in one of multiple pluggable modules" do
+      translations1 = translations_class.new("title", "content")
+      translations2 = translations_class.new("author")
+      klass = Class.new
+      klass.include translations1
+      klass.include translations2
+
+      expect(klass.mobility_attributes).to eq(%w[title content author])
+    end
+  end
+
   describe ".mobility_attribute?" do
     it "returns true if name is an attribute" do
       translations = translations_class.new("title", "content")
@@ -44,6 +56,41 @@ describe Mobility::Plugins::Attributes, type: :plugin do
       expect(klass.mobility_attribute?("content")).to eq(true)
       expect(klass.mobility_attribute?("author")).to eq(true)
       expect(klass.mobility_attribute?("foo")).to eq(false)
+    end
+  end
+
+  describe "inheritance" do
+    it "inherits mobility attributes from parent" do
+      mod1 = translations_class.new("title", "content")
+      klass1 = Class.new
+      klass1.include mod1
+
+      klass2 = Class.new(klass1)
+
+      expect(klass1.mobility_attributes).to match_array(%w[title content])
+      expect(klass2.mobility_attributes).to match_array(%w[title content])
+
+      mod2 = translations_class.new("author")
+      klass2.include mod2
+
+      expect(klass1.mobility_attributes).to match_array(%w[title content])
+      expect(klass2.mobility_attributes).to match_array(%w[title content author])
+    end
+
+    it "freezes inherited attributes to ensure they are not changed after subclassing" do
+      mod1 = translations_class.new("title")
+      stub_const("Foo", Class.new)
+      klass1 = Foo
+      klass1.include mod1
+
+      Class.new(klass1)
+      expect(klass1.mobility_attributes).to be_frozen
+
+      mod2 = translations_class.new("content")
+      expect {
+        klass1.include mod2
+      }.to raise_error(Mobility::Plugins::Attributes::FrozenAttributesError,
+                       "Attempting to translate these attributes on Foo, which has already been subclassed: content.")
     end
   end
 end

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -100,6 +100,18 @@ describe Mobility::Plugins::Backend, type: :plugin do
         content_backend_class = model_subclass.mobility_backend_class("content")
         expect(content_backend_class).to be <(backend_class_2)
       end
+
+      it "freezes backends after subclassing" do
+        backend_class_1 = Class.new
+        backend_class_1.include Mobility::Backend
+
+        mod1 = translations_class.new("title", backend: backend_class_1)
+        model_class.include mod1
+
+        Class.new(model_class)
+
+        expect(model_class.send(:mobility_backend_classes)).to be_frozen
+      end
     end
 
     describe "#mobility_backends" do


### PR DESCRIPTION
Summary:
- make `mobility_attributes` public (see https://github.com/shioyama/mobility/pull/460#issuecomment-722445031)
- remove `register_mobility_attribute`, which was public but intended to be private (actually don't need it)
- add tests

Also, while I was add it I made a change to the backend plugin to remove `register_mobility_backend_class`, which we don't actually need either.