### PR TITLE
Fix reader creation

### DIFF
--- a/lib/mobility/backends/table.rb
+++ b/lib/mobility/backends/table.rb
@@ -85,7 +85,8 @@ set.
       # @!group Backend Accessors
       # @!macro backend_reader
       def read(locale, **options)
-        translation_for(locale, **options).send(attribute)
+        translation = translations.in_locale(locale)
+        translation.send(attribute) if translation
       end
 
       # @!macro backend_writer

--- a/spec/mobility/backends/active_record/table_spec.rb
+++ b/spec/mobility/backends/active_record/table_spec.rb
@@ -109,6 +109,20 @@ describe "Mobility::Backends::ActiveRecord::Table", orm: :active_record, type: :
         end
       end
 
+      it "does not prevent saving when a nil translation is generated and invalid" do
+        Article::Translation.validates :title, presence: true
+
+        Mobility.locale = :en
+        article = Article.new(title: "New Article")
+        expect(article.save).to eq(true)
+
+        Mobility.locale = :ja
+        article.title
+
+        Mobility.locale = :en
+        expect(article.save).to eq(true)
+      end
+
       it "removes nil translations when saving persisted record" do
         Mobility.locale = :en
         article = Article.create(title: "New Article")


### PR DESCRIPTION
To me this seems not to break anything and fixes #569

Please note I did not update existing specs that explicitly test that translations have been created on read, which is now not the case so they are failing. However I do not see any reason for attr reader to build translations on parent.