### PR TITLE
Make translatable references not nullable in rails migration generators

### DIFF
--- a/lib/rails/generators/mobility/templates/create_string_translations.rb
+++ b/lib/rails/generators/mobility/templates/create_string_translations.rb
@@ -4,7 +4,7 @@ class CreateStringTranslations < <%= activerecord_migration_class %>
       t.string :locale, null: false
       t.string :key, null: false
       t.string :value
-      t.references :translatable, polymorphic: true, index: false
+      t.references :translatable, polymorphic: true, index: false, null: false
       t.timestamps null: false
     end
     add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys

--- a/lib/rails/generators/mobility/templates/create_text_translations.rb
+++ b/lib/rails/generators/mobility/templates/create_text_translations.rb
@@ -4,7 +4,7 @@ class CreateTextTranslations < <%= activerecord_migration_class %>
       t.string :locale, null: false
       t.string :key,    null: false
       t.text :value
-      t.references :translatable, polymorphic: true, index: false
+      t.references :translatable, polymorphic: true, index: false, null: false
       t.timestamps null: false
     end
     add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys


### PR DESCRIPTION
Make translatable_id + translatable_type not nullable in rails migration generators