### PR TITLE
Fix passing unpacked options

### DIFF
--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -142,7 +142,8 @@ the ActiveRecord dirty plugin for more information.
                     mutations_from_mobility.attribute_previously_changed?(attr_name))
                   mutations_from_mobility.send(#{method_name.inspect}, attr_name, *rest#{kwargs})
                 else
-                  super
+                  options = rest.first || {}
+                  super(attr_name, **options)
                 end
               end
               EOM


### PR DESCRIPTION
The define_handler_methods method in the Mobility gem's plugin was not properly handling method invocation with additional parameters, causing issues with methods like `will_save_change_to_attribute?(from:,to:)`. This fix modifies the else block to correctly pass additional parameters to the super method, ensuring proper functionality.