### PR TITLE
Allow passing configured backend class as third argument to setup

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -21,8 +21,8 @@ On top of this, a backend will normally:
   corresponding to valid keys for configuring this backend.
 - implement a +configure+ class method to apply any normalization to the
   keys on the options hash included in +valid_keys+
-- call the +setup+ method yielding attributes and options to configure the
-  model class
+- call the +setup+ method yielding attributes and options (and optionally the
+  configured backend class) to configure the model class
 
 @example Defining a Backend
   class MyBackend
@@ -47,6 +47,13 @@ On top of this, a backend will normally:
     setup do |attributes, options|
       # Do something with attributes and options in context of model class.
     end
+
+    # The block can optionally take the configured backend class as its third
+    # argument:
+    #
+    # setup do |attributes, options, backend_class|
+    #   ...
+    # end
   end
 
 @see Mobility::Translations

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -173,9 +173,9 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
       setup do |attributes, options, backend_class|
         association_name  = options[:association_name]
         translation_class = options[:class_name]
-        key_column         = options[:key_column]
-        value_column       = options[:value_column]
-        belongs_to         = options[:belongs_to]
+        key_column        = options[:key_column]
+        value_column      = options[:value_column]
+        belongs_to        = options[:belongs_to]
 
         # Track all attributes for this association, so that we can limit the scope
         # of keys for the association to only these attributes. We need to track the

--- a/lib/mobility/backends/active_record/key_value.rb
+++ b/lib/mobility/backends/active_record/key_value.rb
@@ -85,6 +85,7 @@ Implements the {Mobility::Backends::KeyValue} backend for ActiveRecord models.
             autosave:   true
         end
 
+        # Called from setup block. Can be overridden to customize behaviour.
         def define_initialize_dup
           b = self
           module_name = "MobilityArKeyValue#{association_name.to_s.camelcase}"

--- a/lib/mobility/backends/sequel/container.rb
+++ b/lib/mobility/backends/sequel/container.rb
@@ -57,9 +57,7 @@ Implements the {Mobility::Backends::Container} backend for Sequel models.
         end
       end
 
-      backend = self
-
-      setup do |attributes, options|
+      setup do |attributes, options, backend_class|
         column_name = options[:column_name]
         mod = Module.new do
           define_method :before_validation do
@@ -71,7 +69,7 @@ Implements the {Mobility::Backends::Container} backend for Sequel models.
           end
         end
         include mod
-        backend.define_hash_initializer(mod, [column_name])
+        backend_class.define_hash_initializer(mod, [column_name])
 
         plugin :defaults_setter
         attributes.each { |attribute| default_values[attribute.to_sym] = {} }

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -51,6 +51,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
           end
         end
 
+        # Called from setup block. Can be overridden to customize behaviour.
         def define_one_to_many_association(attributes)
           belongs_to_id     = :"#{belongs_to}_id"
           belongs_to_type   = :"#{belongs_to}_type"
@@ -75,6 +76,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
             class:           class_name
         end
 
+        # Called from setup block. Can be overridden to customize behaviour.
         def define_save_callbacks(attributes)
           b = self
           callback_methods = Module.new do

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -180,19 +180,13 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
 
       backend = self
 
-      setup do |attributes, options, backend_class|
-        association_name  = options[:association_name]
-        translation_class = options[:class_name]
-        key_column        = options[:key_column]
-        value_column      = options[:value_column]
-        belongs_to        = options[:belongs_to]
-
+      setup do |attributes, _options, backend_class|
         backend_class.define_one_to_many_association(attributes)
         backend_class.define_save_callbacks(attributes)
         backend_class.define_after_destroy_callback
 
         include(mod = Module.new)
-        backend.define_column_changes(mod, attributes)
+        backend_class.define_column_changes(mod, attributes)
       end
 
       # Returns translation for a given locale, or initializes one if none is present.

--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -178,8 +178,6 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
         end
       end
 
-      backend = self
-
       setup do |attributes, _options, backend_class|
         backend_class.define_one_to_many_association(attributes)
         backend_class.define_save_callbacks(attributes)

--- a/lib/mobility/backends/sequel/pg_hash.rb
+++ b/lib/mobility/backends/sequel/pg_hash.rb
@@ -33,9 +33,7 @@ jsonb).
           model[column_name.to_sym]
         end
 
-        backend = self
-
-        setup do |attributes, options|
+        setup do |attributes, options, backend_class|
           columns = attributes.map { |attribute| (options[:column_affix] % attribute).to_sym }
 
           mod = Module.new do
@@ -47,8 +45,8 @@ jsonb).
             end
           end
           include mod
-          backend.define_hash_initializer(mod, columns)
-          backend.define_column_changes(mod, attributes, column_affix: options[:column_affix])
+          backend_class.define_hash_initializer(mod, columns)
+          backend_class.define_column_changes(mod, attributes, column_affix: options[:column_affix])
 
           plugin :defaults_setter
           columns.each { |column| default_values[column] = {} }

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -116,9 +116,7 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
         end
       end
 
-      backend = self
-
-      setup do |attributes, options|
+      setup do |attributes, options, backend_class|
         association_name = options[:association_name]
         subclass_name    = options[:subclass_name]
 
@@ -155,7 +153,7 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
         include callback_methods
 
         include(mod = Module.new)
-        backend.define_column_changes(mod, attributes)
+        backend_class.define_column_changes(mod, attributes)
       end
 
       def translation_for(locale, **)

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -106,9 +106,9 @@ describe Mobility::Backend do
     end
 
     describe ".setup" do
-      before do
-        backend_class.class_eval do
-          setup do |attributes, options|
+      context "with two block arguments" do
+        before do
+          backend_class.setup do |attributes, options|
             def self.foo
               "foo"
             end
@@ -123,32 +123,30 @@ describe Mobility::Backend do
             end
           end
         end
-      end
 
-      it "stores setup as block which is called in model class" do
-        model_class = Class.new
-        backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title"])
-        expect(model_class.foo).to eq("foo")
-        expect(model_class.new.bar).to eq("bar")
-      end
+        it "stores setup as block which is called in model class" do
+          model_class = Class.new
+          backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title"])
+          expect(model_class.foo).to eq("foo")
+          expect(model_class.new.bar).to eq("bar")
+        end
 
-      it "passes attributes and options to setup block when called on class" do
-        model_class = Class.new
-        backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title"])
-        expect(model_class.new.my_attributes).to eq(["title"])
-        expect(model_class.new.my_options).to eq({ foo: "bar" })
-      end
+        it "passes attributes and options to setup block when called on class" do
+          model_class = Class.new
+          backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title"])
+          expect(model_class.new.my_attributes).to eq(["title"])
+          expect(model_class.new.my_options).to eq({ foo: "bar" })
+        end
 
-      it "assigns setup block to descendants" do
-        model_class = Class.new
-        subclass = backend_class.build_subclass(model_class, foo: "bar")
-        subclass.setup_model(model_class, ["title"])
-        expect(model_class.foo).to eq("foo")
-      end
+        it "assigns setup block to descendants" do
+          model_class = Class.new
+          subclass = backend_class.build_subclass(model_class, foo: "bar")
+          subclass.setup_model(model_class, ["title"])
+          expect(model_class.foo).to eq("foo")
+        end
 
-      it "concatenates blocks when called multiple times" do
-        backend_class.class_eval do
-          setup do |attributes, options|
+        it "concatenates blocks when called multiple times" do
+          backend_class.setup do |attributes, options|
             def self.foo
               "foo2"
             end
@@ -159,14 +157,61 @@ describe Mobility::Backend do
               "foobar"
             end
           end
-        end
-        model_class = Class.new
-        backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title", "content"])
+          model_class = Class.new
+          backend_class.build_subclass(model_class, foo: "bar").setup_model(model_class, ["title", "content"])
 
-        aggregate_failures do
-          expect(model_class.foo).to eq("foo2")
-          expect(model_class.new.baz).to eq("titlecontent baz")
-          expect(model_class.foobar).to eq("foobar")
+          aggregate_failures do
+            expect(model_class.foo).to eq("foo2")
+            expect(model_class.new.baz).to eq("titlecontent baz")
+            expect(model_class.foobar).to eq("foobar")
+          end
+        end
+      end
+
+      context "with 3 block arguments" do
+        before do
+          backend_class.setup do |attributes, options, klass|
+            define_method :my_attributes do
+              attributes
+            end
+            define_method :my_options do
+              options
+            end
+            define_method :my_backend_class do
+              klass
+            end
+          end
+        end
+
+        it "passes configured backend class as third argument" do
+          model_class = Class.new
+          configured_backend_class = backend_class.build_subclass(model_class, foo: "bar")
+          configured_backend_class.setup_model(model_class, ["title"])
+
+          model = model_class.new
+
+          expect(model.my_attributes).to eq(["title"])
+          expect(model.my_options).to eq({ foo: "bar" })
+          expect(model.my_backend_class).to eq(configured_backend_class)
+        end
+
+        it "works with block concatenation" do
+          backend_class.setup do |attributes, options|
+            define_method :my_attributes_2 do
+              attributes
+            end
+          end
+          model_class = Class.new
+          configured_backend_class = backend_class.build_subclass(model_class, foo: "bar")
+          configured_backend_class.setup_model(model_class, ["title"])
+
+          model = model_class.new
+
+          aggregate_failures do
+            expect(model.my_attributes).to eq(["title"])
+            expect(model.my_options).to eq({ foo: "bar" })
+            expect(model.my_backend_class).to eq(configured_backend_class)
+          end
         end
       end
     end


### PR DESCRIPTION
Refactoring the `setup` block in backend classes can be difficult because the local context in the block is the model class, and we don't want to dump methods there.

This PR makes the `setup` block accept an optional third argument, the configured backend class, which can then be the receiver for method calls to extract common logic (or customizable logic) out of the `setup` block. An immediate use case for this is #525.