### PR TITLE
Clearly distinguish backend classes from their configured subclasses

### DIFF
--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -243,7 +243,7 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record, type: :
 
     let(:options) { {} }
     let(:backend_class) do
-      Class.new(described_class) { @model_class = Article }
+      described_class.build_subclass(Article, {})
     end
 
     it "sets association_name" do

--- a/spec/mobility/backends/sequel/table_spec.rb
+++ b/spec/mobility/backends/sequel/table_spec.rb
@@ -148,7 +148,7 @@ describe "Mobility::Backends::Sequel::Table", orm: :sequel, type: :backend do
 
     let(:options) { {} }
     let(:backend_class) do
-      Class.new(described_class) { @model_class = Article }
+      described_class.build_subclass(Article, {})
     end
 
     it "sets association_name" do


### PR DESCRIPTION
In practice, every backend class that is used in a model is a subclass of one of the base classes like `Mobility::Backends::ActiveRecord::KeyValue` etc. Configured backend classes have a model class (points to the class in which the backend is used) and set of options configuring it, whereas the base backend classes do not.

However, previously you could still call `options` or `model_class` on the base classes and you would get back a `nil`. This is confusing since those getter methods should never be called on the base backend classes.

In this commit I'm restructuring the code such that:
- getter methods raise on the base backend class
- methods which do not make sense on the base backend class are moved to a module which is included into backend subclasses.

I think this should avoid weird bugs and misunderstandings.