### PR TITLE
Fix issues with subclassing, such as when using ActiveRecord STI.

### DIFF
--- a/lib/mobility/plugins/backend.rb
+++ b/lib/mobility/plugins/backend.rb
@@ -159,16 +159,22 @@ Defines:
           raise KeyError, "No backend for: #{name}"
         end
 
-        def inherited(klass)
-          parent_classes = mobility_backend_classes.freeze # ensure backend classes are not modified after being inherited
-          klass.class_eval { @mobility_backend_classes = parent_classes.dup }
-          super
-        end
-
         protected
 
         def mobility_backend_classes
-          @mobility_backend_classes ||= {}
+          if @mobility_backend_classes
+            @mobility_backend_classes
+          else
+            @mobility_backend_classes = {}
+            parent_class = self.superclass
+            while parent_class&.respond_to?(:mobility_backend_classes, true)
+              # ensure backend classes are not modified after being inherited
+              parent_class_classes = parent_class.mobility_backend_classes.freeze
+              @mobility_backend_classes.merge!(parent_class_classes)
+              parent_class = parent_class.superclass
+            end
+            @mobility_backend_classes
+          end
         end
       end
 

--- a/spec/mobility/plugins/backend_spec.rb
+++ b/spec/mobility/plugins/backend_spec.rb
@@ -112,9 +112,30 @@ describe Mobility::Plugins::Backend, type: :plugin do
         mod1 = translations_class.new("title", backend: backend_class_1)
         model_class.include mod1
 
-        Class.new(model_class)
+        # accessing mobility_backend_classes necessary to trigger parent freeze
+        Class.new(model_class).send(:mobility_backend_classes)
 
         expect(model_class.send(:mobility_backend_classes)).to be_frozen
+      end
+
+      it "works with subclasses of subclasses" do
+        backend_class_1 = Class.new
+        backend_class_1.include Mobility::Backend
+
+        model_subclass = Class.new(model_class)
+        model_subclass_2 = Class.new(model_subclass)
+
+        # we specifically include translations after subclassing
+        mod1 = translations_class.new("title", backend: backend_class_1)
+        model_class.include mod1
+
+        title_backend_class_1 = model_class.mobility_backend_class("title")
+        title_backend_class_2 = model_subclass.mobility_backend_class("title")
+        title_backend_class_3 = model_subclass_2.mobility_backend_class("title")
+
+        expect(title_backend_class_1).to be <(backend_class_1)
+        expect(title_backend_class_2).to be <(backend_class_1)
+        expect(title_backend_class_3).to be <(backend_class_1)
       end
     end
 


### PR DESCRIPTION
Fixes mobility to work if subclassing a subclass of a mobility-enabled class, and looks up mobility_backend_classes later in execution (upon being called) to be more flexible.

fixes #566 