### PR TITLE
instance variables will not get shared with subclasses, such as when …

### DIFF
--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -161,14 +161,14 @@ Defines:
 
         def inherited(klass)
           parent_classes = mobility_backend_classes.freeze # ensure backend classes are not modified after being inherited
-          klass.class_eval { @mobility_backend_classes = parent_classes.dup }
+          klass.class_eval { @@mobility_backend_classes = parent_classes.dup }
           super
         end
 
         protected
 
         def mobility_backend_classes
-          @mobility_backend_classes ||= {}
+          @@mobility_backend_classes ||= {}
         end
       end
 


### PR DESCRIPTION
…using ActiveRecord STI. this will break the functionality in all subclasses, as their @mobility_backend_classes will be empty. fix by using class variables, which are shared between subclasses.