### PR TITLE
Make Mobility::Plugins::ActiveRecord::Query::VirtualRow public

### DIFF
--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -29,7 +29,9 @@ enabled for any one attribute on the model.
             klass.class_eval do
               extend QueryMethod
               extend FindByMethods.new(*plugin.names)
-              singleton_class.send :alias_method, plugin.query_method, :__mobility_query_scope__
+              singleton_class.define_method(plugin.query_method) do |locale: Mobility.locale, &block|
+                Query.build_query(self, locale, &block)
+              end
             end
             backend_class.include BackendMethods
           end
@@ -65,8 +67,8 @@ enabled for any one attribute on the model.
         end
 
         module QueryMethod
-          # This is required for UniquenessValidator.
           def __mobility_query_scope__(locale: Mobility.locale, &block)
+            warn '__mobility_query_scope__ is an internal method and will be deprecated in the next release.'
             Query.build_query(self, locale, &block)
           end
         end

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -108,7 +108,7 @@ enabled for any one attribute on the model.
             end
           end
         end
-        private_constant :QueryMethod, :VirtualRow
+        private_constant :QueryMethod
 
         module QueryExtension
           def where!(opts, *rest)

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -39,6 +39,10 @@ enabled for any one attribute on the model.
           def attribute_alias(attribute, locale = Mobility.locale)
             "__mobility_%s_%s__"  % [attribute, ::Mobility.normalize_locale(locale)]
           end
+
+          def build_query(klass, locale = Mobility.locale, &block)
+            VirtualRow.build_query(klass, locale, &block)
+          end
         end
 
         module BackendMethods

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -41,7 +41,11 @@ enabled for any one attribute on the model.
           end
 
           def build_query(klass, locale = Mobility.locale, &block)
-            VirtualRow.build_query(klass, locale, &block)
+            if block_given?
+              VirtualRow.build_query(klass, locale, &block)
+            else
+              klass.all.extending(QueryExtension)
+            end
           end
         end
 
@@ -63,11 +67,7 @@ enabled for any one attribute on the model.
         module QueryMethod
           # This is required for UniquenessValidator.
           def __mobility_query_scope__(locale: Mobility.locale, &block)
-            if block_given?
-              VirtualRow.build_query(self, locale, &block)
-            else
-              all.extending(QueryExtension)
-            end
+            Query.build_query(self, locale, &block)
           end
         end
 

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -277,7 +277,7 @@ enabled for any one attribute on the model.
           end
         end
 
-        private_constant :QueryExtension, :FindByMethods
+        private_constant :FindByMethods
       end
 
       class MissingBackend < Mobility::Error; end

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -71,9 +71,9 @@ enabled for any one attribute on the model.
           end
         end
 
-        # Internal class to create a "clean room" for manipulating translated
-        # attribute nodes in an instance-eval'ed block. Inspired by Sequel's
-        # (much more sophisticated) virtual rows.
+        # Creates a "clean room" for manipulating translated attribute nodes in
+        # an instance-eval'ed block. Inspired by Sequel's (much more
+        # sophisticated) virtual rows.
         class VirtualRow < BasicObject
           attr_reader :__backends
 

--- a/lib/mobility/plugins/active_record/uniqueness_validation.rb
+++ b/lib/mobility/plugins/active_record/uniqueness_validation.rb
@@ -27,7 +27,7 @@ module Mobility
 
             if ([*options[:scope]] + [attribute]).any? { |name| klass.mobility_attribute?(name) }
               return unless value.present?
-              relation = klass.unscoped.__mobility_query_scope__ do |m|
+              relation = Plugins::ActiveRecord::Query.build_query(klass.unscoped, Mobility.locale) do |m|
                 node = m.__send__(attribute)
                 options[:case_sensitive] == false ? node.lower.eq(value.downcase) : node.eq(value)
               end
@@ -50,7 +50,7 @@ module Mobility
 
           def mobility_scope_relation(record, relation)
             [*options[:scope]].inject(relation) do |scoped_relation, scope_item|
-              scoped_relation.__mobility_query_scope__ do |m|
+              Plugins::ActiveRecord::Query.build_query(scoped_relation, Mobility.locale) do |m|
                 m.__send__(scope_item).eq(record.send(scope_item))
               end
             end

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -106,4 +106,30 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
       end
     end
   end
+
+  describe ".build_query" do
+    it "builds VirtualRow" do
+      stub_const 'Article', Class.new(ActiveRecord::Base)
+      translates Article, :title, backend: :table
+
+      article_en = Article.create(title: "foo")
+      article_ja = Mobility.with_locale(:ja) { Article.create(title: "ほげ") }
+
+      expect(described_class.build_query(Article) do
+        title.eq('foo')
+      end).to eq([article_en])
+
+      expect(described_class.build_query(Article) do
+        title.eq('ほげ')
+      end).to eq([])
+
+      expect(described_class.build_query(Article, :ja) do
+        title.eq('foo')
+      end).to eq([])
+
+      expect(described_class.build_query(Article, :ja) do
+        title.eq('ほげ')
+      end).to eq([article_ja])
+    end
+  end
 end

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -23,7 +23,7 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
 
     context "default query scope" do
       it "defines query scope" do
-        expect(model_class.i18n).to eq(model_class.__mobility_query_scope__)
+        expect(model_class.i18n).to eq(described_class.build_query(model_class, Mobility.locale))
       end
     end
 
@@ -34,7 +34,7 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
       end
 
       it "defines query scope" do
-        expect(model_class.foo).to eq(model_class.__mobility_query_scope__)
+        expect(model_class.foo).to eq(described_class.build_query(model_class, Mobility.locale))
         expect { model_class.i18n }.to raise_error(NoMethodError)
       end
     end
@@ -55,13 +55,11 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
   end
 
   describe "query method" do
-    # NOTE: __mobility_query_scope__ is a public method for convenience, but is
-    # intended for internal use.
     it "creates a __mobility_query_scope__ method" do
       stub_const 'Article', Class.new(ActiveRecord::Base)
       translates Article, :title, backend: :table
       article = Article.create(title: "foo")
-      expect(Article.__mobility_query_scope__.first).to eq(article)
+      expect(Article.i18n.first).to eq(article)
     end
   end
 


### PR DESCRIPTION
There should be a way to build queries without using the query scope. This PR makes this more easily possible by making `Mobility::Plugins::ActiveRecord::Query::VirtualRow` public, and also adding a class method `Query.build_query` which can be used like this:

```ruby
Mobility::Plugins::ActiveRecord::Query.build_query(Post) do
  title.eq('foo')
end
```

This is equivalent to:
```ruby
Post.i18n do
  title.eq('foo')
end
```

The namespace is cumbersome but you can just name it something else in your application:

```ruby
I18nQueryScope = Mobility::Plugins::ActiveRecord::Query
```

then use:

```ruby
I18nQueryScope.build_query(Post) do
  title.eq('foo')
end
```