### PR TITLE
Fix Sequel querying on untranslated attributes in `i18n` block

### DIFF
--- a/lib/mobility/backends/sequel/key_value.rb
+++ b/lib/mobility/backends/sequel/key_value.rb
@@ -131,7 +131,7 @@ Implements the {Mobility::Backends::KeyValue} backend for Sequel models.
             visit_sql_identifier(predicate, locale)
           when ::Sequel::SQL::BooleanExpression
             visit_boolean(predicate, locale)
-          when ::Sequel::SQL::Expression
+          when ::Sequel::SQL::ComplexExpression
             visit(predicate.args, locale)
           else
             {}

--- a/lib/mobility/backends/sequel/table.rb
+++ b/lib/mobility/backends/sequel/table.rb
@@ -84,7 +84,7 @@ Implements the {Mobility::Backends::Table} backend for Sequel models.
             visit_sql_identifier(predicate, locale)
           when ::Sequel::SQL::BooleanExpression
             visit_boolean(predicate, locale)
-          when ::Sequel::SQL::Expression
+          when ::Sequel::SQL::ComplexExpression
             visit(predicate.args, locale)
           else
             nil

--- a/lib/mobility/plugins/sequel/query.rb
+++ b/lib/mobility/plugins/sequel/query.rb
@@ -61,7 +61,7 @@ ActiveRecord query plugin.
               locale = args[0] || @global_locale
               @locales |= [locale]
               @model_class.mobility_backend_class(m).build_op(m.to_s, locale)
-            elsif @model_class.columns.include?(m.to_s)
+            elsif @model_class.columns.include?(m)
               ::Sequel::SQL::QualifiedIdentifier.new(@model_class.table_name, m)
             else
               super

--- a/spec/integration/sequel_compatibility_spec.rb
+++ b/spec/integration/sequel_compatibility_spec.rb
@@ -2,4 +2,44 @@ require "spec_helper"
 
 #TODO: Add general compatibility specs for Sequel
 describe "Sequel compatibility", orm: :sequel do
+  include Helpers::Plugins
+  include Helpers::Translates
+  # Enable all plugins that are enabled by default pre v1.0
+  plugins :sequel, :reader, :writer, :cache, :dirty, :presence, :query, :fallbacks
+
+  before do
+    stub_const 'Article', Class.new(Sequel::Model)
+    Article.dataset = DB[:articles]
+    Article
+  end
+
+  describe "querying on translated and untranslated attributes" do
+    %i[key_value table].each do |backend|
+      #TODO: update querying examples to correctly test untranslated attributes
+      context "#{backend} backend" do
+        before do
+          options = { backend: backend, fallbacks: false }
+          options[:type] = :string if backend == :key_value
+          translates Article, :title, **options
+        end
+        let!(:article1) { Article.create(title: "foo", slug: "bar") }
+        let!(:article2) { Article.create(              slug: "baz") }
+        let!(:article4) { Article.create(title: "foo"             ) }
+
+        it "works with hash arguments" do
+          expect(Article.i18n.where(title: "foo", slug: "bar").select_all(:articles).all).to eq([article1])
+          expect(Article.i18n.where(title: "foo"             ).select_all(:articles).all).to match_array([article1, article4])
+          expect(Article.i18n.where(title: "foo", slug: "baz").select_all(:articles).all).to eq([])
+          expect(Article.i18n.where(              slug: "baz").select_all(:articles).all).to match_array([article2])
+        end
+
+        it "works with virtual rows" do
+          expect(Article.i18n { (title =~ "foo") & (slug =~ "bar") }.select_all(:articles).all).to eq([article1])
+          expect(Article.i18n { (title =~ "foo")                   }.select_all(:articles).all).to match_array([article1, article4])
+          expect(Article.i18n { (title =~ "foo") & (slug =~ "baz") }.select_all(:articles).all).to eq([])
+          expect(Article.i18n {                    (slug =~ "baz") }.select_all(:articles).all).to eq([article2])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I noticed this wasn't working correctly while working on another PR. Once tests pass I'l ship this as 1.1.4.