### PR TITLE
Fix missing translated attributes in as_json

### DIFF
--- a/lib/mobility/plugins/attribute_methods.rb
+++ b/lib/mobility/plugins/attribute_methods.rb
@@ -25,6 +25,14 @@ attributes only.
             attributes.merge(name.to_s => send(name))
           end)
         end
+
+        private
+
+        define_method :attribute_names_for_serialization do
+          return unless defined?(super)
+
+          super() + names.map(&:to_s)
+        end
       end
 
       # Applies attribute_methods plugin for a given option value.

--- a/spec/mobility/plugins/attribute_methods_spec.rb
+++ b/spec/mobility/plugins/attribute_methods_spec.rb
@@ -38,6 +38,13 @@ describe Mobility::Plugins::AttributeMethods, orm: :active_record, type: :plugin
     end
   end
 
+  describe "#as_json" do
+    it "adds translated attributes to normal attributes" do
+      expect(backend).to receive(:read).with(Mobility.locale, any_args).and_return('foo').at_least(1)
+      expect(instance.as_json).to eq(untranslated_attributes.merge('title' => 'foo'))
+    end
+  end
+
   describe "#untranslated_attributes" do
     it "returns original value of attributes method" do
       expect(instance.untranslated_attributes).to eq(untranslated_attributes)


### PR DESCRIPTION
This PR fixes a regression that I noticed in `ActiveRecord::Base#as_json` return value.

### Description

If you enable `attribute_methods` plugin, mobility patches `ActiveRecord::Base#attributes` method to include translated attributes as wekk. The same change used to apply to `ActiveRecord::Base#as_json` too. 

But the internal implementation of serialization [changed slightly in Rails 7.0](https://github.com/rails/rails/commit/322e62842ce656e4bb7b6562efc2a7f314fe5d43#diff-89d44807164a1461ee3c9a225c9f1301a87fdac8b45b4759b035d37157eced14R25) to improve the performance. 

As a result, `as_json` method no longer includes translated attributes.

### Solution

I added an override of `attribute_names_for_serialization` method into the plugin to make it include the missing translated fields into `serialized_attributes` hash which is used by `as_json` later.

`attribute_names_for_serialization` would be never be called by Rails 6.x or lower, but I still added a safe guard against calling `super`.