### PR TITLE
MySQL JSON backend

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,13 +40,13 @@ namespace :db do
   desc "Set up the database schema"
   task up: :setup do
     orm = ENV['ORM']
-    return unless orm
-
-    require orm
-    require "database"
-    DB = Mobility::Test::Database.connect(orm)
-    require "#{orm}/schema"
-    Mobility::Test::Schema.up
+    if orm
+      require orm
+      require "database"
+      DB = Mobility::Test::Database.connect(orm)
+      require "#{orm}/schema"
+      Mobility::Test::Schema.up
+    end
   end
 
   desc "Drop and recreate the database schema"

--- a/lib/mobility/backends/active_record/db_hash.rb
+++ b/lib/mobility/backends/active_record/db_hash.rb
@@ -11,7 +11,7 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
 
 =end
     module ActiveRecord
-      class PgHash
+      class DbHash
         include ActiveRecord
         include HashValued
 
@@ -36,7 +36,7 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
           model[column_name]
         end
       end
-      private_constant :PgHash
+      private_constant :DbHash
     end
   end
 end

--- a/lib/mobility/backends/active_record/db_hash.rb
+++ b/lib/mobility/backends/active_record/db_hash.rb
@@ -33,6 +33,7 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
         end
 
         def translations
+          model[column_name] ||= {}
           model[column_name]
         end
       end

--- a/lib/mobility/backends/active_record/hstore.rb
+++ b/lib/mobility/backends/active_record/hstore.rb
@@ -1,4 +1,4 @@
-require 'mobility/backends/active_record/pg_hash'
+require 'mobility/backends/active_record/db_hash'
 require 'mobility/plugins/arel/nodes/pg_ops'
 
 module Mobility
@@ -11,7 +11,7 @@ Implements the {Mobility::Backends::Hstore} backend for ActiveRecord models.
 
 =end
     module ActiveRecord
-      class Hstore < PgHash
+      class Hstore < DbHash
         # @!group Backend Accessors
         # @!macro backend_reader
         # @!method read(locale, options = {})

--- a/lib/mobility/backends/active_record/json.rb
+++ b/lib/mobility/backends/active_record/json.rb
@@ -1,4 +1,4 @@
-require 'mobility/backends/active_record/pg_hash'
+require 'mobility/backends/active_record/db_hash'
 require 'mobility/plugins/arel/nodes/pg_ops'
 
 module Mobility
@@ -11,7 +11,7 @@ Implements the {Mobility::Backends::Json} backend for ActiveRecord models.
 
 =end
     module ActiveRecord
-      class Json < PgHash
+      class Json < DbHash
         # @!group Backend Accessors
         #
         # @!method read(locale, **options)

--- a/lib/mobility/backends/active_record/json.rb
+++ b/lib/mobility/backends/active_record/json.rb
@@ -1,5 +1,5 @@
 require 'mobility/backends/active_record/db_hash'
-require 'mobility/plugins/arel/nodes/pg_ops'
+require 'mobility/plugins/arel/nodes/json_ops'
 
 module Mobility
   module Backends

--- a/lib/mobility/backends/active_record/jsonb.rb
+++ b/lib/mobility/backends/active_record/jsonb.rb
@@ -1,4 +1,4 @@
-require 'mobility/backends/active_record/pg_hash'
+require 'mobility/backends/active_record/db_hash'
 require 'mobility/plugins/arel/nodes/pg_ops'
 
 module Mobility
@@ -11,7 +11,7 @@ Implements the {Mobility::Backends::Jsonb} backend for ActiveRecord models.
 
 =end
     module ActiveRecord
-      class Jsonb < PgHash
+      class Jsonb < DbHash
         # @!group Backend Accessors
         #
         # @!method read(locale, **options)

--- a/lib/mobility/backends/sequel/db_hash.rb
+++ b/lib/mobility/backends/sequel/db_hash.rb
@@ -12,7 +12,7 @@ jsonb).
 
 =end
     module Sequel
-      class PgHash
+      class DbHash
         include Sequel
         include HashValued
 
@@ -52,7 +52,7 @@ jsonb).
           columns.each { |column| default_values[column] = {} }
         end
       end
-      private_constant :PgHash
+      private_constant :DbHash
     end
   end
 end

--- a/lib/mobility/backends/sequel/hstore.rb
+++ b/lib/mobility/backends/sequel/hstore.rb
@@ -1,4 +1,4 @@
-require 'mobility/backends/sequel/pg_hash'
+require 'mobility/backends/sequel/db_hash'
 
 Sequel.extension :pg_hstore, :pg_hstore_ops
 
@@ -12,7 +12,7 @@ Implements the {Mobility::Backends::Hstore} backend for Sequel models.
 
 =end
     module Sequel
-      class Hstore < PgHash
+      class Hstore < DbHash
         # @!group Backend Accessors
         # @!macro backend_reader
         # @!method read(locale, options = {})

--- a/lib/mobility/backends/sequel/json.rb
+++ b/lib/mobility/backends/sequel/json.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'mobility/backends/sequel/pg_hash'
+require 'mobility/backends/sequel/db_hash'
 
 Sequel.extension :pg_json, :pg_json_ops
 
@@ -13,7 +13,7 @@ Implements the {Mobility::Backends::Json} backend for Sequel models.
 
 =end
     module Sequel
-      class Json < PgHash
+      class Json < DbHash
         # @!group Backend Accessors
         #
         # @!method read(locale, options = {})

--- a/lib/mobility/backends/sequel/jsonb.rb
+++ b/lib/mobility/backends/sequel/jsonb.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'mobility/backends/sequel/pg_hash'
+require 'mobility/backends/sequel/db_hash'
 
 Sequel.extension :pg_json, :pg_json_ops
 
@@ -13,7 +13,7 @@ Implements the {Mobility::Backends::Jsonb} backend for Sequel models.
 
 =end
     module Sequel
-      class Jsonb < PgHash
+      class Jsonb < DbHash
         # @!group Backend Accessors
         #
         # @!method read(locale, **options)

--- a/lib/mobility/plugins/arel/nodes/json_ops.rb
+++ b/lib/mobility/plugins/arel/nodes/json_ops.rb
@@ -46,9 +46,31 @@ module Mobility
             visit(Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right)), a)
           end
         end
+
+        module MySQL
+          def visit_Mobility_Plugins_Arel_Nodes_JsonDashArrow o, a
+            json_infix o, a, '->'
+          end
+
+          def visit_Mobility_Plugins_Arel_Nodes_JsonDashDoubleArrow o, a
+            # for MySQL we need to re-quote the JSON key name, otherwise it will break on keys like `pt-BR`
+            # https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_json-inline-path
+            unless o.right.value.to_s.start_with?('$.')
+              o.right = o.right.class.new(%Q($."#{o.right.value}"))
+            end
+            json_infix o, a, '->>'
+          end
+
+          private
+
+          def json_infix o, a, opr
+            visit(Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right)), a)
+          end
+        end
       end
 
       ::Arel::Visitors::PostgreSQL.include Visitors::PostgreSQL
+      ::Arel::Visitors::MySQL.include Visitors::MySQL
     end
   end
 end

--- a/lib/mobility/plugins/arel/nodes/json_ops.rb
+++ b/lib/mobility/plugins/arel/nodes/json_ops.rb
@@ -31,22 +31,24 @@ module Mobility
       end
 
       module Visitors
-        def visit_Mobility_Plugins_Arel_Nodes_JsonDashArrow o, a
-          json_infix o, a, '->'
-        end
+        module PostgreSQL
+          def visit_Mobility_Plugins_Arel_Nodes_JsonDashArrow o, a
+            json_infix o, a, '->'
+          end
 
-        def visit_Mobility_Plugins_Arel_Nodes_JsonDashDoubleArrow o, a
-          json_infix o, a, '->>'
-        end
+          def visit_Mobility_Plugins_Arel_Nodes_JsonDashDoubleArrow o, a
+            json_infix o, a, '->>'
+          end
 
-        private
+          private
 
-        def json_infix o, a, opr
-          visit(Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right)), a)
+          def json_infix o, a, opr
+            visit(Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right)), a)
+          end
         end
       end
 
-      ::Arel::Visitors::PostgreSQL.include Visitors
+      ::Arel::Visitors::PostgreSQL.include Visitors::PostgreSQL
     end
   end
 end

--- a/lib/mobility/plugins/arel/nodes/json_ops.rb
+++ b/lib/mobility/plugins/arel/nodes/json_ops.rb
@@ -1,0 +1,52 @@
+# frozen-string-literal: true
+require "mobility/plugins/arel"
+
+module Mobility
+  module Plugins
+    module Arel
+      module Nodes
+        %w[
+          JsonDashArrow
+          JsonDashDoubleArrow
+        ].each do |name|
+          const_set name, (Class.new(Binary) do
+            include ::Arel::Predications
+            include ::Arel::OrderPredications
+            include ::Arel::AliasPredication
+            include MobilityExpressions
+
+            def lower
+              super self
+            end
+          end)
+        end
+
+        class Json < JsonDashDoubleArrow; end
+
+        class JsonContainer < Json
+          def initialize column, locale, attr
+            super(Nodes::JsonDashArrow.new(column, locale), attr)
+          end
+        end
+      end
+
+      module Visitors
+        def visit_Mobility_Plugins_Arel_Nodes_JsonDashArrow o, a
+          json_infix o, a, '->'
+        end
+
+        def visit_Mobility_Plugins_Arel_Nodes_JsonDashDoubleArrow o, a
+          json_infix o, a, '->>'
+        end
+
+        private
+
+        def json_infix o, a, opr
+          visit(Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right)), a)
+        end
+      end
+
+      ::Arel::Visitors::PostgreSQL.include Visitors
+    end
+  end
+end

--- a/lib/mobility/plugins/arel/nodes/pg_ops.rb
+++ b/lib/mobility/plugins/arel/nodes/pg_ops.rb
@@ -6,8 +6,6 @@ module Mobility
     module Arel
       module Nodes
         %w[
-          JsonDashArrow
-          JsonDashDoubleArrow
           JsonbDashArrow
           JsonbDashDoubleArrow
           JsonbQuestion
@@ -72,14 +70,6 @@ module Mobility
           end
         end
 
-        class Json < JsonDashDoubleArrow; end
-
-        class JsonContainer < Json
-          def initialize column, locale, attr
-            super(Nodes::JsonDashArrow.new(column, locale), attr)
-          end
-        end
-
         class JsonbContainer < Jsonb
           def initialize column, locale, attr
             @column, @locale = column, locale
@@ -93,14 +83,6 @@ module Mobility
       end
 
       module Visitors
-        def visit_Mobility_Plugins_Arel_Nodes_JsonDashArrow o, a
-          json_infix o, a, '->'
-        end
-
-        def visit_Mobility_Plugins_Arel_Nodes_JsonDashDoubleArrow o, a
-          json_infix o, a, '->>'
-        end
-
         def visit_Mobility_Plugins_Arel_Nodes_JsonbDashArrow o, a
           json_infix o, a, '->'
         end

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -79,17 +79,26 @@ module Mobility
             t.timestamps null: false
           end
 
+          if ENV['DB'] == 'mysql'
+            create_table "json_posts" do |t|
+              t.json :my_title_i18n
+              t.json :my_content_i18n
+              t.boolean :published
+              t.timestamps null: false
+            end
+          end
+
           if ENV['DB'] == 'postgres'
-            create_table "jsonb_posts" do |t|
-              t.jsonb :my_title_i18n, default: {}
-              t.jsonb :my_content_i18n, default: {}
+            create_table "json_posts" do |t|
+              t.json :my_title_i18n, default: {}
+              t.json :my_content_i18n, default: {}
               t.boolean :published
               t.timestamps null: false
             end
 
-            create_table "json_posts" do |t|
-              t.json :my_title_i18n, default: {}
-              t.json :my_content_i18n, default: {}
+            create_table "jsonb_posts" do |t|
+              t.jsonb :my_title_i18n, default: {}
+              t.jsonb :my_content_i18n, default: {}
               t.boolean :published
               t.timestamps null: false
             end

--- a/spec/mobility/backends/active_record/json_spec.rb
+++ b/spec/mobility/backends/active_record/json_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
-describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: :postgres, type: :backend do
+describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, type: :backend do
   require "mobility/backends/active_record/json"
 
   before { stub_const 'JsonPost', Class.new(ActiveRecord::Base) }
@@ -30,7 +30,7 @@ describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: :pos
       post = JsonPost.create!
       post.reload
 
-      expect(post.my_title_i18n).to eq({})
+      expect([nil, {}]).to include(post.my_title_i18n)
       expect(post.changes).to eq({})
     end
 

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -551,8 +551,15 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, a1=:t
         it "includes partial string matches" do
           foobar = model_class.create(a1 => "foObar")
           barfoo = model_class.create(a1 => "barfOo")
-          expect(query { __send__(a1).matches("foo%") }).to match_array([i[0], *i[5..6], foobar])
-          expect(query { __send__(a1).matches("%foo") }).to match_array([i[0], *i[5..6], barfoo])
+
+          if backend == Mobility::Backends::ActiveRecord::Json && ENV['DB'] == 'mysql'
+            # MySQL JSON columns are case sensitive
+            expect(query { __send__(a1).matches("foO%") }).to match_array([foobar])
+            expect(query { __send__(a1).matches("%fOo") }).to match_array([barfoo])
+          else
+            expect(query { __send__(a1).matches("foo%") }).to match_array([i[0], *i[5..6], foobar])
+            expect(query { __send__(a1).matches("%foo") }).to match_array([i[0], *i[5..6], barfoo])
+          end
         end
 
         if ENV['DB'] == 'postgres' && ::ActiveRecord::VERSION::STRING >= '5.0'


### PR DESCRIPTION
We have been using mobility for a few years using the JSON backend with a MySQL 8 JSON column.

I see a few people over the years have put together PRs, but they are still marked WIP.

The thing I am most unsure about in this PR is the `visit_Mobility_Plugins_Arel_Nodes_JsonDashDoubleArrow` function.
Maybe moving that quoting somewhere else would be better - I notice PR #271 from a few years ago has it elsewhere.