### PR TITLE
Add column_fallback to Mobility initializer

### DIFF
--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -58,6 +58,19 @@ Mobility.configure do
     # Or uncomment this line to include but disable by default, and only enable
     # per model by passing +dirty: true+ to +translates+.
     # dirty false
+    
+    # Column Fallback
+    #
+    # Uncomment line below to fallback to original column. You can pass
+    # +column_fallback: true+ to +translates+ to return original column on
+    # default locale, or pass +column_fallback: [:en, :de]+ to +translates+
+    # to return original column for those locales or pass
+    # +column_fallback: ->(locale) { ... }+ to +translates to evaluate which
+    # locales to return original column for.
+    # column_fallback
+    #
+    # Or uncomment this line to enable column fallback with a global default.
+    # column_fallback true
 
     # Fallbacks
     #


### PR DESCRIPTION
This feature was implemented in 1.2 but I had to read the PR to understand how to use it. Thought I'd add it into the default initializer.