### PR TITLE
Don't try to load generators if Rails is loaded but ActiveRecord is not.

### DIFF
--- a/lib/mobility.rb
+++ b/lib/mobility.rb
@@ -90,7 +90,7 @@ module Mobility
   CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
   private_constant :CALL_COMPILABLE_REGEXP
 
-  require "rails/generators/mobility/generators" if defined?(Rails)
+  require "rails/generators/mobility/generators" if defined?(Rails) && defined?(ActiveRecord)
 
   class << self
     def extended(model_class)

--- a/spec/generators/rails/mobility/install_generator_spec.rb
+++ b/spec/generators/rails/mobility/install_generator_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-return unless defined?(Rails)
+return unless defined?(Rails) && defined?(ActiveRecord)
 
 require "rails/generators/mobility/install_generator"
 

--- a/spec/generators/rails/mobility/translations_generator_spec.rb
+++ b/spec/generators/rails/mobility/translations_generator_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-return unless defined?(Rails)
+return unless defined?(Rails) && defined?(ActiveRecord)
 
 require "rails/generators/mobility/translations_generator"
 


### PR DESCRIPTION
The generators are implicitly dependent on ActiveRecord, so if you are using Rails and you are not using ActiveRecord (We use Sequel with Rails), mobility would not load correctly and we would get the following error :

```
`require': cannot load such file -- rails/generators/active_record (LoadError)
```

This patch explicitly check that ActiveRecord is loaded before requiring the generators.