### PR TITLE
Add key, value and belongs_to options to key-value backend

### DIFF
--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -81,7 +81,7 @@ other backends on model (otherwise one will overwrite the other).
         backend_class.option_reader :class_name
         backend_class.option_reader :key_column
         backend_class.option_reader :value_column
-        backend_class.option_reader :translatable
+        backend_class.option_reader :belongs_to
       end
 
       module ClassMethods
@@ -103,7 +103,7 @@ other backends on model (otherwise one will overwrite the other).
           options[:class_name]       &&= Util.constantize(options[:class_name])
           options[:key_column]       ||= :key
           options[:value_column]     ||= :value
-          options[:translatable]     ||= :translatable
+          options[:belongs_to]       ||= :translatable
           if !(options[:type] || (options[:class_name] && options[:association_name]))
             raise ArgumentError, "KeyValue backend requires an explicit type option, either text or string."
           end

--- a/lib/mobility/backends/key_value.rb
+++ b/lib/mobility/backends/key_value.rb
@@ -55,18 +55,18 @@ other backends on model (otherwise one will overwrite the other).
       # @!group Backend Accessors
       # @!macro backend_reader
       def read(locale, **options)
-        translation_for(locale, **options).value
+        translation_for(locale, **options).send(value_column)
       end
 
       # @!macro backend_writer
       def write(locale, value, **options)
-        translation_for(locale, **options).value = value
+        translation_for(locale, **options).send(:"#{value_column}=", value)
       end
       # @!endgroup
 
       # @!macro backend_iterator
       def each_locale
-        translations.each { |t| yield(t.locale.to_sym) if t.key == attribute }
+        translations.each { |t| yield(t.locale.to_sym) if t.send(key_column) == attribute }
       end
 
       private
@@ -79,6 +79,9 @@ other backends on model (otherwise one will overwrite the other).
         backend_class.extend ClassMethods
         backend_class.option_reader :association_name
         backend_class.option_reader :class_name
+        backend_class.option_reader :key_column
+        backend_class.option_reader :value_column
+        backend_class.option_reader :translatable
       end
 
       module ClassMethods
@@ -98,6 +101,9 @@ other backends on model (otherwise one will overwrite the other).
           options[:type]             &&= options[:type].to_sym
           options[:association_name] &&= options[:association_name].to_sym
           options[:class_name]       &&= Util.constantize(options[:class_name])
+          options[:key_column]       ||= :key
+          options[:value_column]     ||= :value
+          options[:translatable]     ||= :translatable
           if !(options[:type] || (options[:class_name] && options[:association_name]))
             raise ArgumentError, "KeyValue backend requires an explicit type option, either text or string."
           end

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -403,23 +403,29 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
         Class.new(described_class) { @model_class = Article }
       end
 
-      it "sets association_name and class_name from string type" do
+      it "sets association_name, class_name, key_column, value_colum and translatable from string type" do
         options = { type: :string }
         backend_class.configure(options)
         expect(options).to eq({
           type: :string,
           class_name: string_translation_class,
-          association_name: :string_translations
+          association_name: :string_translations,
+          key_column: :key,
+          value_column: :value,
+          translatable: :translatable
         })
       end
 
-      it "sets association_name and class_name from text type" do
+      it "sets association_name, class_name, key_column, value_colum and translatable from text type" do
         options = { type: :text }
         backend_class.configure(options)
         expect(options).to eq({
           type: :text,
           class_name: text_translation_class,
-          association_name: :text_translations
+          association_name: :text_translations,
+          key_column: :key,
+          value_column: :value,
+          translatable: :translatable
         })
       end
 
@@ -429,13 +435,16 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
                           "You must define a Mobility::Backends::ActiveRecord::KeyValue::IntegerTranslation class.")
       end
 
-      it "sets default association_name and class_name from type" do
+      it "sets default association_name, class_name, key_column, value_colum and translatable from type" do
         options = { type: :text }
         backend_class.configure(options)
         expect(options).to eq({
           type: :text,
           class_name: text_translation_class,
-          association_name: :text_translations
+          association_name: :text_translations,
+          key_column: :key,
+          value_column: :value,
+          translatable: :translatable
         })
       end
     end

--- a/spec/mobility/backends/active_record/key_value_spec.rb
+++ b/spec/mobility/backends/active_record/key_value_spec.rb
@@ -403,7 +403,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
         Class.new(described_class) { @model_class = Article }
       end
 
-      it "sets association_name, class_name, key_column, value_colum and translatable from string type" do
+      it "sets association_name, class_name, key_column, value_colum and belongs_to from string type" do
         options = { type: :string }
         backend_class.configure(options)
         expect(options).to eq({
@@ -412,11 +412,11 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
           association_name: :string_translations,
           key_column: :key,
           value_column: :value,
-          translatable: :translatable
+          belongs_to: :translatable
         })
       end
 
-      it "sets association_name, class_name, key_column, value_colum and translatable from text type" do
+      it "sets association_name, class_name, key_column, value_colum and belongs_to from text type" do
         options = { type: :text }
         backend_class.configure(options)
         expect(options).to eq({
@@ -425,7 +425,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
           association_name: :text_translations,
           key_column: :key,
           value_column: :value,
-          translatable: :translatable
+          belongs_to: :translatable
         })
       end
 
@@ -435,7 +435,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
                           "You must define a Mobility::Backends::ActiveRecord::KeyValue::IntegerTranslation class.")
       end
 
-      it "sets default association_name, class_name, key_column, value_colum and translatable from type" do
+      it "sets default association_name, class_name, key_column, value_colum and belongs_to from type" do
         options = { type: :text }
         backend_class.configure(options)
         expect(options).to eq({
@@ -444,7 +444,7 @@ describe "Mobility::Backends::ActiveRecord::KeyValue", orm: :active_record, type
           association_name: :text_translations,
           key_column: :key,
           value_column: :value,
-          translatable: :translatable
+          belongs_to: :translatable
         })
       end
     end

--- a/spec/mobility/backends/sequel/key_value_spec.rb
+++ b/spec/mobility/backends/sequel/key_value_spec.rb
@@ -400,23 +400,29 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
       Class.new(described_class) { @model_class = Post }
     end
 
-    it "sets association_name and class_name from string type" do
+    it "sets association_name, class_name, key_column, value_colum and translatable from string type" do
       options = { type: :string }
       backend_class.configure(options)
       expect(options).to eq({
         type: :string,
         class_name: string_translation_class,
-        association_name: :string_translations
+        association_name: :string_translations,
+        key_column: :key,
+        value_column: :value,
+        translatable: :translatable
       })
     end
 
-    it "sets association_name and class_name from text type" do
+    it "sets association_name, class_name, key_column, value_colum and translatable from text type" do
       options = { type: :text }
       backend_class.configure(options)
       expect(options).to eq({
         type: :text,
         class_name: text_translation_class,
-        association_name: :text_translations
+        association_name: :text_translations,
+        key_column: :key,
+        value_column: :value,
+        translatable: :translatable
       })
     end
 
@@ -427,13 +433,16 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
     end
 
 
-    it "sets default association_name and class_name from type" do
+    it "sets default association_name, class_name, key_column, value_colum and translatable from type" do
       options = { type: :text }
       backend_class.configure(options)
       expect(options).to eq({
         type: :text,
         class_name: text_translation_class,
-        association_name: :text_translations
+        association_name: :text_translations,
+        key_column: :key,
+        value_column: :value,
+        translatable: :translatable
       })
     end
   end

--- a/spec/mobility/backends/sequel/key_value_spec.rb
+++ b/spec/mobility/backends/sequel/key_value_spec.rb
@@ -400,7 +400,7 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
       Class.new(described_class) { @model_class = Post }
     end
 
-    it "sets association_name, class_name, key_column, value_colum and translatable from string type" do
+    it "sets association_name, class_name, key_column, value_colum and belongs_to from string type" do
       options = { type: :string }
       backend_class.configure(options)
       expect(options).to eq({
@@ -409,11 +409,11 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
         association_name: :string_translations,
         key_column: :key,
         value_column: :value,
-        translatable: :translatable
+        belongs_to: :translatable
       })
     end
 
-    it "sets association_name, class_name, key_column, value_colum and translatable from text type" do
+    it "sets association_name, class_name, key_column, value_colum and belongs_to from text type" do
       options = { type: :text }
       backend_class.configure(options)
       expect(options).to eq({
@@ -422,7 +422,7 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
         association_name: :text_translations,
         key_column: :key,
         value_column: :value,
-        translatable: :translatable
+        belongs_to: :translatable
       })
     end
 
@@ -433,7 +433,7 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
     end
 
 
-    it "sets default association_name, class_name, key_column, value_colum and translatable from type" do
+    it "sets default association_name, class_name, key_column, value_colum and belongs_to from type" do
       options = { type: :text }
       backend_class.configure(options)
       expect(options).to eq({
@@ -442,7 +442,7 @@ describe "Mobility::Backends::Sequel::KeyValue", orm: :sequel, type: :backend do
         association_name: :text_translations,
         key_column: :key,
         value_column: :value,
-        translatable: :translatable
+        belongs_to: :translatable
       })
     end
   end


### PR DESCRIPTION
In preparation for #385.

Also see #412.