### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## 1.3
 
-### (unreleased)
+### 1.3.0
 
 - Only support ActiveRecord >= 7.0
 - Allow `I18n.available_locales` to contain Strings
   ([#612](https://github.com/shioyama/mobility/pull/612))
+- Update CI config, add support for Rails 8
+  ([#653](https://github.com/shioyama/mobility/pull/653)), thanks
+  [d-rodriguez](https://github.com/n-rodriguez)!
+- Fix broken count statements in Active Record 8.0
+  ([#655](https://github.com/shioyama/mobility/pull/655)), thanks
+  [jukra](https://github.com/jukra)!
 
 ### 1.3.0.rc3
 

--- a/lib/mobility/version.rb
+++ b/lib/mobility/version.rb
@@ -9,7 +9,7 @@ module Mobility
     MAJOR = 1
     MINOR = 3
     TINY = 0
-    PRE = "rc3"
+    PRE = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
   end


### PR DESCRIPTION
With support for ActiveRecord 8.

There's a warning in the gemspec related to #535, it's been in the release candidates for like 2 years now, I think we can release :joy: 