### PR TITLE
handling for string columns in Rails 8

### DIFF
--- a/lib/mobility/plugins/active_record/query.rb
+++ b/lib/mobility/plugins/active_record/query.rb
@@ -187,21 +187,25 @@ enabled for any one attribute on the model.
 
           if ::ActiveRecord::VERSION::MAJOR >= 8
             # Fix for https://github.com/shioyama/mobility/pull/654#issuecomment-2503479112
-            # TODO: Make this better
+            # When counting with select values that include mobility-translated attributes,
+            # we need to filter out the aliased columns that Mobility adds (e.g. __mobility_title_en__)
+            # to prevent errors in the COUNT SQL generation.
             def select_for_count
               return super unless klass.respond_to?(:mobility_attribute?)
 
-              if select_values.any? { |value| value.right.start_with?(ATTRIBUTE_ALIAS_PREFIX) }
-                filtered_select_values = select_values.map do |value|
-                  value.right.start_with?(ATTRIBUTE_ALIAS_PREFIX) ? value.left : value
-                end
+              # Check if any select values are Mobility attribute aliases
+              has_mobility_aliases = select_values.any? { |value| value.respond_to?(:right) && value.right.start_with?(ATTRIBUTE_ALIAS_PREFIX) }
 
-                # Copied from lib/active_record/relation/calculations.rb
-                with_connection do |conn|
-                  arel_columns(filtered_select_values).map { |column| conn.visitor.compile(column) }.join(", ")
-                end
-              else
-                super
+              return super unless has_mobility_aliases
+
+              # Filter out Mobility aliases, replacing them with the underlying columns
+              filtered_select_values = select_values.map do |value|
+                value.respond_to?(:right) && value.right.start_with?(ATTRIBUTE_ALIAS_PREFIX) ? value.left : value
+              end
+
+              # Copied from lib/active_record/relation/calculations.rb
+              with_connection do |conn|
+                arel_columns(filtered_select_values).map { |column| conn.visitor.compile(column) }.join(", ")
               end
             end
           end

--- a/spec/mobility/plugins/active_record/query_spec.rb
+++ b/spec/mobility/plugins/active_record/query_spec.rb
@@ -218,4 +218,49 @@ describe Mobility::Plugins::ActiveRecord::Query, orm: :active_record, type: :plu
       expect(Article.i18n.where(title: "Title", content: "Content")).to eq([article2])
     end
   end
+
+  describe "regression: select_for_count with mixed select values" do
+    # Test for bug where select_for_count called .right on string values
+    # causing NoMethodError when select_values contained non-Arel nodes
+    if ::ActiveRecord::VERSION::MAJOR >= 8
+      before do
+        stub_const 'Article', Class.new(ActiveRecord::Base)
+        translates Article, :title, backend: :table
+      end
+
+      it "handles count with regular column in select" do
+        Article.create(title: "Article 1")
+        Article.create(title: "Article 2")
+
+        # The original bug: calling .right on string values like "id"
+        # This should not raise NoMethodError: undefined method `right' for "id":String
+        expect { Article.select(:id).count }.not_to raise_error
+        expect(Article.select(:id).count).to eq(2)
+      end
+
+      it "handles count with translated column in select" do
+        Article.create(title: "Article 1")
+        Article.create(title: "Article 2")
+
+        # When selecting translated attributes, Mobility creates Arel::Nodes::As with aliases
+        # This should properly filter out the aliased columns for counting
+        relation = Article.i18n.select(:title)
+
+        expect { relation.count }.not_to raise_error
+        expect(relation.count).to eq(2)
+      end
+
+      it "handles count without select when mobility is present" do
+        Article.create(title: "Article 1")
+        Article.create(title: "Article 2")
+
+        # Ensure normal counting still works on models with mobility
+        expect { Article.count }.not_to raise_error
+        expect(Article.count).to eq(2)
+
+        expect { Article.i18n.count }.not_to raise_error
+        expect(Article.i18n.count).to eq(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Fixes a bug in `select_for_count` (Rails 8.0+) where calling `.right` on 
select_values crashes when the array contains plain strings instead of 
Arel nodes.

## The Problem

When using Mobility with Rails 8.0+ and calling `.count` on a query with 
selected columns, the code assumes all `select_values` are `Arel::Nodes::As` 
objects with a `.right` method. However, select_values can contain a mix of 
plain strings (like `"id"`) and Arel nodes, causing:

```ruby
Article.select(:id).count
# NoMethodError: undefined method `right' for "id":String
```

## The Solution

Added `respond_to?(:right)` checks before calling `.right` on select_values 
to safely handle both strings and Arel nodes.

## Changes Made

- ✅ Added `respond_to?(:right)` checks in `select_for_count` method
- ✅ Improved inline documentation explaining the fix
- ✅ Added 3 regression tests covering different scenarios

## Test Results

All existing tests pass, plus 3 new tests:
- ✅ Handles count with regular column in select (reproduces original bug)
- ✅ Handles count with translated column in select  
- ✅ Handles count without select when mobility is present

```bash
# Rails 8.0 with Ruby 3.2.5
15 examples, 0 failures
```

## Related Issues

Closes #678
Related to 
1. https://github.com/shioyama/mobility/pull/654#issuecomment-2503479112
2. https://github.com/shioyama/mobility/pull/659#issuecomment-2582160733