### PR TITLE
Merge options including defaults into backend options

### DIFF
--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -83,7 +83,7 @@ Defines:
           @backend, @backend_options = options[:backend], options.dup
         when Array
           @backend, @backend_options = options[:backend]
-          @backend_options = @backend_options.merge(original_options)
+          @backend_options = @backend_options.merge(options)
         when NilClass
           @backend = @backend_options = nil
         else

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -30,8 +30,14 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record, type: :
   end
 
   context "with cache" do
-    plugins :active_record, :reader, :writer, :cache
-    before { translates Article, :title, :content, backend: :table, cache: true }
+    plugins do
+      backend :table
+      active_record
+      reader
+      writer
+      cache
+    end
+    before { translates Article, :title, :content }
 
     include_accessor_examples "Article"
     include_dup_examples "Article"

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -200,7 +200,7 @@ describe Mobility::Plugins::Backend, type: :plugin do
 
       translations = pluggable.new(my_plugin: 'my_plugin', foo: 'bar')
       expect(translations.options).to eq(backend: [:my_backend, {}], foo: 'bar', my_plugin: 'my_plugin')
-      expect(translations.backend_options).to eq(foo: 'bar', my_plugin: 'my_plugin')
+      expect(translations.backend_options).to eq(backend: [:my_backend, {}], foo: 'bar', my_plugin: 'my_plugin')
 
       expect {
         pluggable.new(my_plugin: 'my_plugin', other: 'other')


### PR DESCRIPTION
Follow up to #499, which isn't working because `options[:cache]` does not include the default `true` option value.

Fixes #490.