### PR TITLE
Define dependencies_satisfied? to avoid loading plugin

### DIFF
--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -121,8 +121,8 @@ Also includes a +configure+ class method to apply plugins to a pluggable
     # Does this class include all plugins this plugin depends (directly) on?
     # @param [Class] klass Pluggable class
     def dependencies_satisfied?(klass)
-      required_plugins = dependencies.keys.map { |name| Plugins.load_plugin(name) }
-      (required_plugins - klass.included_modules).none?
+      plugin_keys = klass.included_plugins.map { |plugin| Plugins.lookup_name(plugin) }
+      (dependencies.keys - plugin_keys).none?
     end
 
     # Specifies a dependency of this plugin.


### PR DESCRIPTION
I noticed that this line can actually load (`require`) a plugin that is not in fact needed, e.g. `active_record_dirty` depends on `dirty` being included but it should not actually have to load the dirty plugin to do this check.

The change here avoids that unnecessary file load.