### PR TITLE
Require set before referencing Set

### DIFF
--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -1,4 +1,5 @@
 # frozen-string-literal: true
+require "set"
 require "mobility/util"
 require "mobility/backends/sequel"
 require "mobility/backends/key_value"

--- a/lib/mobility/plugin.rb
+++ b/lib/mobility/plugin.rb
@@ -1,5 +1,6 @@
 # frozen-string-literal: true
 require "tsort"
+require "set"
 require "mobility/util"
 
 module Mobility


### PR DESCRIPTION
Tests are failing now for some reason, although they were not before. Anyway we should be requiring `set` before using `Set`, so this is a good thing to do, but still... mysterious.