### PR TITLE
Update fallthrough_accessor regex to allow for ISO 639-2 codes (1-2 branch)

### DIFF
--- a/lib/mobility/plugins/fallthrough_accessors.rb
+++ b/lib/mobility/plugins/fallthrough_accessors.rb
@@ -36,7 +36,7 @@ model class is generated.
       private
 
       def define_fallthrough_accessors(*names)
-        method_name_regex = /\A(#{names.join('|')})_([a-z]{2}(_[a-z]{2})?)(=?|\??)\z/.freeze
+        method_name_regex = /\A(#{names.join('|')})_([a-z]{2,3}(_[a-z]{2})?)(=?|\??)\z/.freeze
 
         define_method :method_missing do |method_name, *args, &block|
           if method_name =~ method_name_regex

--- a/spec/mobility/plugins/fallthrough_accessors_spec.rb
+++ b/spec/mobility/plugins/fallthrough_accessors_spec.rb
@@ -22,7 +22,7 @@ describe Mobility::Plugins::FallthroughAccessors, type: :plugin do
     it_behaves_like "locale accessor", :title, 'en'
     it_behaves_like "locale accessor", :title, 'de'
     it_behaves_like "locale accessor", :title, 'pt-BR'
-    it_behaves_like "locale accessor", :title, 'ru'
+    it_behaves_like "locale accessor", :title, 'rus'
 
     it 'passes arguments and options to super when method does not match' do
       mod = Module.new do


### PR DESCRIPTION
https://github.com/shioyama/mobility/pull/580 for 1-2 branch.