### PR TITLE
Docker tests and new rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
           - '3.2'
         database:
           - 'sqlite3'
-          - 'mysql'
+          - 'mysql57'
+          - 'mysql80'
           - 'postgres'
         orm:
           - name: 'active_record'
@@ -84,7 +85,12 @@ jobs:
               name: 'active_record'
               version: '8.1'
           - ruby: '3.2'
-            database: 'mysql'
+            database: 'mysql57'
+            orm:
+              name: 'active_record'
+              version: '8.1'
+          - ruby: '3.2'
+            database: 'mysql80'
             orm:
               name: 'active_record'
               version: '8.1'
@@ -100,6 +106,10 @@ jobs:
       BUNDLE_PATH: vendor/bundle
       ORM: ${{ matrix.orm.name }}
       ORM_VERSION: ${{ matrix.orm.version }}
+      MYSQL57_HOST: 127.0.0.1
+      MYSQL57_PORT: 3306
+      MYSQL80_HOST: 127.0.0.1
+      MYSQL80_PORT: 3307
       MYSQL_PASSWORD: root
       PGHOST: localhost
       PGPORT: 5432
@@ -113,9 +123,16 @@ jobs:
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
-      mysql:
+      mysql57:
         image: mysql:5.7
         ports: ["3306:3306"]
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        env:
+          MYSQL_ROOT_PASSWORD: root
+
+      mysql80:
+        image: mysql:8.0
+        ports: ["3307:3306"]
         options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
         env:
           MYSQL_ROOT_PASSWORD: root
@@ -131,6 +148,9 @@ jobs:
       - name: Install Postgres
         run: sudo apt-get install libpq-dev postgresql-client -y
         if: matrix.database == 'postgres'
+      - name: Install MySQL client
+        run: sudo apt-get install default-mysql-client -y
+        if: startsWith(matrix.database, 'mysql')
       - id: cache-bundler
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '4.0'
+          - '3.4'
           - '3.3'
           - '3.2'
         database:
@@ -38,6 +40,20 @@ jobs:
 
         include:
           # rails/sqlite3/active_record-7.2
+          - ruby: '4.0'
+            feature: 'rails'
+            orm:
+              name: 'active_record'
+              version: '7.2'
+            database: 'sqlite3'
+            experimental: false
+          - ruby: '3.4'
+            feature: 'rails'
+            orm:
+              name: 'active_record'
+              version: '7.2'
+            database: 'sqlite3'
+            experimental: false
           - ruby: '3.3'
             feature: 'rails'
             orm:
@@ -54,6 +70,12 @@ jobs:
             experimental: false
 
           # i18n fallbacks
+          - ruby: '4.0'
+            feature: 'i18n_fallbacks'
+            experimental: false
+          - ruby: '3.4'
+            feature: 'i18n_fallbacks'
+            experimental: false
           - ruby: '3.3'
             feature: 'i18n_fallbacks'
             experimental: false
@@ -62,6 +84,12 @@ jobs:
             experimental: false
 
           # Performance tests
+          - ruby: '4.0'
+            feature: 'performance'
+            experimental: false
+          - ruby: '3.4'
+            feature: 'performance'
+            experimental: false
           - ruby: '3.3'
             feature: 'performance'
             experimental: false
@@ -70,6 +98,14 @@ jobs:
             experimental: false
 
           # Unit tests
+          - ruby: '4.0'
+            feature: 'unit'
+            orm:
+            experimental: false
+          - ruby: '3.4'
+            feature: 'unit'
+            orm:
+            experimental: false
           - ruby: '3.3'
             feature: 'unit'
             orm:

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,22 @@
+ARG RUBY_VERSION
+FROM ruby:${RUBY_VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    libpq-dev \
+    postgresql-client \
+    default-mysql-client \
+    default-libmysqlclient-dev \
+    libsqlite3-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN printf "%s\n" "[client]" "ssl=false" > /root/.my.cnf
+
+WORKDIR /app
+
+ENV BUNDLE_PATH=/usr/local/bundle \
+  BUNDLE_JOBS=4

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :development, :test do
       else
         gem 'sqlite3', '~> 1.5.0'
       end
-    when 'mysql'
+    when 'mysql57', 'mysql80'
       gem 'mysql2'
     when 'postgres'
       gem 'pg'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 orm, orm_version = ENV['ORM'], ENV['ORM_VERSION']
 
 group :development, :test do
+  gem 'ostruct'
   case orm
   when 'active_record'
     orm_version ||= '7.0'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+COMPOSE ?= docker compose
+
+# Default Ruby versions can include newer Rubies locally; override to match CI exactly:
+#   make test-matrix RUBIES="3.3"
+# Or opt-in to Ruby 4.0 explicitly:
+#   make test-matrix RUBIES="4.0 3.4 3.3 3.2"
+RUBIES ?= 4.0 3.4 3.3 3.2
+DBS ?= sqlite3 mysql57 mysql80 postgres
+AR_VERSIONS ?= 7.2 8.0 8.1
+SEQUEL_VERSION ?= 5
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+## Following commands are available
+help: ## Show this help
+	@awk -v FS=':.*?## ' ' /^##/{print $0} /^[a-zA-Z_-]+:.*?## /{printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+## Infrastructure
+compose-up: ## Start required services
+	$(COMPOSE) up -d mysql57 mysql80 postgres
+
+compose-down: ## Stop required services
+	$(COMPOSE) down --remove-orphans
+
+wait-db: ## Wait for required services to be ready
+	$(COMPOSE) run --rm --entrypoint "sh -c 'echo mysql57 ready'" mysql57 >/dev/null
+	$(COMPOSE) run --rm --entrypoint "sh -c 'echo mysql80 ready'" mysql80 >/dev/null
+	$(COMPOSE) run --rm --entrypoint "sh -c 'echo postgres ready'" postgres >/dev/null
+
+## Development
+bash: ## Run bash in a service container, e.g. make bash SERVICE="ruby-3.2"
+	$(COMPOSE) run --rm $(SERVICE) bash
+
+test: ## Run tests in a service container, e.g. make test SERVICE="ruby-3.2" DB="mysql57" ORM="active_record" ORM_VERSION="7.2" FEATURE="unit"
+	$(COMPOSE) run -e DB=$(DB) -e ORM=$(ORM) -e ORM_VERSION=$(ORM_VERSION) -e FEATURE=$(FEATURE) --rm $(SERVICE) bash -lc '\
+bundle install && \
+if [ "$$DB" != "" ]; then \
+  cleanup() { bundle exec rake db:drop; }; \
+  trap cleanup EXIT; \
+  bundle exec rake db:drop db:create db:up; \
+fi && \
+bundle exec rake \
+'
+
+test-matrix: ## Run test matrix like in CI
+	@set -e; \
+	$(MAKE) -s compose-up >/dev/null; \
+	for ruby in $(RUBIES); do \
+	  service="ruby-$$ruby"; \
+	  for db in $(DBS); do \
+	    for ar_version in $(AR_VERSIONS); do \
+	      if [ "$$ruby" = "3.2" ] && [ "$$ar_version" = "8.1" ]; then continue; fi; \
+	      $(MAKE) test SERVICE="$$service" DB="$$db" ORM=active_record ORM_VERSION="$$ar_version" FEATURE=unit; \
+	    done; \
+	    $(MAKE) test SERVICE="$$service" DB="$$db" ORM=sequel ORM_VERSION="$(SEQUEL_VERSION)" FEATURE=unit; \
+	  done; \
+	  $(MAKE) test SERVICE="$$service" DB=sqlite3 ORM=active_record ORM_VERSION=7.2 FEATURE=rails; \
+	  $(MAKE) test SERVICE="$$service" DB= ORM= ORM_VERSION= FEATURE=i18n_fallbacks; \
+	  $(MAKE) test SERVICE="$$service" DB= ORM= ORM_VERSION= FEATURE=performance; \
+	  $(MAKE) test SERVICE="$$service" DB= ORM= ORM_VERSION= FEATURE=unit; \
+	done

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ tables](http://dejimata.com/2017/3/3/translating-with-mobility#strategy-2), as
 well as database-specific storage solutions such as
 [json/jsonb](https://www.postgresql.org/docs/current/static/datatype-json.html) and
 [Hstore](https://www.postgresql.org/docs/current/static/hstore.html) (for
-PostgreSQL).
+PostgreSQL), and JSON columns on MySQL.
 
 Mobility is a cross-platform solution, currently supporting both
 [ActiveRecord](http://api.rubyonrails.org/classes/ActiveRecord/Base.html)
@@ -912,12 +912,17 @@ Backend](https://github.com/shioyama/mobility/wiki/Column-Backend) page of the
 wiki and API documentation on the [`Mobility::Backend::Column`
 class](http://www.rubydoc.info/gems/mobility/Mobility/Backends/Column).
 
-### PostgreSQL-specific Backends
+### PostgreSQL/MySQL Backends
 
-Mobility also supports JSON and Hstore storage options, if you are using
-PostgreSQL as your database. To use this option, create column(s) on the model
-table for each translated attribute, and set your backend to `:json`, `:jsonb`
-or `:hstore`. If you are using Sequel, note that you
+Mobility also supports JSON and Hstore storage options for backends which store
+translations in a Hash on database columns. To use this option, create column(s)
+on the model table for each translated attribute, and set your backend to
+`:json`, `:jsonb` or `:hstore`.
+
+Note: `:jsonb` and `:hstore` are PostgreSQL-specific. The `:json` backend is
+tested on PostgreSQL and MySQL 8.0+ (ActiveRecord).
+
+If you are using Sequel, note that you
 will need to enable the [pg_json](http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/pg_json_rb.html)
 or
 [pg_hstore](http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/pg_hstore_rb.html)
@@ -936,9 +941,8 @@ pages of the wiki and in the API documentation
 and
 [`Mobility::Backend::Hstore`](http://www.rubydoc.info/gems/mobility/Mobility/Backends/Hstore)).
 
-*Note: The Json backend (`:json`) may also work with recent versions of MySQL
-with JSON column support, although this backend/db combination is not tested.
-See [this issue](https://github.com/shioyama/mobility/issues/226) for details.*
+*Note: See [this issue](https://github.com/shioyama/mobility/issues/226) for
+historical context on MySQL JSON support.*
 
 Development
 -----------

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require "yaml"
 
 RSpec::Core::RakeTask.new(:spec) do |task|
   task.rspec_opts = '-f p'
+  task.fail_on_error = true
 end
 
 task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,8 @@ namespace :db do
   desc "Create the database"
   task create: :setup do
     commands = {
-      "mysql"    => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'create database #{config["database"]} default character set #{config["encoding"]} default collate #{config["collation"]};' >/dev/null",
+      "mysql57"  => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'create database if not exists #{config["database"]} default character set #{config["encoding"]} default collate #{config["collation"]};' >/dev/null",
+      "mysql80"  => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'create database if not exists #{config["database"]} default character set #{config["encoding"]} default collate #{config["collation"]};' >/dev/null",
       "postgres" => "psql -c 'create database #{config['database']};' -U #{config['username']} >/dev/null"
     }
     %x{#{commands[driver] || true}}
@@ -30,7 +31,8 @@ namespace :db do
   desc "Drop the database"
   task drop: :setup do
     commands = {
-      "mysql"    => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'drop database #{config["database"]};' >/dev/null",
+      "mysql57"  => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'drop database if exists #{config["database"]};' >/dev/null",
+      "mysql80"  => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'drop database if exists #{config["database"]};' >/dev/null",
       "postgres" => "psql -c 'drop database #{config['database']};' -U #{config['username']} >/dev/null"
     }
     %x{#{commands[driver] || true}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,94 @@
+services:
+  mysql57:
+    image: mysql:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: mobility_test
+    command: ["--default-authentication-plugin=mysql_native_password", "--character-set-server=utf8", "--collation-server=utf8_unicode_ci"]
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  mysql80:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: mobility_test
+    command: ["--default-authentication-plugin=mysql_native_password", "--character-set-server=utf8", "--collation-server=utf8_unicode_ci"]
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: mobility_test
+      POSTGRES_USER: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  ruby-3.3:
+    &ruby-base
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        RUBY_VERSION: "3.3"
+    working_dir: /app
+    volumes:
+      - .:/app
+      - bundle_cache:/usr/local/bundle
+    environment:
+      DB: ${DB:-sqlite3}
+      ORM: ${ORM:-none}
+      ORM_VERSION: ${ORM_VERSION:-}
+      FEATURE: ${FEATURE:-unit}
+      MYSQL57_HOST: ${MYSQL57_HOST:-mysql57}
+      MYSQL57_PORT: ${MYSQL57_PORT:-3306}
+      MYSQL80_HOST: ${MYSQL80_HOST:-mysql80}
+      MYSQL80_PORT: ${MYSQL80_PORT:-3306}
+      MYSQL_PASSWORD: root
+      PGHOST: postgres
+    depends_on:
+      mysql57:
+        condition: service_healthy
+      mysql80:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    command: ["bash", "-lc", "bundle config set path /usr/local/bundle && bundle install && bundle exec rake"]
+
+  ruby-3.2:
+    <<: *ruby-base
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        RUBY_VERSION: "3.2"
+
+  ruby-3.4:
+    <<: *ruby-base
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        RUBY_VERSION: "3.4"
+
+  ruby-4.0:
+    <<: *ruby-base
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        RUBY_VERSION: "4.0"
+
+volumes:
+  bundle_cache:

--- a/lib/mobility/backends/active_record/container.rb
+++ b/lib/mobility/backends/active_record/container.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "mobility/backends/active_record"
 require "mobility/backends/container"
-require "mobility/plugins/arel/nodes/pg_ops"
+require "mobility/plugins/arel/nodes/db_ops"
 
 module Mobility
   module Backends

--- a/lib/mobility/backends/active_record/db_hash.rb
+++ b/lib/mobility/backends/active_record/db_hash.rb
@@ -6,20 +6,21 @@ module Mobility
   module Backends
 =begin
 
-Internal class used by ActiveRecord backends backed by a Postgres data type
-(hstore, jsonb).
+Internal class used by ActiveRecord backends backed by a database data type
+(hstore, jsonb, json).
 
 =end
     module ActiveRecord
-      class PgHash
+      class DbHash
         include ActiveRecord
         include HashValued
 
         def read(locale, _options = nil)
-          translations[locale.to_s]
+          translations&.fetch(locale.to_s, nil)
         end
 
         def write(locale, value, _options = nil)
+          translations = (model[column_name] ||= {})
           if value.nil?
             translations.delete(locale.to_s)
             nil
@@ -30,14 +31,18 @@ Internal class used by ActiveRecord backends backed by a Postgres data type
 
         # @!macro backend_iterator
         def each_locale
-          super { |l| yield l.to_sym }
+          model[column_name]&.each_key { |l| yield l.to_sym }
         end
 
         def translations
-          model[column_name]
+          if model.new_record?
+            model[column_name] ||= {}
+          else
+            model[column_name]
+          end
         end
       end
-      private_constant :PgHash
+      private_constant :DbHash
     end
   end
 end

--- a/lib/mobility/backends/active_record/hstore.rb
+++ b/lib/mobility/backends/active_record/hstore.rb
@@ -1,5 +1,5 @@
-require 'mobility/backends/active_record/pg_hash'
-require 'mobility/plugins/arel/nodes/pg_ops'
+require 'mobility/backends/active_record/db_hash'
+require 'mobility/plugins/arel/nodes/db_ops'
 
 module Mobility
   module Backends
@@ -11,7 +11,7 @@ Implements the {Mobility::Backends::Hstore} backend for ActiveRecord models.
 
 =end
     module ActiveRecord
-      class Hstore < PgHash
+      class Hstore < DbHash
         # @!group Backend Accessors
         # @!macro backend_reader
         # @!method read(locale, options = {})

--- a/lib/mobility/backends/active_record/json.rb
+++ b/lib/mobility/backends/active_record/json.rb
@@ -1,5 +1,5 @@
-require 'mobility/backends/active_record/pg_hash'
-require 'mobility/plugins/arel/nodes/pg_ops'
+require 'mobility/backends/active_record/db_hash'
+require 'mobility/plugins/arel/nodes/db_ops'
 
 module Mobility
   module Backends
@@ -11,7 +11,7 @@ Implements the {Mobility::Backends::Json} backend for ActiveRecord models.
 
 =end
     module ActiveRecord
-      class Json < PgHash
+      class Json < DbHash
         # @!group Backend Accessors
         #
         # @!method read(locale, **options)

--- a/lib/mobility/backends/active_record/jsonb.rb
+++ b/lib/mobility/backends/active_record/jsonb.rb
@@ -1,5 +1,5 @@
-require 'mobility/backends/active_record/pg_hash'
-require 'mobility/plugins/arel/nodes/pg_ops'
+require 'mobility/backends/active_record/db_hash'
+require 'mobility/plugins/arel/nodes/db_ops'
 
 module Mobility
   module Backends
@@ -11,7 +11,7 @@ Implements the {Mobility::Backends::Jsonb} backend for ActiveRecord models.
 
 =end
     module ActiveRecord
-      class Jsonb < PgHash
+      class Jsonb < DbHash
         # @!group Backend Accessors
         #
         # @!method read(locale, **options)

--- a/lib/mobility/plugins/arel/nodes/db_ops.rb
+++ b/lib/mobility/plugins/arel/nodes/db_ops.rb
@@ -87,6 +87,7 @@ module Mobility
         end
 
         def visit_Mobility_Plugins_Arel_Nodes_JsonDashDoubleArrow o, a
+          quote_mysql_json_key!(o) if mysql_visitor?
           json_infix o, a, '->>'
         end
 
@@ -112,12 +113,36 @@ module Mobility
 
         private
 
+        def mysql_visitor?
+          (defined?(::Arel::Visitors::MySQL) && is_a?(::Arel::Visitors::MySQL)) ||
+            (defined?(::Arel::Visitors::MySQL2) && is_a?(::Arel::Visitors::MySQL2))
+        end
+
+        # MySQL requires JSON path to be prefixed with '$.' and keys quoted to
+        # support locales like "pt-BR" when using the ->> operator.
+        def quote_mysql_json_key!(node)
+          return unless node.respond_to?(:right) && node.right.respond_to?(:value)
+
+          value = node.right.value.to_s
+          return if value.start_with?('$.')
+
+          node.right = node.right.class.new(%Q($."#{value}"))
+        end
+
         def json_infix o, a, opr
-          visit(Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right)), a)
+          node = Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new(opr, o.left, o.right))
+
+          if mysql_visitor? && opr == '->>'
+            node = Nodes::Grouping.new(::Arel::Nodes::InfixOperation.new('COLLATE', node, ::Arel::Nodes::SqlLiteral.new('utf8mb4_general_ci')))
+          end
+
+          visit(node, a)
         end
       end
 
       ::Arel::Visitors::PostgreSQL.include Visitors
+      ::Arel::Visitors::MySQL.include Visitors if defined?(::Arel::Visitors::MySQL)
+      ::Arel::Visitors::MySQL2.include Visitors if defined?(::Arel::Visitors::MySQL2)
     end
   end
 end

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -103,6 +103,13 @@ module Mobility
               t.boolean :published
               t.timestamps null: false
             end
+          elsif ENV['DB'] == 'mysql'
+            create_table "json_posts" do |t|
+              t.json :my_title_i18n, default: -> { "(JSON_OBJECT())" }, null: false
+              t.json :my_content_i18n, default: -> { "(JSON_OBJECT())" }, null: false
+              t.boolean :published
+              t.timestamps null: false
+            end
           end
         end
       end

--- a/spec/active_record/schema.rb
+++ b/spec/active_record/schema.rb
@@ -103,7 +103,7 @@ module Mobility
               t.boolean :published
               t.timestamps null: false
             end
-          elsif ENV['DB'] == 'mysql'
+          elsif ENV['DB'].to_s == 'mysql80'
             create_table "json_posts" do |t|
               t.json :my_title_i18n, default: -> { "(JSON_OBJECT())" }, null: false
               t.json :my_content_i18n, default: -> { "(JSON_OBJECT())" }, null: false

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -37,7 +37,9 @@ module Mobility
         end
 
         def driver
-          (ENV["DB"] or "sqlite3").downcase
+          driver = ENV["DB"]
+          driver = nil if driver == ''
+          (driver || "sqlite3").downcase
         end
 
         def in_memory?

--- a/spec/databases.yml
+++ b/spec/databases.yml
@@ -1,7 +1,17 @@
-mysql:
+mysql57:
   adapter: mysql2
-  host: 127.0.0.1
-  port: 3306
+  host: <%= ENV['MYSQL57_HOST'] || '127.0.0.1' %>
+  port: <%= (ENV['MYSQL57_PORT'] || 3306).to_i %>
+  database: mobility_test
+  password: <%= ENV['MYSQL_PASSWORD'] %>
+  username: root
+  encoding: utf8
+  collation: utf8_unicode_ci
+
+mysql80:
+  adapter: mysql2
+  host: <%= ENV['MYSQL80_HOST'] || '127.0.0.1' %>
+  port: <%= (ENV['MYSQL80_PORT'] || 3307).to_i %>
   database: mobility_test
   password: <%= ENV['MYSQL_PASSWORD'] %>
   username: root
@@ -10,7 +20,7 @@ mysql:
 
 postgres:
   adapter: postgresql
-  host: localhost
+  host: <%= ENV['PGHOST'] || 'localhost' %>
   port: 5432
   database: mobility_test
   username: postgres

--- a/spec/generators/rails/mobility/translations_generator_spec.rb
+++ b/spec/generators/rails/mobility/translations_generator_spec.rb
@@ -84,7 +84,7 @@ describe Mobility::TranslationsGenerator, type: :generator do
         }
       end
 
-      context "index name is too long for database", db: [:mysql, :postgres] do
+      context "index name is too long for database", db: [:mysql57, :mysql80, :postgres] do
         it_behaves_like "long index name truncator"
       end
     end
@@ -116,7 +116,7 @@ describe Mobility::TranslationsGenerator, type: :generator do
         }
       end
 
-      context "index name is too long for database", db: [:mysql, :postgres] do
+      context "index name is too long for database", db: [:mysql57, :mysql80, :postgres] do
         it_behaves_like "long index name truncator"
       end
     end

--- a/spec/mobility/backends/active_record/hstore_spec.rb
+++ b/spec/mobility/backends/active_record/hstore_spec.rb
@@ -41,7 +41,7 @@ describe "Mobility::Backends::ActiveRecord::Hstore", orm: :active_record, db: :p
         backend = post.mobility_backends[:title]
         backend.write(:en, { foo: :bar } )
         post.save
-        expect(post[column_affix % "title"]).to match_hash({ en: "{:foo=>:bar}" })
+        expect(post[column_affix % "title"]).to match_hash({ en: { foo: :bar }.to_s })
       end
     end
   end

--- a/spec/mobility/backends/active_record/json_spec.rb
+++ b/spec/mobility/backends/active_record/json_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
-describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: :postgres, type: :backend do
+describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: [:mysql, :postgres], type: :backend do
   require "mobility/backends/active_record/json"
 
   before { stub_const 'JsonPost', Class.new(ActiveRecord::Base) }
@@ -28,9 +28,9 @@ describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: :pos
 
     it "does not impact dirty tracking on original column" do
       post = JsonPost.create!
-      post.reload
-
+      expect { post.reload }.not_to change { post.changes }.from({})
       expect(post.my_title_i18n).to eq({})
+      expect { post.title }.not_to change { post.my_title_i18n }
       expect(post.changes).to eq({})
     end
 

--- a/spec/mobility/backends/active_record/json_spec.rb
+++ b/spec/mobility/backends/active_record/json_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 return unless defined?(ActiveRecord)
 
-describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: [:mysql, :postgres], type: :backend do
+describe "Mobility::Backends::ActiveRecord::Json", orm: :active_record, db: [:mysql80, :postgres], type: :backend do
   require "mobility/backends/active_record/json"
 
   before { stub_const 'JsonPost', Class.new(ActiveRecord::Base) }

--- a/spec/mobility/backends/active_record/serialized_spec.rb
+++ b/spec/mobility/backends/active_record/serialized_spec.rb
@@ -32,7 +32,7 @@ describe "Mobility::Backends::ActiveRecord::Serialized", orm: :active_record, ty
             backend = post.mobility_backends[:title]
             backend.write(:en, { foo: :bar } )
             post.save
-            expect(post[column_affix % "title"]).to match_hash({ en: "{:foo=>:bar}" })
+            expect(post[column_affix % "title"]).to match_hash({ en: { foo: :bar }.to_s })
           end
         end
 

--- a/spec/mobility/backends/sequel/hstore_spec.rb
+++ b/spec/mobility/backends/sequel/hstore_spec.rb
@@ -43,7 +43,7 @@ describe "Mobility::Backends::Sequel::Hstore", orm: :sequel, db: :postgres, type
         backend = post.mobility_backends[:title]
         backend.write(:en, { foo: :bar } )
         post.save
-        expect(post[(column_affix % "title").to_sym].to_hash).to eq({ "en" => "{:foo=>:bar}" })
+        expect(post[(column_affix % "title").to_sym].to_hash).to eq({ "en" => { foo: :bar }.to_s })
       end
     end
   end

--- a/spec/mobility/backends/sequel/serialized_spec.rb
+++ b/spec/mobility/backends/sequel/serialized_spec.rb
@@ -34,7 +34,7 @@ describe "Mobility::Backends::Sequel::Serialized", orm: :sequel, type: :backend 
         it "converts non-string types to strings when saving" do
           backend.write(:en, { foo: :bar } )
           post.save
-          expect(post[(column_affix % "title").to_sym]).to eq({ en: "{:foo=>:bar}" }.to_yaml)
+          expect(post[(column_affix % "title").to_sym]).to eq({ en: { foo: :bar }.to_s }.to_yaml)
         end
       end
 
@@ -59,7 +59,7 @@ describe "Mobility::Backends::Sequel::Serialized", orm: :sequel, type: :backend 
         it "converts non-string types to strings when saving" do
           backend.write(:en, { foo: :bar } )
           post.save
-          expect(post[(column_affix % "title").to_sym]).to eq({ en: "{:foo=>:bar}" }.to_json)
+          expect(post[(column_affix % "title").to_sym]).to eq({ en: { foo: :bar }.to_s }.to_json)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,8 @@ end
 
 require 'rails' if ENV['FEATURE'] == 'rails'
 
-db = ENV['DB'] || 'none'
+db = ENV['DB']
+db = 'none' if db.nil? || db == ''
 require 'pry-byebug'
 require 'i18n'
 require 'i18n/backend/fallbacks' if ENV['FEATURE'] == 'i18n_fallbacks'

--- a/spec/support/shared_examples/querying_examples.rb
+++ b/spec/support/shared_examples/querying_examples.rb
@@ -668,6 +668,11 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
             @ja_instance1 = model_class.create(a1 => "foo ja")
             @ja_instance2 = model_class.create(a1 => "foo")
           end
+
+          Mobility.with_locale(:'pt-BR') do
+            @pt_br_instance1 = model_class.create(a1 => "foo pt-BR")
+            @pt_br_instance2 = model_class.create(a1 => "foo")
+          end
         end
 
         it "returns correct result when querying on same attribute value in different locale" do
@@ -677,12 +682,20 @@ shared_examples_for "Sequel Model with translated dataset" do |model_class_name,
             expect(query_scope.where(a1 => "foo ja").select_all(table_name).all).to eq([@ja_instance1])
             expect(query_scope.where(a1 => "foo").select_all(table_name).all).to eq([@ja_instance2])
           end
+
+          Mobility.with_locale(:'pt-BR') do
+            expect(query_scope.where(a1 => "foo pt-BR").select_all(table_name).all).to eq([@pt_br_instance1])
+            expect(query_scope.where(a1 => "foo").select_all(table_name).all).to eq([@pt_br_instance2])
+          end
         end
 
         it "returns correct result when querying with locale option" do
           expect(query_scope.where(a1 => "foo", locale: :en).select_all(table_name).all).to match_array([@instance1, @instance5])
           expect(query_scope.where(a1 => "foo ja", locale: :ja).select_all(table_name).all).to eq([@ja_instance1])
           expect(query_scope.where(a1 => "foo", locale: :ja).select_all(table_name).all).to eq([@ja_instance2])
+
+          expect(query_scope.where(a1 => "foo pt-BR", locale: :'pt-BR').select_all(table_name).all).to eq([@pt_br_instance1])
+          expect(query_scope.where(a1 => "foo", locale: :'pt-BR').select_all(table_name).all).to eq([@pt_br_instance2])
         end
 
         it "returns correct result when querying with locale option twice in separate clauses" do


### PR DESCRIPTION
Add rubies 3.4 and 4.0.
Add docker + compose for easy testing environment.
Add Makefile for easy orchestration of tests locally - reflecting CI. 

As this is based of #684, only commit https://github.com/shioyama/mobility/commit/ebfd7b8213ebe6d9c47aca9bf165fd7ac84302e8 is relevant.

If maintainers are interested I can clean it up and prepare for merging, especially `gem 'ostruct'` probably needs moving to gemspec and lib/mobility.rb ... but that's easy peasy ;)