### PR TITLE
Tolerate string availalbe locales to resolve shioyama/mobility#605

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### (unreleased)
 
 - Allow `I18n.available_locales` to contain Strings
-  ([#605](https://github.com/shioyama/mobility/issues/605))
+  ([#612](https://github.com/shioyama/mobility/pull/612))
 
 ### 1.3.0.rc1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.3
 
+### (unreleased)
+
+- Allow `I18n.available_locales` to contain Strings
+  ([#605](https://github.com/shioyama/mobility/issues/605))
+
 ### 1.3.0.rc1
 
 This version includes potentially breaking chnages for jsonb and hstore

--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -228,9 +228,9 @@ module Mobility
     #   methods (in LocaleAccessors) than is really necessary.
     def available_locales
       if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
-        Rails.application.config.i18n.available_locales&.map(&:to_sym) || I18n.available_locales
+        Rails.application.config.i18n.available_locales&.map(&:to_sym) || I18n.available_locales.map(&:to_sym)
       else
-        I18n.available_locales
+        I18n.available_locales.map(&:to_sym)
       end
     end
 


### PR DESCRIPTION
This feature converts string keys in `I18n.available_locales` to symbol, solving https://github.com/shioyama/mobility/issues/605