### PR TITLE
Issue #664 | Update handling nil value for PgHash

### DIFF
--- a/lib/mobility/backends/active_record/pg_hash.rb
+++ b/lib/mobility/backends/active_record/pg_hash.rb
@@ -22,6 +22,7 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
         def write(locale, value, _options = nil)
           if value.nil?
             translations.delete(locale.to_s)
+            nil
           else
             translations[locale.to_s] = value
           end

--- a/spec/integration/active_record_compatibility_spec.rb
+++ b/spec/integration/active_record_compatibility_spec.rb
@@ -48,6 +48,8 @@ describe "ActiveRecord compatibility", orm: :active_record do
       post.send(backend_for(post, :title).association_name).first.value = "association changed value"
       post.save
       expect(Post.first.title).to eq("association changed value")
+      post.title = nil
+      expect(post.title).to eq(nil)
     end
 
     it "resets cache when model is reloaded" do


### PR DESCRIPTION
## [Issue 664: Cache returns last value if nil value provided](https://github.com/shioyama/mobility/issues/664)

When assigning attribute (which uses translations) nil value, it won't invalidate cache and will store previous value.
This possibly can affect any logic, but the common example is ActiveRecord validations. As cache uses previous value, it will pass presence validation, but it is incorrect as current value is nil.
Disabling cache for the attribute fixes situation, but actually it is not a solution.
This change appeared after version 1.2.9 and possibly after implementing logic for the Issue https://github.com/shioyama/mobility/issues/535