### PR TITLE
Simply return `value` after write in active_record container backend

### DIFF
--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -37,7 +37,7 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
       # @return [String,Integer,Boolean] Updated value
       def write(locale, value, _ = nil)
         set_attribute_translation(locale, value)
-        read(locale)
+        value
       end
       # @!endgroup
 

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -52,6 +52,17 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
     end
   end
 
+  context "with cache plugin" do
+    plugins :active_record, :reader, :writer, :cache
+    before { translates ContainerPost, :title, backend: :container }
+
+    it 'resets cache on write' do
+      post = ContainerPost.create!
+
+      expect { post.title = 'aaa' }.to change { post.title }.from(nil).to('aaa')
+    end
+  end
+
   context "with query plugin" do
     plugins :active_record, :reader, :writer, :query
     before { translates ContainerPost, :title, :content, backend: :container }

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -63,6 +63,20 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
     end
   end
 
+  context "with presence plugin" do
+    plugins :active_record, :reader, :writer, :presence
+    before { translates ContainerPost, :title, backend: :container }
+
+    it 'applies presence plugin on write to database' do
+      post = ContainerPost.create!(title: 'Title en')
+
+      expect { post.title = "" }
+        .to change { post.translations }
+        .from({ "en" => { "title" => "Title en" }})
+        .to({})
+    end
+  end
+
   context "with query plugin" do
     plugins :active_record, :reader, :writer, :query
     before { translates ContainerPost, :title, :content, backend: :container }


### PR DESCRIPTION
Simply return `value` after write in active_record container backend

This fixes a bug where `#read` is overwritten by the cache plugin and
therefore the container backend returns stale data. It should always
return the value it wrote.

Since `value` is never modified by this backend it makes no sense to
read it again after setting it.

Besides fixing the bug it might give a small perfomance boost, too.

fixes https://github.com/shioyama/mobility/pull/543/files#r1944637671

thanks @dramalho for uncovering the bug and hints