### PR TITLE
Remove empty lines in Rails generator templates

### DIFF
--- a/lib/rails/generators/mobility/templates/create_string_translations.rb
+++ b/lib/rails/generators/mobility/templates/create_string_translations.rb
@@ -1,5 +1,4 @@
 class CreateStringTranslations < <%= activerecord_migration_class %>
-
   def change
     create_table :mobility_string_translations do |t|
       t.string :locale, null: false

--- a/lib/rails/generators/mobility/templates/create_text_translations.rb
+++ b/lib/rails/generators/mobility/templates/create_text_translations.rb
@@ -1,5 +1,4 @@
 class CreateTextTranslations < <%= activerecord_migration_class %>
-
   def change
     create_table :mobility_text_translations do |t|
       t.string :locale, null: false

--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -1,5 +1,4 @@
 Mobility.configure do
-
   # PLUGINS
   plugins do
     # Backend


### PR DESCRIPTION
E.g. Rubocop by default would complain as `Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body beginning.`

[ci skip]