### PR TITLE
Call after_destroy in setup block to delete associated translations

### DIFF
--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -125,8 +125,8 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
       backend = self
 
       setup do |attributes, options|
-        association_name   = options[:association_name]
-        translations_class = options[:class_name]
+        association_name  = options[:association_name]
+        translation_class = options[:class_name]
 
         attrs_method_name = :"#{association_name}_attributes"
         association_attributes = (instance_variable_get(:"@#{attrs_method_name}") || []) + attributes
@@ -140,7 +140,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
           adder:           proc { |translation| translation.update(translatable_id: pk, translatable_type: self.class.to_s) },
           remover:         proc { |translation| translation.update(translatable_id: nil, translatable_type: nil) },
           clearer:         proc { send(:"#{association_name}_dataset").update(translatable_id: nil, translatable_type: nil) },
-          class:           translations_class
+          class:           translation_class
 
         callback_methods = Module.new do
           define_method :before_save do
@@ -154,7 +154,17 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
         end
         include callback_methods
 
-        include DestroyKeyValueTranslations
+        # Clean up *all* leftover translations of this model, only once.
+        translation_classes = [translation_class, *Mobility::Backends::Sequel::KeyValue::Translation.descendants].uniq
+        define_method :after_destroy do
+          super()
+
+          @mobility_after_destroy_translation_classes = [] unless defined?(@mobility_after_destroy_translation_classes)
+          (translation_classes - @mobility_after_destroy_translation_classes).each do |klass|
+            klass.where(translatable_id: id, translatable_type: self.class.name).destroy
+          end
+          @mobility_after_destroy_translation_classes += translation_classes
+        end
         include(mod = Module.new)
         backend.define_column_changes(mod, attributes)
       end
@@ -173,17 +183,6 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
         cache.each_value do |translation|
           next unless present?(translation.value)
           translation.id ? translation.save : model.send("add_#{singularize(association_name)}", translation)
-        end
-      end
-
-      # Clean up *all* leftover translations of this model, only once.
-      module DestroyKeyValueTranslations
-        def after_destroy
-          super
-          [:string, :text].freeze.each do |type|
-            Mobility::Backends::Sequel::KeyValue.const_get("#{type.capitalize}Translation").
-              where(translatable_id: id, translatable_type: self.class.name).destroy
-          end
         end
       end
 
@@ -211,7 +210,15 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
       end
 
       module Translation
+        # Strictly these are not "descendants", but to keep terminology
+        # consistent with ActiveRecord KeyValue backend.
+        def self.descendants
+          @descendants ||= Set.new
+        end
+
         def self.included(base)
+          @descendants ||= Set.new
+          @descendants << base
           base.class_eval do
             plugin :validation_helpers
 

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -315,34 +315,82 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
 
     describe "after destroy" do
       plugins :active_record, :reader, :writer
-      before do
-        translates Article, :title, :content, backend: :key_value, type: :text
-        stub_const 'Post', Class.new(ActiveRecord::Base)
-        translates Post, :title, backend: :key_value, type: :string
-        translates Post, :content, backend: :key_value, type: :text
+
+      before(:all) do
+        m = ActiveRecord::Migration.new
+        m.verbose = false
+        m.create_table :mobility_foo_translations do |t|
+          t.string :locale, null: false
+          t.string :key, null: false
+          t.string :value
+          t.references :translatable, polymorphic: true, index: false
+          t.timestamps null: false
+        end
+      end
+      after(:all) do
+        m = ActiveRecord::Migration.new
+        m.verbose = false
+        m.drop_table :mobility_foo_translations
       end
 
       # In case we change the translated attributes on a model, we need to make
       # sure we clean them up when the model is destroyed.
       it "cleans up all associated translations, regardless of key" do
-        article = Article.create(title: "foo title", content: "foo content")
-        Mobility.with_locale(:ja) { article.update(title: "あああ", content: "ばばば") }
+        # test with custom subclass
+        foo_translation_class = Class.new(Mobility::Backends::ActiveRecord::KeyValue::Translation)
+        foo_translation_class.table_name = "mobility_foo_translations"
+        stub_const('Mobility::Backends::ActiveRecord::KeyValue::FooTranslation', foo_translation_class)
+
+        translates Article, :title, backend: :key_value, type: :string
+        translates Article, :subtitle, backend: :key_value, type: :string
+        translates Article, :content, backend: :key_value, type: :text
+        translates Article, :author, backend: :key_value, type: :foo
+        article = Article.create(title: "foo title", content: "foo content", subtitle: "foo subtitle", author: "foo author")
+        Mobility.with_locale(:ja) { article.update(title: "あああ", content: "ばばば", subtitle: "ぱぱぱ", author: "ややや") }
         article.save
 
         # Create translations on another model, to check they do not get destroyed
+        stub_const 'Post', Class.new(ActiveRecord::Base)
+        translates Post, :title, backend: :key_value, type: :string
+        translates Post, :content, backend: :key_value, type: :text
         Post.create(title: "post title", content: "post content")
 
-        expect(string_translation_class.count).to eq(1)
-        expect(text_translation_class.count).to eq(5)
+        expect(string_translation_class.count).to eq(5)
+        expect(text_translation_class.count).to eq(3)
+        expect(foo_translation_class.count).to eq(2)
 
         text_translation_class.create!(translatable: article, key: "key1", value: "value1", locale: "de")
         string_translation_class.create!(translatable: article, key: "key2", value: "value2", locale: "fr")
-        expect(text_translation_class.count).to eq(6)
-        expect(string_translation_class.count).to eq(2)
+        foo_translation_class.create!(translatable: article, key: "key3", value: "value3", locale: "ja")
+        expect(string_translation_class.count).to eq(6)
+        expect(text_translation_class.count).to eq(4)
+        expect(foo_translation_class.count).to eq(3)
 
-        article.destroy!
+        # ensure we're doing the right number of deletes
+        deletes = []
+        selects = []
+        callback = ->(_name, _started, _finished, _unique_id, payload) do
+          selects << payload[:sql] if payload[:sql].start_with?('SELECT')
+          deletes << payload[:sql] if payload[:sql].start_with?('DELETE')
+        end
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          article.destroy!
+        end
+
         expect(text_translation_class.count).to eq(1)
         expect(string_translation_class.count).to eq(1)
+        expect(foo_translation_class.count).to eq(0)
+
+        expect(deletes.grep(/mobility_string_translations/).size).to eq(5)
+        expect(deletes.grep(/mobility_text_translations/).size).to eq(3)
+        expect(deletes.grep(/mobility_foo_translations/).size).to eq(3)
+        expect(deletes.size).to eq(12)
+
+        # We should only need one select per table, if we're doing more it
+        # means we've assigned multiple callback hooks for the same table.
+        expect(selects.grep(/mobility_string_translations/).size).to eq(1)
+        expect(selects.grep(/mobility_text_translations/).size).to eq(1)
+        expect(selects.grep(/mobility_foo_translations/).size).to eq(1)
       end
     end
 


### PR DESCRIPTION
Currently we include a module which adds an `after_destroy` hook to destroy both text and string translations after a model is destroyed, if it has any attributes using the KeyValue backend. This is a conservative move to ensure that string/text translations for a model are always cleaned up, even if a model may have changed code in the past from string to text (leaving behind orphan translations, for example).

However, this makes assumptions about the `translations_class`, which in general may use another class/table entirely.

~I think dealing with orphan translations should be the responsibility of the application developer, and the code itself should only define callbacks for _currently defined attributes_. Thus if a model only has string translations, then the `after_destroy` block should only destroy string translations for that model table, not text translations. This avoids useless queries, at the cost of possibly leaving behind previously generated translations, which become orphaned.~

I've rethought this and decided to keep the current behaviour the default, with one small change: we now look for descendants of `Mobility::Backends::ActiveRecord::KeyValue::Translation`, so if someone wants to add a subclass for a type other than `:string` or `:text`, that would be possible and the `after_destroy` callback would automatically clean those up too.

I think given how easy it is to miss orphan translations, the default should be to destroy all string/translation/whatever translations for a model when it is destroyed, regardless of the current use of translations in the model. This ensures that _as long as the model is still translated with the KeyValue backend_, it will continue to cleanup all translations when records are destroyed.