### PR TITLE
Fix broken count statements in Active Record 8.0

### DIFF
--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -172,7 +172,7 @@ enabled for any one attribute on the model.
                 base = keys.each_with_index.inject(self) do |query, (key, index)|
                   next query unless klass.mobility_attribute?(key)
                   keys[index] = backend_node(key)
-                  if method_name == "select"
+                  if method_name == "select" && query.order_values.any?
                     keys[index] = keys[index]
                       .as(::Mobility::Plugins::ActiveRecord::Query.attribute_alias(key.to_s))
                   end


### PR DESCRIPTION
This fixes the issue discussed here https://github.com/shioyama/mobility/pull/654#issuecomment-2503479112,  https://github.com/shioyama/mobility/issues/652#issuecomment-2502206995 and https://github.com/shioyama/mobility/pull/653#issuecomment-2502193696

> I think this caused the second issue with Rails 8.0 and the AS statement with counts not getting wrapped correctly: https://github.com/rails/rails/commit/ba468db0bdc880c694df091b5800d114e963eff0
>
> Previously we got the `Arel::Nodes` for `column_name` in `execute_simple_calculation`. With Rails 8 we actually get just the string `"article_translations_en"."title" AS __mobility_title_en__,` (https://github.com/rails/rails/blob/8-0-stable/activerecord/lib/active_record/relation/calculations.rb#L445)
>
> This is why the `count` in `Countable` module does not get called at all (https://github.com/shioyama/mobility/blob/master/lib/mobility/plugins/arel.rb#L32)

Not particularly pretty, but it works because
- Count queries don't include ORDER BY
  - The problematic counting behavior in Rails 8 is bypassed when there's no alias
- Select queries that need proper column aliases do include ORDER BY

I ran the specs locally for also Rails 8.0 and they all passed with this change.

Maybe @shioyama you have a better way in mind on how to fix it?