### PR TITLE
Add attribute_names support to attribute_methods plugin

### DIFF
--- a/lib/mobility/plugins/attribute_methods.rb
+++ b/lib/mobility/plugins/attribute_methods.rb
@@ -31,6 +31,7 @@ attributes only.
       included_hook do
         if options[:attribute_methods]
           define_method :untranslated_attributes, ::ActiveRecord::Base.instance_method(:attributes)
+          define_method :untranslated_attribute_names, ::ActiveRecord::Base.instance_method(:attribute_names)
         end
       end
 
@@ -41,6 +42,10 @@ attributes only.
 
         def attributes
           super.merge(translated_attributes)
+        end
+
+        def attribute_names
+          super.concat(translated_attributes.keys)
         end
       end
     end

--- a/spec/mobility/plugins/attribute_methods_spec.rb
+++ b/spec/mobility/plugins/attribute_methods_spec.rb
@@ -43,4 +43,17 @@ describe Mobility::Plugins::AttributeMethods, orm: :active_record, type: :plugin
       expect(instance.untranslated_attributes).to eq(untranslated_attributes)
     end
   end
+
+  describe "#attribute_names" do
+    it "adds translated attribute names to normal attribute names" do
+      expect(backend).to receive(:read).once.with(Mobility.locale, any_args).and_return('foo')
+      expect(instance.attribute_names).to eq(untranslated_attributes.keys.concat(['title']))
+    end
+  end
+
+  describe "#untranslated_attribute_names" do
+    it "adds translated attribute names to normal attribute names" do
+      expect(instance.untranslated_attribute_names).to eq(untranslated_attributes.keys)
+    end
+  end
 end


### PR DESCRIPTION
Thank you great gem ❤️ 

I want to use attribute_names.
And I think good location that this definition is located attribute_methods plugin.

What do you think?