### PR TITLE
fix active model `*_previously_changed?` and active record `will_save_change_to_*?` and `saved_change_to_*?` dirty methods to accept kwargs

### DIFF
--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -135,7 +135,7 @@ the ActiveRecord dirty plugin for more information.
             public_patterns.each do |pattern|
               method_name = pattern % 'attribute'
 
-              kwargs = pattern == '%s_changed?' ? ', **kwargs' : ''
+              kwargs = (pattern == '%s_changed?' || pattern == '%s_previously_changed?') ? ', **kwargs' : ''
               module_eval <<-EOM, __FILE__, __LINE__ + 1
               def #{method_name}(attr_name, *rest#{kwargs})
                 if (mutations_from_mobility.attribute_changed?(attr_name) ||
@@ -298,8 +298,10 @@ the ActiveRecord dirty plugin for more information.
               (OPTION_NOT_GIVEN == to || fetch_value(attr_name) == to)
           end
 
-          def attribute_previously_changed?(attr_name)
-            previous_changes.include?(attr_name)
+          def attribute_previously_changed?(attr_name, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN)
+            previous_changes.include?(attr_name) &&
+              (OPTION_NOT_GIVEN == from || attribute_previous_change(attr_name).first == from) &&
+              (OPTION_NOT_GIVEN == to || attribute_previous_change(attr_name).second == to)
           end
 
           def attribute_was(attr_name)

--- a/lib/mobility/plugins/active_model/dirty.rb
+++ b/lib/mobility/plugins/active_model/dirty.rb
@@ -119,6 +119,14 @@ the ActiveRecord dirty plugin for more information.
         class HandlerMethodsBuilder < Module
           attr_reader :klass
 
+          PATTERNS_WITH_KWARGS =
+            %w[
+              %s_changed?
+              %s_previously_changed?
+              will_save_change_to_%s?
+              saved_change_to_%s?
+            ].freeze
+
           # @param [Class] klass Dirty class to mimic
           def initialize(klass)
             @klass = klass
@@ -135,7 +143,7 @@ the ActiveRecord dirty plugin for more information.
             public_patterns.each do |pattern|
               method_name = pattern % 'attribute'
 
-              kwargs = (pattern == '%s_changed?' || pattern == '%s_previously_changed?') ? ', **kwargs' : ''
+              kwargs = PATTERNS_WITH_KWARGS.include?(pattern) ? ', **kwargs' : ''
               module_eval <<-EOM, __FILE__, __LINE__ + 1
               def #{method_name}(attr_name, *rest#{kwargs})
                 if (mutations_from_mobility.attribute_changed?(attr_name) ||

--- a/spec/mobility/plugins/active_model/dirty_spec.rb
+++ b/spec/mobility/plugins/active_model/dirty_spec.rb
@@ -240,10 +240,14 @@ describe "Mobility::Plugins::ActiveModel::Dirty", orm: :active_record, type: :pl
         expect(instance.attribute_changed?(:title_en)).to eq(false)
 
         expect(instance.title_previously_changed?).to eq(true)
+        expect(instance.title_previously_changed?(from: 'foo', to: 'bar')).to eq(true)
+        expect(instance.title_previously_changed?(from: 'foo', to: 'baz')).to eq(false)
         expect(instance.title_previous_change).to eq(["foo", "bar"])
         expect(instance.title_changed?).to eq(false)
 
         expect(instance.attribute_previously_changed?(:title_en)).to eq(true)
+        expect(instance.attribute_previously_changed?(:title_en, from: 'foo', to: 'bar')).to eq(true)
+        expect(instance.attribute_previously_changed?(:title_en, from: 'foo', to: 'baz')).to eq(false)
         expect(instance.attribute_changed?(:title_en)).to eq(false)
 
         expect(instance.title_previously_was).to eq('foo')

--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -220,12 +220,16 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
         expect(instance.title_previous_change).to eq([nil, "foo"])
 
         expect(instance.saved_change_to_title?).to eq(true)
+        expect(instance.saved_change_to_title?(from: nil, to: 'foo')).to eq(true)
+        expect(instance.saved_change_to_title?(from: nil, to: 'foz')).to eq(false)
         expect(instance.saved_change_to_title).to eq([nil, "foo"])
         expect(instance.title_before_last_save).to eq(nil)
         expect(instance.title_in_database).to eq("foo")
 
         # attribute handlers
         expect(instance.saved_change_to_attribute?(:title_en)).to eq(true)
+        expect(instance.saved_change_to_attribute?(:title_en, from: nil, to: 'foo')).to eq(true)
+        expect(instance.saved_change_to_attribute?(:title_en, from: nil, to: 'foz')).to eq(false)
         expect(instance.saved_change_to_attribute(:title_en)).to eq([nil, 'foo'])
         expect(instance.attribute_before_last_save(:title_en)).to eq(nil)
         expect(instance.attribute_in_database(:title_en)).to eq('foo')
@@ -239,6 +243,9 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
         expect(instance.title_changed?(from: 'foo', to: 'baz')).to eq(false)
         expect(instance.title_change).to eq(["foo", "bar"])
         expect(instance.title_was).to eq("foo")
+        expect(instance.will_save_change_to_title?).to eq(true)
+        expect(instance.will_save_change_to_title?(from: 'foo', to: 'bar')).to eq(true)
+        expect(instance.will_save_change_to_title?(from: 'foo', to: 'baz')).to eq(false)
 
         instance.save
 
@@ -249,6 +256,8 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
         expect(instance.title_changed?).to eq(false)
 
         expect(instance.saved_change_to_title?).to eq(true)
+        expect(instance.saved_change_to_title?(from: 'foo', to: 'bar')).to eq(true)
+        expect(instance.saved_change_to_title?(from: 'foo', to: 'baz')).to eq(false)
         expect(instance.saved_change_to_title).to eq(["foo", "bar"])
         expect(instance.title_before_last_save).to eq("foo")
         expect(instance.will_save_change_to_title?).to eq(false)
@@ -257,6 +266,8 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
 
         # attribute handlers
         expect(instance.saved_change_to_attribute?(:title_en)).to eq(true)
+        expect(instance.saved_change_to_attribute?(:title_en, from: 'foo', to: 'bar')).to eq(true)
+        expect(instance.saved_change_to_attribute?(:title_en, from: 'foo', to: 'baz')).to eq(false)
         expect(instance.saved_change_to_attribute(:title_en)).to eq(['foo', 'bar'])
         expect(instance.attribute_before_last_save(:title_en)).to eq('foo')
         expect(instance.will_save_change_to_attribute?(:title_en)).to eq(false)
@@ -271,16 +282,24 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
           expect(instance.title_changed?).to eq(true)
 
           expect(instance.saved_change_to_title?).to eq(true)
+          expect(instance.saved_change_to_title?(from: 'foo', to: 'bar')).to eq(true)
+          expect(instance.saved_change_to_title?(from: 'foo', to: 'baz')).to eq(false)
           expect(instance.saved_change_to_title).to eq(["foo", "bar"])
           expect(instance.title_before_last_save).to eq("foo")
           expect(instance.will_save_change_to_title?).to eq(true)
+          expect(instance.will_save_change_to_title?(from: 'bar', to: 'bar')).to eq(true)
+          expect(instance.will_save_change_to_title?(from: 'bar', to: 'baz')).to eq(false)
           expect(instance.title_change_to_be_saved).to eq(["bar", "bar"])
           expect(instance.title_in_database).to eq("bar")
 
           expect(instance.saved_change_to_attribute?(:title_en)).to eq(true)
+          expect(instance.saved_change_to_attribute?(:title_en, from: 'foo', to: 'bar')).to eq(true)
+          expect(instance.saved_change_to_attribute?(:title_en, from: 'foo', to: 'baz')).to eq(false)
           expect(instance.saved_change_to_attribute(:title_en)).to eq(['foo', 'bar'])
           expect(instance.attribute_before_last_save(:title_en)).to eq('foo')
           expect(instance.will_save_change_to_attribute?(:title_en)).to eq(true)
+          expect(instance.will_save_change_to_attribute?(:title_en, from: 'bar', to: 'bar')).to eq(true)
+          expect(instance.will_save_change_to_attribute?(:title_en, from: 'bar', to: 'baz')).to eq(false)
           expect(instance.attribute_change_to_be_saved(:title_en)).to eq(['bar', 'bar'])
           expect(instance.attribute_in_database(:title_en)).to eq('bar')
         end
@@ -291,6 +310,8 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
           expect(instance.title_changed?).to eq(false)
 
           expect(instance.saved_change_to_title?).to eq(true)
+          expect(instance.saved_change_to_title?(from: 'bar', to: 'bar')).to eq(true)
+          expect(instance.saved_change_to_title?(from: 'bar', to: 'baz')).to eq(false)
           expect(instance.saved_change_to_title).to eq(["bar", "bar"])
           expect(instance.title_before_last_save).to eq("bar")
           expect(instance.will_save_change_to_title?).to eq(false)
@@ -298,6 +319,8 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
           expect(instance.title_in_database).to eq("bar")
 
           expect(instance.saved_change_to_attribute?(:title_en)).to eq(true)
+          expect(instance.saved_change_to_attribute?(:title_en, from: 'bar', to: 'bar')).to eq(true)
+          expect(instance.saved_change_to_attribute?(:title_en, from: 'bar', to: 'baz')).to eq(false)
           expect(instance.saved_change_to_attribute(:title_en)).to eq(['bar', 'bar'])
           expect(instance.attribute_before_last_save(:title_en)).to eq('bar')
           expect(instance.will_save_change_to_attribute?(:title_en)).to eq(false)


### PR DESCRIPTION
since Rails 6.1 they accept kwargs `from` and `to`, see https://github.com/rails/rails/commit/a6841c720ad567d28a5ffac945bce8acc8b66c1a