### PR TITLE
Do not swallow keyword args on ruby 3 in fallthrough accessors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.0'
           - '2.7'
           - '2.6'
         database:
@@ -45,6 +46,10 @@ jobs:
         experimental: [false]
         feature: ['unit']
         include:
+          - ruby: '3.0'
+            feature: 'unit'
+            orm:
+            experimental: false
           - ruby: '2.7'
             feature: 'unit'
             orm:
@@ -57,6 +62,40 @@ jobs:
             feature: 'unit'
             orm:
             experimental: false
+          - ruby: '3.0'
+            feature: 'rails'
+            orm:
+              name: 'active_record'
+              version: '6.1'
+            database: 'sqlite3'
+            experimental: false
+          - ruby: '3.0'
+            feature: 'performance'
+            experimental: false
+          - ruby: '3.0'
+            feature: 'i18n_fallbacks'
+            experimental: false
+          - ruby: '3.0'
+            database: 'sqlite3'
+            feature: 'unit'
+            orm:
+              name: 'active_record'
+              version: '7.0'
+            experimental: true
+          - ruby: '3.0'
+            database: 'mysql'
+            feature: 'unit'
+            orm:
+              name: 'active_record'
+              version: '7.0'
+            experimental: true
+          - ruby: '3.0'
+            database: 'postgres'
+            feature: 'unit'
+            orm:
+              name: 'active_record'
+              version: '7.0'
+            experimental: true
           - ruby: '2.7'
             feature: 'rails'
             orm:
@@ -96,6 +135,22 @@ jobs:
             orm:
               name: 'active_record'
               version: '4.2'
+          - ruby: '3.0'
+            orm:
+              name: 'active_record'
+              version: '4.2'
+          - ruby: '3.0'
+            orm:
+              name: 'active_record'
+              version: '5.0'
+          - ruby: '3.0'
+            orm:
+              name: 'active_record'
+              version: '5.1'
+          - ruby: '3.0'
+            orm:
+              name: 'active_record'
+              version: '5.2'
     env:
       DB: ${{ matrix.database }}
       BUNDLE_JOBS: 4

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -73,6 +73,9 @@ fallbacks plugin, whereas +Post+ uses +Translations+ which does not have that
 plugin enabled.
 
 =end
+
+def ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)
+
 module Mobility
   # A generic exception used by Mobility.
   class Error < StandardError

--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -55,6 +55,13 @@ model class is generated.
           end
         end
 
+        # Following is needed in order to not swallow `kwargs` on ruby >= 3.0.
+        # Otherwise `kwargs` are not passed by `super` to a possible other
+        # `method_missing` defined like this:
+        #
+        # def method_missing(name, *args, **kwargs, &block); end
+        ruby2_keywords :method_missing
+
         define_method :respond_to_missing? do |method_name, include_private = false|
           (method_name =~ method_name_regex) || super(method_name, include_private)
         end

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -40,6 +40,22 @@ describe Mobility::Plugins::FallthroughAccessors, type: :plugin do
       expect(instance.foo(**options)).to eq([options])
     end
 
+    it 'passes kwargs to super when method does not match' do
+      mod = Module.new do
+        def method_missing(method_name, *args, **kwargs, &block)
+          (method_name == :foo) ? [args, kwargs] : super
+        end
+      end
+
+      model_class = Class.new
+      model_class.include translations, mod
+
+      instance = model_class.new
+
+      kwargs = { some: 'params' }
+      expect(instance.foo(**kwargs)).to eq([[], kwargs])
+    end
+
     it 'does not pass on empty keyword options hash to super' do
       mod = Module.new do
         def method_missing(method_name, *args, &block)


### PR DESCRIPTION
If a `method_missing` is defined explicitly with kwargs in own code, for example like this:

```ruby
        def method_missing(method_name, *args, **kwargs, &block)
           ...
        end
```

*and* fallthrough accessors are used, it looks like `kwargs` are swallowed by mobility's definition of `method_missing`.

For now I only added a failing spec to illustrated what I think should happen.

The spec **passes on ruby 2.7** but **fails on ruby 3**.

I'm not sure what the solution is for now.