### PR TITLE
Fixes validations with validates_uniqueness_of

### DIFF
--- a/lib/mobility/plugins/active_record/uniqueness_validation.rb
+++ b/lib/mobility/plugins/active_record/uniqueness_validation.rb
@@ -10,6 +10,10 @@ module Mobility
           klass.class_eval do
             unless const_defined?(:UniquenessValidator, false)
               self.const_set(:UniquenessValidator, Class.new(UniquenessValidator))
+
+              def self.validates_uniqueness_of(*attr_names)
+                validates_with(UniquenessValidator, _merge_attributes(attr_names))
+              end
             end
           end
         end

--- a/spec/support/shared_examples/validation_examples.rb
+++ b/spec/support/shared_examples/validation_examples.rb
@@ -26,6 +26,19 @@ shared_examples_for "AR Model validation" do |model_class_name, attribute1=:titl
       end
     end
 
+    context "with validates_uniqueness_of" do
+      let(:model_class) do
+        model_class = model_class_name.constantize
+        model_class.validates_uniqueness_of(attribute1)
+        model_class
+      end
+
+      it "is invalid if other record has same attribute value in this locale" do
+        model_class.create(attribute1 => "foo")
+        expect(model_class.new(attribute1 => "foo")).not_to be_valid
+      end
+    end
+
     context "with untranslated scope on translated attribute" do
       let(:model_class) do
         model_class_name.constantize.tap do |klass|


### PR DESCRIPTION
Hi, we're having issues with uniqueness validations done with `validates_uniqueness_of`.
I assume that constant in `validates_uniqueness_of ` is still points to default rails validator.

```ruby
    Failure/Error: model_class.create(attribute1 => "foo")

     ActiveRecord::StatementInvalid:
       PG::UndefinedColumn: ERROR:  column container_posts.title does not exist
       LINE 1: SELECT 1 AS one FROM "container_posts" WHERE "container_post...
```

I came up with straightforward solution, but I believe there are better solutions.