### PR TITLE
Allow setting locale per node in query block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   ([#475](https://github.com/shioyama/mobility/pull/475))
 - Add public method `Mobility::Plugins::ActiveRecord::Query.build_query`
   ([#471](https://github.com/shioyama/mobility/pull/471))
+- Allow setting locale per node in query block
+  ([#479](https://github.com/shioyama/mobility/pull/479))
+- Add `Mobility.validate_locale!`
+  ([#479](https://github.com/shioyama/mobility/pull/479))
 
 ## 1.0
 

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -201,6 +201,14 @@ module Mobility
       end
     end
 
+    # Check that a non-nil locale is valid. (Does not actually parse locale to
+    # check its format.)
+    # @raise [InvalidLocale] if locale is not a Symbol or not available
+    def validate_locale!(locale)
+      raise Mobility::InvalidLocale.new(locale) unless Symbol === locale
+      enforce_available_locales!(locale) if I18n.enforce_available_locales
+    end
+
     # Raises InvalidLocale exception if the locale passed in is present but not available.
     # @param [String,Symbol] locale
     # @raise [InvalidLocale] if locale is present but not available
@@ -231,8 +239,8 @@ module Mobility
     end
 
     def set_locale(locale)
-      locale = locale.to_sym if locale
-      enforce_available_locales!(locale) if I18n.enforce_available_locales
+      locale = locale.to_sym if String === locale
+      validate_locale!(locale) if locale
       storage[:mobility_locale] = locale
     end
   end

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -77,17 +77,17 @@ enabled for any one attribute on the model.
         # an instance-eval'ed block. Inspired by Sequel's (much more
         # sophisticated) virtual rows.
         class VirtualRow < BasicObject
-          attr_reader :__backends, :__locales
+          attr_reader :backends, :locales
 
-          def initialize(klass, locale)
-            @klass, @locale, @__locales, @__backends = klass, locale, [], []
+          def initialize(klass, global_locale)
+            @klass, @global_locale, @locales, @backends = klass, global_locale, [], []
           end
 
           def method_missing(m, *args)
             if @klass.mobility_attribute?(m)
-              @__backends |= [@klass.mobility_backend_class(m)]
-              locale = args[0] || @locale
-              @__locales |= [locale]
+              @backends |= [@klass.mobility_backend_class(m)]
+              locale = args[0] || @global_locale
+              @locales |= [locale]
               @klass.mobility_backend_class(m).build_node(m, locale)
             elsif @klass.column_names.include?(m.to_s)
               @klass.arel_table[m]
@@ -103,9 +103,9 @@ enabled for any one attribute on the model.
 
               if ::ActiveRecord::Relation === query
                 predicates = query.arel.constraints
-                apply_scopes(klass.all, row.__backends, row.__locales, predicates).merge(query)
+                apply_scopes(klass.all, row.backends, row.locales, predicates).merge(query)
               else
-                apply_scopes(klass.all, row.__backends, row.__locales, query).where(query)
+                apply_scopes(klass.all, row.backends, row.locales, query).where(query)
               end
             end
 

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -79,18 +79,18 @@ enabled for any one attribute on the model.
         class VirtualRow < BasicObject
           attr_reader :__backends, :__locales
 
-          def initialize(model_class, locale)
-            @model_class, @locale, @__locales, @__backends = model_class, locale, [], []
+          def initialize(klass, locale)
+            @klass, @locale, @__locales, @__backends = klass, locale, [], []
           end
 
           def method_missing(m, *args)
-            if @model_class.mobility_attribute?(m)
-              @__backends |= [@model_class.mobility_backend_class(m)]
+            if @klass.mobility_attribute?(m)
+              @__backends |= [@klass.mobility_backend_class(m)]
               locale = args[0] || @locale
               @__locales |= [locale]
-              @model_class.mobility_backend_class(m).build_node(m, locale)
-            elsif @model_class.column_names.include?(m.to_s)
-              @model_class.arel_table[m]
+              @klass.mobility_backend_class(m).build_node(m, locale)
+            elsif @klass.column_names.include?(m.to_s)
+              @klass.arel_table[m]
             else
               super
             end

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -86,6 +86,7 @@ enabled for any one attribute on the model.
           def method_missing(m, *args)
             if @klass.mobility_attribute?(m)
               @backends |= [@klass.mobility_backend_class(m)]
+              ::Mobility.validate_locale!(args[0]) if args[0]
               locale = args[0] || @global_locale
               @locales |= [locale]
               @klass.mobility_backend_class(m).build_node(m, locale)
@@ -98,6 +99,8 @@ enabled for any one attribute on the model.
 
           class << self
             def build_query(klass, locale, &block)
+              ::Mobility.validate_locale!(locale)
+
               row = new(klass, locale)
               query = block.arity.zero? ? row.instance_eval(&block) : block.call(row)
 

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -87,6 +87,25 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
           end
         end
       end
+
+      context "multiple locales" do
+        it "applies locale argument to node" do
+          article1 = Article.create(author: "foo")
+          Mobility.with_locale(:ja) { article1.author = "ほげ"; article1.save }
+          article2 = Article.create(author: "bar")
+          Mobility.with_locale(:ja) { article2.author = "ふが"; article2.save }
+
+          expect(Article.i18n { author(:en).eq("foo").and(author(:ja).eq("ほげ")) }).to eq([article1])
+          expect(Article.i18n { author(:en).eq("foo").and(author(:ja).eq("ふが")) }).to eq([])
+          expect(Article.i18n { author(:en).eq("bar").and(author(:ja).eq("ふが")) }).to eq([article2])
+          expect(Article.i18n { author(:en).eq("bar").and(author(:ja).eq("ほげ")) }).to eq([])
+
+          expect(Article.i18n { author(:en).eq("foo").or(author(:ja).eq("ほげ")) }).to eq([article1])
+          expect(Article.i18n { author(:en).eq("foo").or(author(:ja).eq("ふが")) }).to match_array([article1, article2])
+          expect(Article.i18n { author(:en).eq("bar").or(author(:ja).eq("ふが")) }).to eq([article2])
+          expect(Article.i18n { author(:en).eq("bar").or(author(:ja).eq("ほげ")) }).to match_array([article1, article2])
+        end
+      end
     end
 
     # TODO: Test more thoroughly

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -105,6 +105,10 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
           expect(Article.i18n { author(:en).eq("bar").or(author(:ja).eq("ふが")) }).to eq([article2])
           expect(Article.i18n { author(:en).eq("bar").or(author(:ja).eq("ほげ")) }).to match_array([article1, article2])
         end
+
+        it "raises InvalidLocale exception if locale is invalid" do
+          expect { Article.i18n { author([]).eq("foo") } }.to raise_error(Mobility::InvalidLocale)
+        end
       end
     end
 

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -55,7 +55,7 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
   end
 
   describe "query method" do
-    it "creates a __mobility_query_scope__ method" do
+    it "creates a query method method" do
       stub_const 'Article', Class.new(ActiveRecord::Base)
       translates Article, :title, backend: :table
       article = Article.create(title: "foo")

--- a/spec/mobility/plugins/sequel/query_spec.rb
+++ b/spec/mobility/plugins/sequel/query_spec.rb
@@ -1,0 +1,160 @@
+require "spec_helper"
+
+return unless defined?(Sequel)
+
+require "mobility/plugins/sequel/query"
+
+describe Mobility::Plugins::Sequel::Query, orm: :sequel, type: :plugin do
+  plugins :sequel, :reader, :writer, :query, :cache
+  plugin_setup
+
+  describe "query_scope" do
+    let(:model_class) do
+      stub_const 'Article', Class.new(Sequel::Model)
+      Article.dataset = DB[:articles]
+      Article.include translations
+      Article
+    end
+
+    context "default query scope" do
+      it "defines query scope" do
+        expect(model_class.i18n).to eq(described_class.build_query(model_class, Mobility.locale))
+      end
+    end
+
+    context "custom query scope" do
+      plugins do
+        query :foo
+        sequel
+      end
+
+      it "defines query scope" do
+        expect(model_class.foo).to eq(described_class.build_query(model_class, Mobility.locale))
+        expect { model_class.i18n }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe "query methods" do
+    before do
+      stub_const 'Article', Class.new(Sequel::Model)
+      Article.dataset = DB[:articles]
+      translates Article, :title, backend: :table
+    end
+
+    it "does not modify original opts hash" do
+      options = { title: "foo", locale: :en }
+      options_ = options.dup
+      Article.i18n.where(options_)
+      expect(options_).to eq(options)
+    end
+  end
+
+  describe "query method" do
+    it "creates a query method method" do
+      stub_const 'Article', Class.new(Sequel::Model)
+      Article.dataset = DB[:articles]
+      translates Article, :title, backend: :table
+      article = Article.create(title: "foo")
+      expect(Article.i18n.first).to eq(article)
+    end
+  end
+
+  describe "virtual row handling", focus:true do
+    before do
+      stub_const 'Article', Class.new(Sequel::Model)
+      Article.dataset = DB[:articles]
+      translates Article, :title, backend: :table
+      translates Article, :subtitle, backend: :table
+      translates Article, :content, type: :text, backend: :key_value
+      translates Article, :author, type: :string, backend: :key_value
+
+      Article.one_to_many :comments
+
+      stub_const 'Comment', Class.new(Sequel::Model)
+      Comment.dataset = DB[:comments]
+      translates Comment, :author, backend: :column
+      Comment.many_to_one :article
+    end
+
+    # TODO: Test more thoroughly
+    context "single-block querying" do
+      context "multiple backends" do
+        # TODO: Make this work. Requires changes to Table + KeyValue backends
+        # to use a custom op type like we do in the ActiveRecord backends with
+        # Mobility::Plugins::Arel::Attribute which tracks table.
+        pending "does not join translations table when backend node not included in predicate" do
+          Article.i18n { title; (content =~ "bazcontent") | (author =~ "foobarauthor") }.tap do |relation|
+            expect(relation.sql).not_to match /article_translations/
+          end
+        end
+      end
+
+      context "multiple locales" do
+        it "applies locale argument to node" do
+          article1 = Article.create(author: "foo")
+          Mobility.with_locale(:ja) { article1.author = "ほげ"; article1.save }
+          article2 = Article.create(author: "bar")
+          Mobility.with_locale(:ja) { article2.author = "ふが"; article2.save }
+
+          expect(Article.i18n { (author(:en) =~ "foo") & (author(:ja) =~ "ほげ") }.select_all(:articles).all).to match_array([article1])
+          expect(Article.i18n { (author(:en) =~ "foo") & (author(:ja) =~ "ふが") }.select_all(:articles).all).to eq([])
+          expect(Article.i18n { (author(:en) =~ "bar") & (author(:ja) =~ "ふが") }.select_all(:articles).all).to match_array([article2])
+          expect(Article.i18n { (author(:en) =~ "bar") & (author(:ja) =~ "ほげ") }.select_all(:articles).all).to eq([])
+
+          expect(Article.i18n { (author(:en) =~ "foo") | (author(:ja) =~ "ほげ") }.select_all(:articles).all).to match_array([article1])
+          expect(Article.i18n { (author(:en) =~ "foo") | (author(:ja) =~ "ふが") }.select_all(:articles).all).to match_array([article1, article2])
+          expect(Article.i18n { (author(:en) =~ "bar") | (author(:ja) =~ "ふが") }.select_all(:articles).all).to match_array([article2])
+          expect(Article.i18n { (author(:en) =~ "bar") | (author(:ja) =~ "ほげ") }.select_all(:articles).all).to match_array([article1, article2])
+        end
+
+        it "raises InvalidLocale exception if locale is invalid" do
+          expect { Article.i18n { author([]) =~ "foo" } }.to raise_error(Mobility::InvalidLocale)
+        end
+      end
+    end
+
+    # TODO: Test more thoroughly
+    context "multiple-block querying" do
+      it "returns records matching predicate across models" do
+        article1 = Article.create(author: "foo")
+        article2 = Article.create(author: "foo")
+        comment1 = article1.add_comment(author: "foo")
+        comment2 = article2.add_comment(author: "baz")
+
+        expect(Article.i18n { |a| a.author =~ "foo" }.select_all(:articles).all).to match_array([article1, article2])
+        expect(Comment.i18n { |c| c.author =~ "foo" }.select_all(:comments).all).to eq([comment1])
+
+        # This doens't work because dataset is not defined on join. Not digging into it, but could possibly be made to work.
+        #expect(Article.join(:comments).i18n { |a| Comment.i18n { |c| a.author.eq(c.author) } }.select_all(:articles).all).to eq([article1])
+      end
+    end
+  end
+
+  describe ".build_query" do
+    it "builds VirtualRow" do
+      stub_const 'Article', Class.new(Sequel::Model)
+      Article.dataset = DB[:articles]
+      translates Article, :title, backend: :table
+
+      article_en = Article.create(title: "foo")
+      article_ja = Mobility.with_locale(:ja) { Article.create(title: "ほげ") }
+
+      expect(described_class.build_query(Article) do
+        title =~ 'foo'
+      end.select_all(:articles).all).to eq([article_en])
+
+      expect(described_class.build_query(Article) do
+        title =~ 'ほげ'
+      end.select_all(:articles).all).to eq([])
+
+      expect(described_class.build_query(Article, :ja) do
+        title =~ 'foo'
+      end.select_all(:articles).all).to eq([])
+
+      expect(described_class.build_query(Article, :ja) do
+        title =~ 'ほげ'
+      end.select_all(:articles).all).to eq([article_ja])
+    end
+  end
+end


### PR DESCRIPTION
I realized that querying using the block format can be made much more powerful if we allow passing the locale as an argument to the node method in the block, e.g.:

```ruby
Post.i18n do
  title(:en).eq('foo').or(content(:ja).eq('bar'))
end
```

So the argument to `title` and `content` in the block is optional, but if passed will override the locale and apply it just to that node. With this change, it becomes really easy to do very complex queries across multiple languages in the same block.

WDYT folks?