### PR TITLE
Remove internal table_alias_affix option

### DIFF
--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -37,7 +37,6 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
             options[:association_name] ||= :"#{options[:type]}_translations"
             options[:class_name]       ||= const_get("#{type.capitalize}Translation")
           end
-          options[:table_alias_affix] = "#{model_class}_%s_#{options[:association_name]}"
         rescue NameError
           raise ArgumentError, "You must define a Mobility::Backends::ActiveRecord::KeyValue::#{type.capitalize}Translation class."
         end

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -79,7 +79,6 @@ other backends on model (otherwise one will overwrite the other).
         backend_class.extend ClassMethods
         backend_class.option_reader :association_name
         backend_class.option_reader :class_name
-        backend_class.option_reader :table_alias_affix
       end
 
       module ClassMethods
@@ -110,7 +109,7 @@ other backends on model (otherwise one will overwrite the other).
         end
 
         def table_alias(attr, locale)
-          table_alias_affix % "#{attr}_#{Mobility.normalize_locale(locale)}"
+          "#{model_class}_#{attr}_#{Mobility.normalize_locale(locale)}_#{options[:association_name]}"
         end
       end
 

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -31,7 +31,6 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
             options[:association_name] ||= :"#{options[:type]}_translations"
             options[:class_name]       ||= const_get("#{type.capitalize}Translation")
           end
-          options[:table_alias_affix] = "#{model_class}_%s_#{options[:association_name]}"
         rescue NameError
           raise ArgumentError, "You must define a Mobility::Sequel::#{type.capitalize}Translation class."
         end

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -355,25 +355,23 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
         Class.new(described_class) { @model_class = Article }
       end
 
-      it "sets association_name, class_name and table_alias_affix from string type" do
+      it "sets association_name and class_name from string type" do
         options = { type: :string }
         backend_class.configure(options)
         expect(options).to eq({
           type: :string,
           class_name: string_translation_class,
-          association_name: :string_translations,
-          table_alias_affix: "Article_%s_string_translations"
+          association_name: :string_translations
         })
       end
 
-      it "sets association_name, class_name and table_alias_affix from text type" do
+      it "sets association_name and class_name from text type" do
         options = { type: :text }
         backend_class.configure(options)
         expect(options).to eq({
           type: :text,
           class_name: text_translation_class,
-          association_name: :text_translations,
-          table_alias_affix: "Article_%s_text_translations"
+          association_name: :text_translations
         })
       end
 
@@ -389,8 +387,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
         expect(options).to eq({
           type: :text,
           class_name: text_translation_class,
-          association_name: :text_translations,
-          table_alias_affix: "Article_%s_text_translations"
+          association_name: :text_translations
         })
       end
     end

--- a/spec/mobility/backends/sequel/key_value_spec.rb
+++ b/spec/mobility/backends/sequel/key_value_spec.rb
@@ -374,25 +374,23 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
       Class.new(described_class) { @model_class = Post }
     end
 
-    it "sets association_name, class_name and table_alias_affix from string type" do
+    it "sets association_name and class_name from string type" do
       options = { type: :string }
       backend_class.configure(options)
       expect(options).to eq({
         type: :string,
         class_name: string_translation_class,
-        association_name: :string_translations,
-        table_alias_affix: "Post_%s_string_translations"
+        association_name: :string_translations
       })
     end
 
-    it "sets association_name, class_name and table_alias_affix from text type" do
+    it "sets association_name and class_name from text type" do
       options = { type: :text }
       backend_class.configure(options)
       expect(options).to eq({
         type: :text,
         class_name: text_translation_class,
-        association_name: :text_translations,
-        table_alias_affix: "Post_%s_text_translations"
+        association_name: :text_translations
       })
     end
 
@@ -403,14 +401,13 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
     end
 
 
-    it "sets default association_name, class_name and table_alias_affix from type" do
+    it "sets default association_name and class_name from type" do
       options = { type: :text }
       backend_class.configure(options)
       expect(options).to eq({
         type: :text,
         class_name: text_translation_class,
-        association_name: :text_translations,
-        table_alias_affix: "Post_%s_text_translations"
+        association_name: :text_translations
       })
     end
   end


### PR DESCRIPTION
This option is not needed, since it can simply be inlined into the table_alias method.