### PR TITLE
fix passing wrong options to super in fallbacks plugin

### DIFF
--- a/lib/mobility/plugins/fallbacks.rb
+++ b/lib/mobility/plugins/fallbacks.rb
@@ -137,16 +137,16 @@ the current locale was +nil+.
       end
 
       module BackendInstanceMethods
-        def read(locale, fallback: true, **accessor_options)
-          return super(locale, **options) if !fallback || accessor_options[:locale]
+        def read(locale, fallback: true, **kwargs)
+          return super(locale, **kwargs) if !fallback || kwargs[:locale]
 
           locales = fallback == true ? fallbacks[locale] : [locale, *fallback]
           locales.each do |fallback_locale|
-            value = super(fallback_locale, **accessor_options)
+            value = super(fallback_locale, **kwargs)
             return value if Util.present?(value)
           end
 
-          super(locale, **options)
+          super(locale, **kwargs)
         end
 
         private


### PR DESCRIPTION
`accessor_options` should be passed. I think this got mixed up when the plugin was refactored.

FYI: I got a "cannot modify frozen hash" error, because if chained with other plugins like `default` they try to delete the option, which is not possible because `options` (the global one) is frozen. This only happened on ruby 3.0.2 though, 2.7.4 is fine even without this commit 🤷 