### PR TITLE
Fix fallback syntax in initializer example

### DIFF
--- a/lib/rails/generators/mobility/templates/initializer.rb
+++ b/lib/rails/generators/mobility/templates/initializer.rb
@@ -78,7 +78,7 @@ Mobility.configure do
     # fallbacks
     #
     # Or uncomment this line to enable fallbacks with a global default.
-    # fallbacks { :pt => :en }
+    # fallbacks(pt: :en)
 
     # Presence
     #


### PR DESCRIPTION
The previous sample code passed a block to the fallbacks method. Instead, they should be an argument.