### PR TITLE
WIP: duping leaks dirty tracking to original object

### DIFF
--- a/spec/mobility/plugins/active_record/dirty_spec.rb
+++ b/spec/mobility/plugins/active_record/dirty_spec.rb
@@ -200,6 +200,30 @@ describe Mobility::Plugins::ActiveRecord::Dirty, orm: :active_record, type: :plu
         expect(instance.changes).to eq({ "title_fr" => [nil, "Titre en Francais"] })
       end
     end
+
+    it "does not dirty original object when duped" do
+      Mobility.locale = locale = :en
+      instance = model_class.create(title: "foo")
+      dupe = instance.dup
+
+      aggregate_failures do
+        expect(instance.changed?).to eq(false)
+        expect(dupe.changed?).to eq(false)
+
+        backend_for(dupe, :title).write(:en, "bar")
+
+        expect(instance.changed?).to eq(false)
+        expect(dupe.changed?).to eq(true)
+
+        dupe.save
+
+        expect(instance.changed?).to eq(false)
+        expect(dupe.changed?).to eq(false)
+
+        expect(instance.previous_changes).to include({ "title_en" => [nil, "foo"]})
+        expect(dupe.previous_changes).to include({ "title_en" => ["foo", "bar"]})
+      end
+    end
   end
 
   describe "suffix methods" do


### PR DESCRIPTION
hey @shioyama,

I think I just stumbled upon a bug in dirty tracking: duping an object and changing the dupe invalidates/leaks into the dirty tracking of the original object.

I added a failing spec here with what I think should be the right outcome. I'm not 100 % sure about the last assertion about the dupe (`expect(dupe.previous_changes).to include({ "title_en" => ["foo", "bar"]})`), but the rest seams clear to me.

To reproduce, simply create a record, `.dup` it and then change the dupe's localized attributes (see the failing spec).

I didn't investigate it yet (could work around it in my app), just want to give you a heads up. Don't know either if this is only a AR thing (were I added the spec) or some general problem with other ORMs, too.

Probably a cache object/hash does not get reset/duped on `.dup` and then both records share it.

Maybe you can take a look if you have some time? If not I could do so, too, when I find some time for it.

Thanks!