### PR TITLE
Make models work with `Marshal.dump` (take two)

### DIFF
--- a/lib/mobility/backend.rb
+++ b/lib/mobility/backend.rb
@@ -77,6 +77,12 @@ On top of this, a backend will normally:
       @attribute = args[1]
     end
 
+    def ==(backend)
+      backend.class == self.class &&
+        backend.attribute == attribute &&
+        backend.model == model
+    end
+
     # @!macro [new] backend_reader
     #   Gets the translated value for provided locale from configured backend.
     #   @param [Symbol] locale Locale to read

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -114,15 +114,25 @@ Defines:
         defaults[key] = [backend, backend_options] if backend
       end
 
+      class MobilityBackends < Hash
+        def initialize(model)
+          @model = model
+          super()
+        end
+
+        def [](name)
+          return fetch(name) if has_key?(name)
+          return self[name.to_sym] if String === name
+          self[name] = @model.class.mobility_backend_class(name).new(@model, name.to_s)
+        end
+      end
+
       module InstanceMethods
         # Return a new backend for an attribute name.
         # @return [Hash] Hash of attribute names and backend instances
         # @api private
         def mobility_backends
-          @mobility_backends ||= ::Hash.new do |hash, name|
-            next hash[name.to_sym] if String === name
-            hash[name] = self.class.mobility_backend_class(name).new(self, name.to_s)
-          end
+          @mobility_backends ||= MobilityBackends.new(self)
         end
 
         def initialize_dup(other)

--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -125,6 +125,14 @@ Defines:
           return self[name.to_sym] if String === name
           self[name] = @model.class.mobility_backend_class(name).new(@model, name.to_s)
         end
+
+        def marshal_dump
+          @model
+        end
+
+        def marshal_load(model)
+          @model = model
+        end
       end
 
       module InstanceMethods

--- a/spec/mobility/backend_spec.rb
+++ b/spec/mobility/backend_spec.rb
@@ -43,6 +43,24 @@ describe Mobility::Backend do
       end
     end
 
+    describe "#==" do
+      it "returns true if two backends have the same class, model and attributes" do
+        expect(backend_class.new(model, attribute)).to eq(backend)
+      end
+
+      it "returns false if backends have different classes" do
+        expect(Class.new(backend_class).new(model, attribute)).not_to eq(backend)
+      end
+
+      it "returns false if backends have different attributes" do
+        expect(backend_class.new(model, "foo")).not_to eq(backend)
+      end
+
+      it "returns false if backends have different models" do
+        expect(backend_class.new(double(:other_model), attribute)).not_to eq(backend)
+      end
+    end
+
     describe "#each" do
       it "returns nothing by default" do
         backend = backend_class.new(model, attribute)

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -170,6 +170,22 @@ describe Mobility::Plugins::Backend, type: :plugin do
 
         expect(other.mobility_backends[:title]).not_to eq(article.mobility_backends[:title])
       end
+
+      # regression test for https://github.com/shioyama/mobility/issues/494
+      it "does not prevent Marshal from working" do
+        mod = translations_class.new("title", backend: :null)
+        stub_const('Article', model_class)
+        model_class.include mod
+
+        article = model_class.new
+        article.mobility_backends[:title]
+        expect {
+          expect(serialized = Marshal.dump(article)).not_to be_nil
+          expect(deserialized = Marshal.load(serialized)).not_to be_nil
+
+          expect(deserialized.mobility_backends[:title]).to be_a(Mobility::Backends::Null)
+        }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Replaces #505

~I figured out how to avoid an md5 digest or other hack when naming configured backends. Basically, we don't name them based on their attributes but instead on the attribute names in the model that the backend class is created for. This is cleaner and means the backend class name is directly readable, so less unintuitive.~

~I've also assigned the name to a namespace under the backend class itself, rather than off of the root namespace. This way the name only has to incorporate the model name and attribute name(s).~

_Update: I simplified this by just avoiding dumping the backends at all (by defining `marshal_dump` and `marshal_load`), which gets around the problem entirely._