### PR TITLE
add writer plugin type checking option

### DIFF
--- a/spec/mobility/plugins/writer_spec.rb
+++ b/spec/mobility/plugins/writer_spec.rb
@@ -50,5 +50,29 @@ describe Mobility::Plugins::Writer, type: :plugin do
       expect(instance.send(:title=, 'foo', super: true)).to eq("set title to foo")
     end
   end
+
+  describe "type checking" do
+    plugin_setup :title, writer: { type: :integer }
+
+    let(:instance) { model_class.new }
+
+    it "correctly maps setter method for translated attribute to backend if correct type given" do
+      expect(Mobility).to receive(:locale).and_return(:de)
+      expect(listener).to receive(:write).with(:de, 1, any_args)
+      expect(instance.title = 1).to eq(1)
+    end
+
+    it "correctly maps setter method for translated attribute to backend if nil given" do
+      expect(Mobility).to receive(:locale).and_return(:de)
+      expect(listener).to receive(:write).with(:de, nil, any_args)
+      expect(instance.title = nil).to eq(nil)
+    end
+
+    it "raises Mobility::Plugins::Writer::TypeError if wrong type given" do
+      expect {
+        instance.send(:title=, 'foo', locale: :ru)
+      }.to raise_error(Mobility::Plugins::Writer::TypeError, "title= called with string, integer expected")
+    end
+  end
 end
 


### PR DESCRIPTION
Hello! 

Some time ago I have discovered an issue with one of my job rails project. It was translated with Mobility using Postgres jsonb backend. So one of model attributes was used as one type in some places and different in another. And it was hard to figure out what type it was originally 😬 

I thought if with jsonb we losing traditional active record type castings and sql checkings why dont to add some basic checkings on library level? Of course it would be nice if my specific problem was prevented by properly testing or `.rbs` annotations or even just human comment after `translates` expression... but it was't. And I guess not only in my project.

So I decided to propose you type checking feature in writer plugin. I think this tiny but intelligent option will encourage developers to make them models more safely, explicit and reliable. Even when they can't for some reason write tests and types annotations :)  