### PR TITLE
Fix builds with ActiveRecord 7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,11 @@ group :development, :test do
   when 'active_record'
     orm_version ||= '7.0'
     case orm_version
-    when '6.1', '7.0', '7.1', '7.2', '8.0'
+    when '7.0'
+      gem 'activerecord', '~> 7.0'
+      # see https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
+      gem 'concurrent-ruby', '1.3.4'
+    when '7.1', '7.2', '8.0'
       gem 'activerecord', "~> #{orm_version}.0"
     when 'edge'
       git 'https://github.com/rails/rails.git', branch: 'main' do


### PR DESCRIPTION
Builds running AR 7.0 are currently failing, for reasons unrelated to Mobility. This should fix it.