### PR TITLE
Fix rails7 default scope issue with select

### DIFF
--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -137,6 +137,8 @@ enabled for any one attribute on the model.
           end
 
           def order(opts, *rest)
+            return super unless @klass.respond_to?(:mobility_attribute?)
+
             case opts
             when Symbol, String
               @klass.mobility_attribute?(opts) ? order({ opts => :asc }, *rest) : super
@@ -160,6 +162,8 @@ enabled for any one attribute on the model.
             %w[pluck group select].each do |method_name|
               define_method method_name do |*attrs, &block|
                 return super(*attrs, &block) if (method_name == 'select' && block.present?)
+
+                return super(*attrs, &block) unless @klass.respond_to?(:mobility_attribute?)
 
                 return super(*attrs, &block) unless attrs.any?(&@klass.method(:mobility_attribute?))
 

--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -137,8 +137,6 @@ enabled for any one attribute on the model.
           end
 
           def order(opts, *rest)
-            return super unless @klass.respond_to?(:mobility_attribute?)
-
             case opts
             when Symbol, String
               @klass.mobility_attribute?(opts) ? order({ opts => :asc }, *rest) : super
@@ -163,9 +161,6 @@ enabled for any one attribute on the model.
               define_method method_name do |*attrs, &block|
                 return super(*attrs, &block) if (method_name == 'select' && block.present?)
 
-                if ::ActiveRecord::VERSION::STRING < '7.0'
-                  return super(*attrs, &block) unless @klass.respond_to?(:mobility_attribute?)
-                end
                 return super(*attrs, &block) unless attrs.any?(&@klass.method(:mobility_attribute?))
 
                 keys = attrs.dup


### PR DESCRIPTION
We did not investigate too much but after upgrading to rails 7 we had issues when using `default_scope { I18n }` coupled with active record select method.

This PR seems to fix it but feel free to change and or add tests for other use cases. 

This seems to fix issues described in #513 back in the days