### PR TITLE
WIP of initializing fallbacks on start

### DIFF
--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -125,7 +125,12 @@ the current locale was +nil+.
 
       def generate_fallbacks(fallbacks)
         fallbacks_class = I18n.respond_to?(:fallbacks) ? I18nFallbacks : I18n::Locale::Fallbacks
-        fallbacks_class.new(fallbacks)
+        fallbacks_class.new(fallbacks).tap do |fallbacks_instance|
+          fallbacks.each_key do |locale|
+            # Initialize fallbacks
+            fallbacks_instance[locale]
+          end
+        end
       end
 
       class I18nFallbacks < ::I18n::Locale::Fallbacks


### PR DESCRIPTION
As pointed out in #481, I18n fallbacks [are lazy-initialized by default](https://github.com/ruby-i18n/i18n/blob/4709391dceab9096d5988576f93935843023a6ef/lib/i18n/locale/fallbacks.rb#L71). This can be problematic in production environments, particularly with forking appservers, since:
1. The first request pays the initialization cost
2. Memory usage is duplicated across appserver processes rather than taking advantage of copy-on-write

This is a draft of a way to mitigate these problems. Readability isn't great since the `i18n` library doesn't seem to have an API to explicitly initialize fallbacks. Instead we're just looping through each locale and referencing it so that `i18n` will initialize it.

Considerations:
1. We probably don't want this behavior in development, how should we account for that?
2. Ideally this behavior would be configurable, what is the right place for that configuration to live? This could potentially address (1).
3. Would this be considered a breaking change to have turned on by default?