### PR TITLE
Fix for Rails 8 query issue breaks `select` with no `order` clause

### DIFF
--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -171,7 +171,7 @@ enabled for any one attribute on the model.
               base = keys.each_with_index.inject(self) do |query, (key, index)|
                 next query unless klass.mobility_attribute?(key)
                 keys[index] = backend_node(key)
-                if method_name == "select" && query.order_values.any?
+                if method_name == "select"
                   keys[index] = keys[index]
                     .as(::Mobility::Plugins::ActiveRecord::Query.attribute_alias(key.to_s))
                 end

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -354,6 +354,9 @@ shared_examples_for "AR Model with translated scope" do |model_class_name, a1=:t
 
     describe "selecting translated attributes" do
       it "returns value from attribute methods on results" do
+        selected_unordered = query_scope.select(a1).map { |result| result.send(a1) }
+        expect(selected_unordered.sort).to eq(["bar", "bar", "bar", "foo", "foo"])
+
         selected = ordered_results.select(a1)
         expect(selected[0].send(a1)).to eq("foo")
         expect(selected[1].send(a1)).to eq("foo")


### PR DESCRIPTION
https://github.com/shioyama/mobility/pull/655 fixed an issue with failing querying tests in AR 8, but as it turns out test coverage was incomplete and the fix has introduced breakage to `select` when used without `order`.

I added a small expectation which removes the `order` on part of existing querying tests, and tests now fail on master. Removing the fix from https://github.com/shioyama/mobility/pull/655, they pass (but others fail on AR 8).

The change in Rails was this commit: https://github.com/rails/rails/commit/ba468db0bdc880c694df091b5800d114e963eff0

cc @jukra @n-rodriguez 

We now have a broken state on master.