### PR TITLE
Fixes #672 - Container backend - translations should return HashWithIndifferentAccess

### DIFF
--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -47,6 +47,11 @@ Implements the {Mobility::Backends::Container} backend for ActiveRecord models.
         # @raise [InvalidColumnType] if the type of the container column is not json or jsonb
         def configure(options)
           options[:column_name] = options[:column_name]&.to_sym || :translations
+
+          model_class.define_method(options[:column_name]) do
+            value = super()
+            value.is_a?(Hash) ? value.with_indifferent_access : value
+          end
         end
         # @!endgroup
 

--- a/spec/mobility/backends/active_record/container_spec.rb
+++ b/spec/mobility/backends/active_record/container_spec.rb
@@ -50,6 +50,12 @@ describe "Mobility::Backends::ActiveRecord::Container", orm: :active_record, db:
         .from({ "en" => { "title" => "Title en" }, "de" => { "title" => "Title de" }})
         .to({ "de" => { "title" => "Title de" }})
     end
+
+    it "returns translations as ActiveSupport::HashWithIndifferentAccess" do
+      post = ContainerPost.create!
+      
+      expect(post.translations.class).to eq(ActiveSupport::HashWithIndifferentAccess)
+    end
   end
 
   context "with query plugin" do

--- a/spec/mobility/backends/hash_spec.rb
+++ b/spec/mobility/backends/hash_spec.rb
@@ -1,7 +1,12 @@
 require "spec_helper"
-require "mobility/backends/hash"
 
-describe Mobility::Backends::Hash, type: :backend, orm: :none do
+describe "Mobility::Backends::Hash", type: :backend, orm: :none do
+  before(:all) do
+    require "mobility/backends/hash" # leaks state if defined at top of file (defines Mobility::Backends::Hash, adds :hash to @backends)
+  end
+
+  let(:described_class) { Mobility::Backends::Hash }
+
   describe "#read/#write" do
     it "returns value for locale key" do
       backend = described_class.new


### PR DESCRIPTION
Fix for #672 - added a reader to ensure Container backend returns HashWithIndifferentAccess

I also found that hash_spec.rb leaked state to other tests due to `require "mobility/backends/hash"`, which affected the new test for this feature. An initial commit refactors hash_spec.rb to fix this.